### PR TITLE
feat: Add Typescript declarations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+json-schema-form.d.ts

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -16,7 +16,7 @@ type JSConfig = {
   }
 }
 
-type Fields = any; // TODO: We don't know what type we have here, we need to investigate
+type Fields = Record<string, unknown>[]; // TODO: We don't know what type we have here, we need to investigate
 
 type $TsFixMe = any;
 
@@ -25,5 +25,4 @@ type $TsFixMe = any;
  * These fields must be the same from
  * const { fields } = createHeadlessForm()
  */
-
 export function buildCompleteYupSchema(fields: Fields, config: JSConfig): $TsFixMe // TODO: We don't what yup returns here, we'll fix it later

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -3,18 +3,50 @@
  */
 export function pickXKey(node: Object, key: 'presentation' | 'errorMessage'): Object | undefined;
 
+type ValidationTypes =
+  | 'type'
+  | 'minimum'
+  | 'maximum'
+  | 'minLength'
+  | 'maxLength'
+  | 'pattern'
+  | 'maxFileSize'
+  | 'accept'
+  | 'required';
+
 type JSFConfig = {
+  /**
+   * Initial json values to prefill the form fields.
+   * This influences the initial visibility of conditional fields.
+   */
   initialValues?: Record<string, unknown>;
+  /**
+   * It inforces all json properties (fields) to have x-jsf-presentation.inputType.
+    @default true 
+  */
   strictInputType?: boolean;
+  /**
+   * Customize the output of a given named Field.
+   * Useful if you want to enhance the UI/UX of a particular field.
+   * @example
+   * { has_pet: { "optionsDirection": "horizontal" } }
+   */
   customProperties?: {
     description: (description: string, field: $TSFixMe) => string | string;
     [key: string]: unknown;
   };
+  /**
+   * Customize the config for each inputType
+   */
   inputTypes?: {
-    errorMessage: Record<string, unknown>;
+    /**
+     * Customize the error error message of this input type.
+     * @example
+     * { required: "This number is required." }
+     */
+    errorMessage?: Record<ValidationTypes, string>;
   };
 };
-
 type Fields = Record<string, unknown>[]; //TODO: Type the field based on the given JSON Schema properties.
 
 type $TSFixMe = any;
@@ -27,7 +59,42 @@ type $TSFixMe = any;
 export function buildCompleteYupSchema(fields: Fields, config: JSFConfig): $TSFixMe; //TODO: We need to update Yup to 1.0 which supports TS.
 
 type HeadlessFormOutput = {
+  /**
+   * List of Fields. Each Field corresponds to a form input from the json schema.
+   * @example
+   * [
+      {
+        name: "has_pet",
+        label: "Has Pet",
+        options: [
+          { label: "Yes", value: "yes" },
+          { label: "No", value: "no" }
+        ],
+        required: true,
+        inputType: "radio",
+        jsonType: "string",
+        description: "Do you have a pet?",
+        errorMessage: {},
+        isVisible: true
+      },
+      {
+        type: "text",
+        label: "Pet's name",
+        description: "What's your pet's name?",
+        required: false,
+        inputType: "text",
+        jsonType: "string",
+        isVisible: false
+      }
+   * ]
+   */
   fields: Fields;
+  /**
+   * Validates given values and returns the respective errors.
+   * @example
+   * const { formErrors } = handleValidation({ has_pet: "yes" });
+   * console.log(formErrors) // { pet_name: "Required field." }
+   */
   handleValidation: () => $TSFixMe;
   isError: boolean;
   error?: Error;

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -1,4 +1,4 @@
 /**
  * Shorthand to lookup for keys with `x-jsf-*` preffix.
  */
-export function pickXKey(node: Object, key: 'presentation' | 'error-message'): Object
+export function pickXKey(node: Object, key: 'presentation' | 'error-message'): Object | undefined

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -7,7 +7,7 @@ type JSConfig = {
   initialValues?: Record<string, unknown>;
   strictInputType?: boolean;
   customProperties?: {
-    description: Function | string;
+    description: (description: string, field: $TSFixMe) => string | string;
     [key: string]: unknown;
   };
   inputTypes?: {

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -2,3 +2,28 @@
  * Shorthand to lookup for keys with `x-jsf-*` preffix.
  */
 export function pickXKey(node: Object, key: 'presentation' | 'error-message'): Object | undefined
+
+
+type JSConfig = {
+  initialValues?: Record<string, unknown>;
+  strictInputType?: boolean;
+  customProperties?: {
+    description: () => void | string;
+    [key: string]: unknown;
+  }
+  inputTypes?: {
+    errorMessage: Record<string, unknown>;
+  }
+}
+
+type Fields = any; // TODO: We don't know what type we have here, we need to investigate
+
+type $TsFixMe = any;
+
+/**
+ * Returns the Yup schema structure of given fields.
+ * These fields must be the same from
+ * const { fields } = createHeadlessForm()
+ */
+
+export function buildCompleteYupSchema(fields: Fields, config: JSConfig): $TsFixMe // TODO: We don't what yup returns here, we'll fix it later

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -26,23 +26,17 @@ type $TsFixMe = any;
  */
 export function buildCompleteYupSchema(fields: Fields, config: JSConfig): $TsFixMe; // TODO: We don't what yup returns here, we'll fix it later
 
-type HeadlessFormOutput =
-  | {
-      fields: Fields;
-      handleValidation: Function;
-      isError: boolean;
-      error?: undefined;
-    }
-  | {
-      fields: never[];
-      isError: boolean;
-      error: any;
-    };
+type HeadlessFormOutput = {
+  fields: Fields;
+  handleValidation: () => $TsFixMe;
+  isError: boolean;
+  error?: undefined;
+};
 
 /**
  * Generates the Headless form based on the provided JSON schema
  */
 export function createHeadlessForm(
   jsonSchema: Record<string, unknown>,
-  customConfig: JSConfig = {}
+  customConfig: JSConfig
 ): HeadlessFormOutput;

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -44,7 +44,7 @@ type JSFConfig = {
      * @example
      * { required: "This number is required." }
      */
-    errorMessage?: Record<ValidationTypes, string>;
+    errorMessage?: Partial<Record<ValidationTypes, string>>;
   };
 };
 type Fields = Record<string, unknown>[]; //TODO: Type the field based on the given JSON Schema properties.
@@ -106,6 +106,7 @@ type JSONSchemaObjectType = Record<string, unknown>;
  * Generates the Headless form based on the provided JSON schema
  */
 export function createHeadlessForm(
+  /** A JSON Schema of type object */
   jsonSchema: JSONSchemaObjectType,
   customConfig?: JSFConfig
 ): HeadlessFormOutput;

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -1,0 +1,1 @@
+export function pickXKey(node: Object, key: 'presentation' | 'error-message'): Object

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -1,20 +1,19 @@
 /**
  * Shorthand to lookup for keys with `x-jsf-*` preffix.
  */
-export function pickXKey(node: Object, key: 'presentation' | 'error-message'): Object | undefined
-
+export function pickXKey(node: Object, key: 'presentation' | 'error-message'): Object | undefined;
 
 type JSConfig = {
   initialValues?: Record<string, unknown>;
   strictInputType?: boolean;
   customProperties?: {
-    description: () => void | string;
+    description: Function | string;
     [key: string]: unknown;
-  }
+  };
   inputTypes?: {
     errorMessage: Record<string, unknown>;
-  }
-}
+  };
+};
 
 type Fields = Record<string, unknown>[]; // TODO: We don't know what type we have here, we need to investigate
 
@@ -25,4 +24,25 @@ type $TsFixMe = any;
  * These fields must be the same from
  * const { fields } = createHeadlessForm()
  */
-export function buildCompleteYupSchema(fields: Fields, config: JSConfig): $TsFixMe // TODO: We don't what yup returns here, we'll fix it later
+export function buildCompleteYupSchema(fields: Fields, config: JSConfig): $TsFixMe; // TODO: We don't what yup returns here, we'll fix it later
+
+type HeadlessFormOutput =
+  | {
+      fields: Fields;
+      handleValidation: Function;
+      isError: boolean;
+      error?: undefined;
+    }
+  | {
+      fields: never[];
+      isError: boolean;
+      error: any;
+    };
+
+/**
+ * Generates the Headless form based on the provided JSON schema
+ */
+export function createHeadlessForm(
+  jsonSchema: Record<string, unknown>,
+  customConfig: JSConfig = {}
+): HeadlessFormOutput;

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -40,5 +40,5 @@ type JSONSchemaObjectType = Record<string, unknown>;
  */
 export function createHeadlessForm(
   jsonSchema: JSONSchemaObjectType,
-  customConfig: JSFConfig
+  customConfig?: JSFConfig
 ): HeadlessFormOutput;

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -33,10 +33,12 @@ type HeadlessFormOutput = {
   error?: Error;
 };
 
+type JSONSchemaObjectType = Record<string, unknown>;
+
 /**
  * Generates the Headless form based on the provided JSON schema
  */
 export function createHeadlessForm(
-  jsonSchema: Record<string, unknown>,
+  jsonSchema: JSONSchemaObjectType,
   customConfig: JSFConfig
 ): HeadlessFormOutput;

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -1,7 +1,7 @@
 /**
  * Shorthand to lookup for keys with `x-jsf-*` preffix.
  */
-export function pickXKey(node: Object, key: 'presentation' | 'error-message'): Object | undefined;
+export function pickXKey(node: Object, key: 'presentation' | 'errorMessage'): Object | undefined;
 
 type JSConfig = {
   initialValues?: Record<string, unknown>;
@@ -15,22 +15,22 @@ type JSConfig = {
   };
 };
 
-type Fields = Record<string, unknown>[]; // TODO: We don't know what type we have here, we need to investigate
+type Fields = Record<string, unknown>[]; //TODO: Type the field based on the given JSON Schema properties.
 
-type $TsFixMe = any;
+type $TSFixMe = any;
 
 /**
  * Returns the Yup schema structure of given fields.
  * These fields must be the same from
  * const { fields } = createHeadlessForm()
  */
-export function buildCompleteYupSchema(fields: Fields, config: JSConfig): $TsFixMe; // TODO: We don't what yup returns here, we'll fix it later
+export function buildCompleteYupSchema(fields: Fields, config: JSConfig): $TSFixMe; //TODO: We need to update Yup to 1.0 which supports TS.
 
 type HeadlessFormOutput = {
   fields: Fields;
-  handleValidation: () => $TsFixMe;
+  handleValidation: () => $TSFixMe;
   isError: boolean;
-  error?: undefined;
+  error?: Error;
 };
 
 /**

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -3,7 +3,7 @@
  */
 export function pickXKey(node: Object, key: 'presentation' | 'errorMessage'): Object | undefined;
 
-type JSConfig = {
+type JSFConfig = {
   initialValues?: Record<string, unknown>;
   strictInputType?: boolean;
   customProperties?: {
@@ -24,7 +24,7 @@ type $TSFixMe = any;
  * These fields must be the same from
  * const { fields } = createHeadlessForm()
  */
-export function buildCompleteYupSchema(fields: Fields, config: JSConfig): $TSFixMe; //TODO: We need to update Yup to 1.0 which supports TS.
+export function buildCompleteYupSchema(fields: Fields, config: JSFConfig): $TSFixMe; //TODO: We need to update Yup to 1.0 which supports TS.
 
 type HeadlessFormOutput = {
   fields: Fields;
@@ -38,5 +38,5 @@ type HeadlessFormOutput = {
  */
 export function createHeadlessForm(
   jsonSchema: Record<string, unknown>,
-  customConfig: JSConfig
+  customConfig: JSFConfig
 ): HeadlessFormOutput;

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -32,7 +32,7 @@ type JSFConfig = {
    * { has_pet: { "optionsDirection": "horizontal" } }
    */
   customProperties?: {
-    description: (description: string, field: $TSFixMe) => string | string;
+    description?: (description: string, field: $TSFixMe) => string | string;
     [key: string]: unknown;
   };
   /**

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -1,1 +1,4 @@
+/**
+ * Shorthand to lookup for keys with `x-jsf-*` preffix.
+ */
 export function pickXKey(node: Object, key: 'presentation' | 'error-message'): Object

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -95,7 +95,10 @@ type HeadlessFormOutput = {
    * const { formErrors } = handleValidation({ has_pet: "yes" });
    * console.log(formErrors) // { pet_name: "Required field." }
    */
-  handleValidation: () => $TSFixMe;
+  handleValidation: (values: Record<string, unknown>) => {
+    yupError: $TSFixMe;
+    formErrors: $TSFixMe;
+  };
   isError: boolean;
   error?: Error;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230616085129",
+  "version": "0.1.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.1-dev.20230616085129",
+      "version": "0.1.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230615153439",
+  "version": "0.1.1-dev.20230616080231",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.1-dev.20230615153439",
+      "version": "0.1.1-dev.20230616080231",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.1-dev.20230615153439",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.0-beta.0",
+      "version": "0.1.1-dev.20230615153439",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230616083258",
+  "version": "0.1.1-dev.20230616085129",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.1-dev.20230616083258",
+      "version": "0.1.1-dev.20230616085129",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230616080231",
+  "version": "0.1.1-dev.20230616083258",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.1.1-dev.20230616080231",
+      "version": "0.1.1-dev.20230616083258",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230616085129",
+  "version": "0.1.0-beta.0",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230616083258",
+  "version": "0.1.1-dev.20230616085129",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.1-dev.20230615153439",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230615153439",
+  "version": "0.1.1-dev.20230616080231",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "main": "dist/index.cjs",
   "module": "dist/index.js",
+  "typings": "./json-schema-form.d.ts",
   "files": [
     "dist",
     "src/tests",
     "json-schema-form.schema.json",
+    "json-schema-form.d.ts",
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.1.1-dev.20230616080231",
+  "version": "0.1.1-dev.20230616083258",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/src/createHeadlessForm.js
+++ b/src/createHeadlessForm.js
@@ -57,12 +57,12 @@ import { buildYupSchema } from './yupSchema';
 
 /**
  * @typedef {Object} JsfConfig
- * @property {Object} config.initialValues - Initial values to evaluate the form against
- * @param {Boolean} config.strictInputType - Disabled by default. When enabled, presentation.inputType is required.
- * @param {Object} config.customProperties - Object of fields with custom attributes
- * @param {Function|String} config.customProperties[].description - Override description for FieldParameters
- * @param {*} config.customProperties[].* - Any other attribute is included in the FieldParameters
- * @param {Object} config.inputTypes[].errorMessage.* - Custom error messages by each error type. eg errorMessage: { required: 'Cannot be empty' }
+ * @property {Object} [config.initialValues] - Initial values to evaluate the form against
+ * @property {Boolean} [config.strictInputType] - Disabled by default. When enabled, presentation.inputType is required.
+ * @property {Object} [config.customProperties] - Object of fields with custom attributes
+ * @property {Function|String} config.customProperties[].description - Override description for FieldParameters
+ * @property {*} config.customProperties[].* - Any other attribute is included in the FieldParameters
+ * @property {Object} config.inputTypes[].errorMessage.* - Custom error messages by each error type. eg errorMessage: { required: 'Cannot be empty' }
 
 */
 


### PR DESCRIPTION
## 1. Description
Add a declaration file giving some types to the 3 exported functions that the library has.

* `createHeadlessForm`
* `pickXKey`
* `buildCompleteYupSchema`

Some arguments are generic to be able to ship something fast, I think if we need better types, we'll need to spend more time on it.

<!--
A summary of what this MR does. If needed, explain your approach, trade-offs, etc...
-->


## 2. How to test this

I created a next app with typescript in my local environment and copied the content of this [codesandbox](https://codesandbox.io/s/json-schema-form-demo-react-igh3sk?from-embed), after doing that, I installed a release dev version, the one I used is 0.1.1-dev.20230616085129 to test that everything work as expected.
