### PR TITLE
feat(Radio/Select): Spread x-jsf-presentation value to option root

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -406,12 +406,27 @@ export function updateFieldsProperties(fields, formValues, jsonSchema) {
 
 const notNullOption = (opt) => opt.const !== null;
 
+function flatPresentation(item) {
+  return Object.entries(item).reduce((newItem, [key, value]) => {
+    if (key === 'x-jsf-presentation') {
+      return {
+        ...newItem,
+        ...value,
+      };
+    }
+    return {
+      ...newItem,
+      [key]: value,
+    };
+  }, {});
+}
+
 function getFieldOptions(node, presentation) {
   function convertToOptions(nodeOptions) {
     return nodeOptions.filter(notNullOption).map(({ title, const: cons, ...item }) => ({
       label: title,
       value: cons,
-      ...item,
+      ...flatPresentation(item),
     }));
   }
 

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -761,32 +761,24 @@ describe('createHeadlessForm', () => {
 
       const fieldOptions = result.fields[0].options;
 
-      // The x-jsf-presentation value was spread to the root:
+      // The x-jsf-presentation content was spread to the root:
       expect(fieldOptions[0]).not.toHaveProperty('x-jsf-presentation');
       expect(fieldOptions).toEqual([
         {
           label: 'Basic',
           value: 'basic',
-          carrierName: 'Segure Inc',
-          displayCost: '$30.00/mo',
-          urlDetails: 'www.example-bsc.com',
+          meta: {
+            displayCost: '$30.00/mo',
+          },
           // Other x-* keywords are kept as it is.
           'x-another': 'extra-thing',
         },
         {
           label: 'Standard',
           value: 'standard',
-          carrierName: 'Vanilla Lda',
-          displayCost: '$50.00/mo',
-          urlDetails: 'www.example-std.com',
-        },
-        {
-          label: 'Pro',
-          value: 'pro',
-          tierName: 'Pro',
-          carrierName: 'Satefy xtra',
-          displayCost: '$100.00/mo + variable costs',
-          urlDetails: 'www.example-pro.com',
+          meta: {
+            displayCost: '$50.00/mo',
+          },
         },
       ]);
     });

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -10,6 +10,7 @@ import {
   schemaInputTypeRadioDeprecated,
   schemaInputTypeRadio,
   schemaInputTypeRadioRequiredAndOptional,
+  schemaInputTypeRadioOptionsWithDetails,
   schemaInputTypeSelectSoloDeprecated,
   schemaInputTypeSelectSolo,
   schemaInputTypeSelectMultipleDeprecated,
@@ -751,6 +752,43 @@ describe('createHeadlessForm', () => {
       const fieldValidator = result.fields[0].schema;
       expect(fieldValidator.isValidSync('yes')).toBe(true);
       expect(() => fieldValidator.validateSync('')).toThrowError('Required field');
+    });
+
+    it('support "radio" field type with extra info inside each option', () => {
+      const result = createHeadlessForm(schemaInputTypeRadioOptionsWithDetails);
+
+      expect(result.fields).toHaveLength(1);
+
+      const fieldOptions = result.fields[0].options;
+
+      // The x-jsf-presentation value was spread to the root:
+      expect(fieldOptions[0]).not.toHaveProperty('x-jsf-presentation');
+      expect(fieldOptions).toEqual([
+        {
+          label: 'Basic',
+          value: 'basic',
+          carrierName: 'Segure Inc',
+          displayCost: '$30.00/mo',
+          urlDetails: 'www.example-bsc.com',
+          // Other x-* keywords are kept as it is.
+          'x-another': 'extra-thing',
+        },
+        {
+          label: 'Standard',
+          value: 'standard',
+          carrierName: 'Vanilla Lda',
+          displayCost: '$50.00/mo',
+          urlDetails: 'www.example-std.com',
+        },
+        {
+          label: 'Pro',
+          value: 'pro',
+          tierName: 'Pro',
+          carrierName: 'Satefy xtra',
+          displayCost: '$100.00/mo + variable costs',
+          urlDetails: 'www.example-pro.com',
+        },
+      ]);
     });
 
     it('support "number" field type', () => {

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -912,9 +912,9 @@ export const schemaInputTypeRadioOptionsWithDetails = {
           const: 'basic',
           title: 'Basic',
           'x-jsf-presentation': {
-            carrierName: 'Segure Inc',
-            displayCost: '$30.00/mo',
-            urlDetails: 'www.example-bsc.com',
+            meta: {
+              displayCost: '$30.00/mo',
+            },
           },
           'x-another': 'extra-thing',
         },
@@ -922,19 +922,9 @@ export const schemaInputTypeRadioOptionsWithDetails = {
           const: 'standard',
           title: 'Standard',
           'x-jsf-presentation': {
-            carrierName: 'Vanilla Lda',
-            displayCost: '$50.00/mo',
-            urlDetails: 'www.example-std.com',
-          },
-        },
-        {
-          const: 'pro',
-          title: 'Pro',
-          'x-jsf-presentation': {
-            tierName: 'Pro',
-            carrierName: 'Satefy xtra',
-            displayCost: '$100.00/mo + variable costs',
-            urlDetails: 'www.example-pro.com',
+            meta: {
+              displayCost: '$50.00/mo',
+            },
           },
         },
       ],

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -901,6 +901,51 @@ export const schemaInputTypeRadioCard = {
   required: ['experience_level'],
 };
 
+export const schemaInputTypeRadioOptionsWithDetails = {
+  properties: {
+    health_perks: {
+      title: 'Health perks',
+      description:
+        'This example contains options with more custom details, under the x-jsf-presentation key',
+      oneOf: [
+        {
+          const: 'basic',
+          title: 'Basic',
+          'x-jsf-presentation': {
+            carrierName: 'Segure Inc',
+            displayCost: '$30.00/mo',
+            urlDetails: 'www.example-bsc.com',
+          },
+          'x-another': 'extra-thing',
+        },
+        {
+          const: 'standard',
+          title: 'Standard',
+          'x-jsf-presentation': {
+            carrierName: 'Vanilla Lda',
+            displayCost: '$50.00/mo',
+            urlDetails: 'www.example-std.com',
+          },
+        },
+        {
+          const: 'pro',
+          title: 'Pro',
+          'x-jsf-presentation': {
+            tierName: 'Pro',
+            carrierName: 'Satefy xtra',
+            displayCost: '$100.00/mo + variable costs',
+            urlDetails: 'www.example-pro.com',
+          },
+        },
+      ],
+      'x-jsf-presentation': {
+        inputType: 'radio',
+      },
+      type: 'string',
+    },
+  },
+};
+
 /** @deprecated */
 export const schemaInputTypeSelectSoloDeprecated = JSONSchemaBuilder()
   .addInput({

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -871,34 +871,35 @@ export const schemaInputDeprecated = JSONSchemaBuilder()
   .build();
 
 /** @deprecated */
-export const schemaInputTypeRadioDeprecated = JSONSchemaBuilder()
-  .addInput({
+export const schemaInputTypeRadioDeprecated = {
+  properties: {
     has_siblings: mockRadioInputDeprecated,
-  })
-  .setRequiredFields(['has_siblings'])
-  .build();
-export const schemaInputTypeRadio = JSONSchemaBuilder()
-  .addInput({
-    has_siblings: mockRadioInput,
-  })
-  .setRequiredFields(['has_siblings'])
-  .build();
+  },
+  required: ['has_siblings'],
+};
 
-export const schemaInputTypeRadioRequiredAndOptional = JSONSchemaBuilder()
-  .addInput({
+export const schemaInputTypeRadio = {
+  properties: {
+    has_siblings: mockRadioInput,
+  },
+  required: ['has_siblings'],
+};
+
+export const schemaInputTypeRadioRequiredAndOptional = {
+  properties: {
     has_siblings: mockRadioInput,
     has_car: mockRadioInputOptional,
-  })
-  .setRequiredFields(['has_siblings'])
-  .build();
+  },
+  required: ['has_siblings'],
+};
 
-export const schemaInputTypeRadioCard = JSONSchemaBuilder()
-  .addInput({
+export const schemaInputTypeRadioCard = {
+  properties: {
     experience_level: mockRadioCardExpandableInput,
     payment_method: mockRadioCardInput,
-  })
-  .setRequiredFields(['experience_level'])
-  .build();
+  },
+  required: ['experience_level'],
+};
 
 /** @deprecated */
 export const schemaInputTypeSelectSoloDeprecated = JSONSchemaBuilder()


### PR DESCRIPTION
### Example 
For example, given the following JSON Schema, where each `oneOf` contains a `x-jsf-presentation`:

```js
{
  properties: {
    health_perks: {
      title: 'Health perks',
      oneOf: [
        {
          const: 'basic',
          title: 'Basic',
          'x-jsf-presentation': {
            cost: '$30.00/mo',
          },
          'x-another': 'extra-thing',
        },
        {
          const: 'standard',
          title: 'Standard',
          'x-jsf-presentation': {
            cost: '$50.00/mo',
          },
        }
      ],
      'x-jsf-presentation': {
        inputType: 'radio',
        layout: "vertical"
      },
      type: 'string',
    },
  },
}
```

Without this PR, to access the `cost` of each option, you'd need to do:


``` js
const { fields } = createHeadlessForm(demoAbove);

const cost = fields[0].options[0]['x-jsf-presentation'].cost
```

Now, you can access it directly with:

```js
const cost = fields[0].options[0].displayCost
```

In other words, now we move the `x-jsf-presentation`'s data to the closest parent, removing the key itself, similar to how we already do with the root (check `layout` to compare). The `fields[0]` would look like this:

```js
{
  "name": "health_perks",
  "label": "Health perks",
  "options": [
    {
      "label": "Basic",
      "value": "basic",
      "cost": "$30.00/mo", // <-- moved to parent
      "x-another": "extra-thing" // <-- still accepts any other arbitrary key
    },
    {
      "label": "Standard",
      "value": "standard",
      "cost": "$50.00/mo"
    }
  ],
  "inputType": "radio",
  "jsonType": "string",
  "layout": "vertical"  // <-- the new behavior is similar to this existing one in the field root
}
```



---

## Related
- [Linear issue](https://linear.app/remote/issue/BNFT-670) (private)
- [Slack thread](https://remote-com.slack.com/archives/C02HTN0LY02/p1687270322322069) (private)
