### PR TITLE
WIP: feat: support nested group arrays

### DIFF
--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -1008,6 +1008,48 @@ describe('createHeadlessForm', () => {
         ]);
       });
 
+      it('supports nested group arrays', () => {
+        const result = createHeadlessForm({
+          type: 'object',
+          required: ['steps'],
+          properties: {
+            steps: {
+              type: 'array',
+              required: ['ingredients'],
+              additionalItems: false,
+              'x-jsf-presentation': {
+                inputType: 'group-array',
+                addFieldText: 'Add new step',
+              },
+              items: {
+                type: 'object',
+                additionalProperties: true,
+                properties: {
+                  highlights: {
+                    type: 'array',
+                    additionalItems: false,
+                    'x-jsf-presentation': {
+                      inputType: 'group-array',
+                      addFieldText: 'Add new ingredient',
+                    },
+                    items: {
+                      type: 'string',
+                      'x-jsf-presentation': {
+                        inputType: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        expect(result.fields[0].schema.innerType.fields).not.toMatchObject({
+          undefined: undefined,
+        });
+      });
+
       it('nested fields (native, core and custom) has correct validations', () => {
         const { handleValidation } = createHeadlessForm({
           properties: {


### PR DESCRIPTION
![storybook playground showing steps[0].undefined as a field instead of a nested array](https://github.com/remoteoss/json-schema-form/assets/25524993/d0228dea-8bd9-4151-9bd8-af2871168ea9)

`buildGroupArraySchema` always expects an object, but it could be something else.
https://github.com/remoteoss/json-schema-form/blob/1e9d6cf96436cf16018e045b351567c643e10dac/src/yupSchema.js#L207-L217