### PR TITLE
WIP: fix: crashing when format is uri

### DIFF
--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -1810,6 +1810,22 @@ describe('createHeadlessForm', () => {
     });
   });
 
+  describe('when a field is text', () => {
+    describe('and format is uri', () => {
+      it('should not throw an error', () => {
+        const { handleValidation } = createHeadlessForm({
+          url: {
+            type: 'string',
+            format: 'uri',
+          },
+        });
+        const validateForm = (vals) => friendlyError(handleValidation(vals));
+
+        expect(validateForm({ url: 'https://example.com' })).toBeUndefined();
+      });
+    });
+  });
+
   describe('when a field is number', () => {
     let fields;
     beforeEach(() => {


### PR DESCRIPTION
`{
            type: 'string',
            format: 'uri'
          }` results in the following error:
```
  ● createHeadlessForm › when a field is text › and format is uri › should not throw an error

    expect(jest.fn()).not.toHaveBeenCalled()

    Expected number of calls: 0
    Received number of calls: 1

    1: "JSON Schema invalid!", [TypeError: Cannot convert undefined or null to object]

      82 |
      83 | afterEach(() => {
    > 84 |   expect(console.error).not.toHaveBeenCalled();
         |                             ^
      85 |   console.error.mockRestore();
      86 | });
      87 |

      at Object.toHaveBeenCalled (src/tests/createHeadlessForm.test.js:84:29)

```