### PR TITLE
fix(text-validation) - pass only values that are strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.1-dev.20230613092121",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.0-beta.0",
+      "version": "0.1.1-dev.20230613092121",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230613092121",
+  "version": "0.1.1-dev.20230614173637",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.1-dev.20230613092121",
+      "version": "0.1.1-dev.20230614173637",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230616112349",
+  "version": "0.1.1-dev.20230619163824",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.1-dev.20230616112349",
+      "version": "0.1.1-dev.20230619163824",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230614173637",
+  "version": "0.1.1-dev.20230616112349",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.1-dev.20230614173637",
+      "version": "0.1.1-dev.20230616112349",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230619163824",
+  "version": "0.1.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.1-dev.20230619163824",
+      "version": "0.1.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "lodash": "^4.17.21",
         "randexp": "^0.5.3",
-        "yup": "^0.29.1"
+        "yup": "^0.30.0"
       },
       "devDependencies": {
         "@babel/core": "^7.21.5",
@@ -4892,14 +4892,6 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "node_modules/fn-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-3.0.0.tgz",
-      "integrity": "sha512-eNMNr5exLoavuAMhIUVsOKF79SWd/zG104ef6sxBTSw+cZc6BXdQXDvYcGvp0VbxVVSp1XDUNoz7mg1xMtSznA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -8073,11 +8065,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "node_modules/synchronous-promise": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.15.tgz",
-      "integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg=="
-    },
     "node_modules/table": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -8726,16 +8713,14 @@
       }
     },
     "node_modules/yup": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.29.3.tgz",
-      "integrity": "sha512-RNUGiZ/sQ37CkhzKFoedkeMfJM0vNQyaz+wRZJzxdKE7VfDeVKH8bb4rr7XhRLbHJz5hSjoDNwMEIaKhuMZ8gQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.30.0.tgz",
+      "integrity": "sha512-GX3vqpC9E+Ow0fmQPgqbEg7UV40XRrN1IOEgKF5v04v6T4ha2vBas/hu0thWgewk8L4wUEBLRO/EnXwYyP+p+A==",
       "dependencies": {
         "@babel/runtime": "^7.10.5",
-        "fn-name": "~3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "lodash-es": "^4.17.11",
-        "property-expr": "^2.0.2",
-        "synchronous-promise": "^2.0.13",
+        "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       },
       "engines": {
@@ -12212,11 +12197,6 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "fn-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-3.0.0.tgz",
-      "integrity": "sha512-eNMNr5exLoavuAMhIUVsOKF79SWd/zG104ef6sxBTSw+cZc6BXdQXDvYcGvp0VbxVVSp1XDUNoz7mg1xMtSznA=="
-    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -14519,11 +14499,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "synchronous-promise": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.15.tgz",
-      "integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg=="
-    },
     "table": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -15009,16 +14984,14 @@
       "dev": true
     },
     "yup": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.29.3.tgz",
-      "integrity": "sha512-RNUGiZ/sQ37CkhzKFoedkeMfJM0vNQyaz+wRZJzxdKE7VfDeVKH8bb4rr7XhRLbHJz5hSjoDNwMEIaKhuMZ8gQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.30.0.tgz",
+      "integrity": "sha512-GX3vqpC9E+Ow0fmQPgqbEg7UV40XRrN1IOEgKF5v04v6T4ha2vBas/hu0thWgewk8L4wUEBLRO/EnXwYyP+p+A==",
       "requires": {
         "@babel/runtime": "^7.10.5",
-        "fn-name": "~3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "lodash-es": "^4.17.11",
-        "property-expr": "^2.0.2",
-        "synchronous-promise": "^2.0.13",
+        "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230619163824",
+  "version": "0.1.0-beta.0",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230613092121",
+  "version": "0.1.1-dev.20230614173637",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230616112349",
+  "version": "0.1.1-dev.20230619163824",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.1-dev.20230613092121",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "jest",
+    "test:watch": "jest --watchAll",
     "lint": "eslint \"src/**/*.{js,ts}\"",
     "format": "npm run format:prettier && npm run format:eslint",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230614173637",
+  "version": "0.1.1-dev.20230616112349",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "randexp": "^0.5.3",
-    "yup": "^0.29.1"
+    "yup": "^0.30.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.5",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -41,7 +41,7 @@ function getField(fieldName, fields) {
  */
 function validateFieldSchema(field, value) {
   const validator = buildYupSchema(field);
-  return validator().isValidSync(value, { strict: true });
+  return validator().isValidSync(value);
 }
 
 /**
@@ -558,7 +558,6 @@ export const handleValuesChange = (fields, jsonSchema, config) => (values) => {
   try {
     lazySchema.validateSync(values, {
       abortEarly: false,
-      strict: true,
     });
   } catch (err) {
     if (err.name === 'ValidationError') {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -41,7 +41,7 @@ function getField(fieldName, fields) {
  */
 function validateFieldSchema(field, value) {
   const validator = buildYupSchema(field);
-  return validator().isValidSync(value);
+  return validator().isValidSync(value, { strict: true });
 }
 
 /**
@@ -558,6 +558,7 @@ export const handleValuesChange = (fields, jsonSchema, config) => (values) => {
   try {
     lazySchema.validateSync(values, {
       abortEarly: false,
+      strict: true,
     });
   } catch (err) {
     if (err.name === 'ValidationError') {

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -419,7 +419,7 @@ describe('createHeadlessForm', () => {
 
   describe('field support', () => {
     it('support "text" field type', () => {
-      const { fields } = createHeadlessForm(schemaInputTypeText);
+      const { fields, handleValidation } = createHeadlessForm(schemaInputTypeText);
 
       expect(fields[0]).toMatchObject({
         description: 'The number of your national identification (max 10 digits)',
@@ -439,6 +439,10 @@ describe('createHeadlessForm', () => {
       expect(fieldValidator.isValidSync(true)).toBe(false);
       expect(fieldValidator.isValidSync(1)).toBe(false);
       expect(fieldValidator.isValidSync(0)).toBe(false);
+
+      expect(handleValidation({ id_number: 1 }).formErrors).toEqual({
+        id_number: 'The field id_number must be a string, but you introduced 1',
+      });
 
       expect(() => fieldValidator.validateSync('')).toThrowError('Required field');
     });

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -435,10 +435,10 @@ describe('createHeadlessForm', () => {
       });
 
       const fieldValidator = fields[0].schema;
-      expect(fieldValidator.isValidSync('CI007', { strict: true })).toBe(true);
-      expect(fieldValidator.isValidSync(true, { strict: true })).toBe(false);
-      expect(fieldValidator.isValidSync(1, { strict: true })).toBe(false);
-      expect(fieldValidator.isValidSync(0, { strict: true })).toBe(false);
+      expect(fieldValidator.isValidSync('CI007')).toBe(true);
+      expect(fieldValidator.isValidSync(true)).toBe(false);
+      expect(fieldValidator.isValidSync(1)).toBe(false);
+      expect(fieldValidator.isValidSync(0)).toBe(false);
 
       expect(handleValidation({ id_number: 1 }).formErrors).toEqual({
         id_number: 'id_number must be a `string` type, but the final value was: `1`.',

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -436,9 +436,9 @@ describe('createHeadlessForm', () => {
 
       const fieldValidator = fields[0].schema;
       expect(fieldValidator.isValidSync('CI007')).toBe(true);
-      expect(fieldValidator.isValidSync(true)).toBe(true); // @BUG RMT-446 - cannot be a bool
-      expect(fieldValidator.isValidSync(1)).toBe(true); // @BUG RMT-446 - cannot be a number
-      expect(fieldValidator.isValidSync(0)).toBe(true); // @BUG RMT-446 - cannot be a number
+      expect(fieldValidator.isValidSync(true)).toBe(false);
+      expect(fieldValidator.isValidSync(1)).toBe(false);
+      expect(fieldValidator.isValidSync(0)).toBe(false);
 
       expect(() => fieldValidator.validateSync('')).toThrowError('Required field');
     });
@@ -2313,7 +2313,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_tabs: 'no',
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
             },
             mandatory_group_array: 'no',
           })
@@ -2328,7 +2328,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_tabs: 'yes',
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
             },
             mandatory_group_array: 'no',
           })
@@ -2344,7 +2344,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_tabs: 'yes',
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
             },
             mandatory_group_array: 'yes',
             a_group_array: [{ full_name: 'adfs' }],
@@ -2355,7 +2355,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_tabs: 'yes',
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
               tabs: 2,
             },
             mandatory_group_array: 'no',
@@ -2446,7 +2446,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_fieldset: ['id_number'],
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
             },
           })
         ).toBeUndefined();
@@ -2455,7 +2455,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_fieldset: ['id_number', 'all'],
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
             },
           })
         ).toEqual({
@@ -2468,7 +2468,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_fieldset: ['id_number', 'all'],
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
               tabs: 2,
             },
           })
@@ -2483,7 +2483,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_fieldset: ['id_number'],
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
             },
           })
         ).toBeUndefined();
@@ -2492,7 +2492,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_fieldset: ['id_number', 'all'],
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
             },
           })
         ).toEqual({
@@ -2505,7 +2505,7 @@ describe('createHeadlessForm', () => {
           validateForm({
             validate_fieldset: ['id_number', 'all'],
             a_fieldset: {
-              id_number: 123,
+              id_number: '123',
               tabs: 2,
             },
           })

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -435,13 +435,13 @@ describe('createHeadlessForm', () => {
       });
 
       const fieldValidator = fields[0].schema;
-      expect(fieldValidator.isValidSync('CI007')).toBe(true);
-      expect(fieldValidator.isValidSync(true)).toBe(false);
-      expect(fieldValidator.isValidSync(1)).toBe(false);
-      expect(fieldValidator.isValidSync(0)).toBe(false);
+      expect(fieldValidator.isValidSync('CI007', { strict: true })).toBe(true);
+      expect(fieldValidator.isValidSync(true, { strict: true })).toBe(false);
+      expect(fieldValidator.isValidSync(1, { strict: true })).toBe(false);
+      expect(fieldValidator.isValidSync(0, { strict: true })).toBe(false);
 
       expect(handleValidation({ id_number: 1 }).formErrors).toEqual({
-        id_number: 'The field id_number must be a string, but you introduced 1',
+        id_number: 'id_number must be a `string` type, but the final value was: `1`.',
       });
 
       expect(() => fieldValidator.validateSync('')).toThrowError('Required field');
@@ -1311,9 +1311,7 @@ describe('createHeadlessForm', () => {
 
       // The "child.has_child" is required
       expect(validateForm({})).toEqual({
-        child: {
-          has_child: 'Required field',
-        },
+        child: 'Required field',
       });
 
       // The "child.no" is valid

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -1311,7 +1311,9 @@ describe('createHeadlessForm', () => {
 
       // The "child.has_child" is required
       expect(validateForm({})).toEqual({
-        child: 'Required field',
+        child: {
+          has_child: 'Required field',
+        },
       });
 
       // The "child.no" is valid

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -18,9 +18,13 @@ const todayDateHint = new Date().toISOString().substring(0, 10);
 const convertBytesToKB = convertDiskSizeFromTo('Bytes', 'KB');
 const convertKbBytesToMB = convertDiskSizeFromTo('KB', 'MB');
 
-const yupSchemas = {
-  text: string().trim().nullable(),
+const validateOnlyStrings = string()
+  .trim()
+  .nullable()
+  .test('is-string', (value, context) => typeof context.originalValue === 'string');
 
+const yupSchemas = {
+  text: validateOnlyStrings,
   select: string().trim().nullable(),
   radio: string().trim().nullable(),
   date: string()

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -17,9 +17,16 @@ export const baseString = string().trim();
 const todayDateHint = new Date().toISOString().substring(0, 10);
 const convertBytesToKB = convertDiskSizeFromTo('Bytes', 'KB');
 const convertKbBytesToMB = convertDiskSizeFromTo('KB', 'MB');
+const useOnlyStrings = (value, originalValue) => {
+  if (typeof originalValue === 'string') {
+    return originalValue;
+  }
+
+  return null;
+};
 
 const yupSchemas = {
-  text: string().trim().nullable(),
+  text: string().transform(useOnlyStrings).trim().nullable(),
   select: string().trim().nullable(),
   radio: string().trim().nullable(),
   date: string()

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -25,7 +25,7 @@ const validateOnlyStrings = string()
     'is-string',
     '${path} must be a `string` type, but the final value was: `${value}`.',
     (value, context) => {
-      if (context.originalValue) {
+      if (context.originalValue !== null && context.originalValue !== undefined) {
         return typeof context.originalValue === 'string';
       }
       return true;

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -21,7 +21,16 @@ const convertKbBytesToMB = convertDiskSizeFromTo('KB', 'MB');
 const validateOnlyStrings = string()
   .trim()
   .nullable()
-  .test('is-string', (value, context) => typeof context.originalValue === 'string');
+  .test(
+    'is-string',
+    '${path} must be a `string` type, but the final value was: `${value}`.',
+    (value, context) => {
+      if (context.originalValue) {
+        return typeof context.originalValue === 'string';
+      }
+      return true;
+    }
+  );
 
 const yupSchemas = {
   text: validateOnlyStrings,

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -17,16 +17,10 @@ export const baseString = string().trim();
 const todayDateHint = new Date().toISOString().substring(0, 10);
 const convertBytesToKB = convertDiskSizeFromTo('Bytes', 'KB');
 const convertKbBytesToMB = convertDiskSizeFromTo('KB', 'MB');
-const useOnlyStrings = (value, originalValue) => {
-  if (typeof originalValue === 'string') {
-    return originalValue;
-  }
-
-  return null;
-};
 
 const yupSchemas = {
-  text: string().transform(useOnlyStrings).trim().nullable(),
+  text: string().trim().nullable(),
+
   select: string().trim().nullable(),
   radio: string().trim().nullable(),
   date: string()


### PR DESCRIPTION
## 1. Description
Add a transform function to make the validation work when we're passing numbers or booleans to our text validation.


<!--
A summary of what this MR does. If needed, explain your approach, trade-offs, etc...
-->

### Screenshots
https://www.loom.com/share/b7a127623c5b41e78d6d3f2d21fcba59?focus_title=1&muted=1&from_recorder=1

### Related Resources
- https://linear.app/remote/issue/RMT-446/jsf-text-validation-is-incorrect


## 2. Type of Change (select one)

- [X] Bug fix (non-breaking change that fixes an issue)
