### PR TITLE
fix(date) - fix breaking field when not passing the property format

### DIFF
--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -1117,6 +1117,29 @@ describe('createHeadlessForm', () => {
       });
     });
 
+    it('support format date with minDate and maxDate without the format property', () => {
+      const schemaFormatDate = {
+        properties: {
+          birthdate: {
+            title: 'Birthdate',
+            type: 'string',
+            'x-jsf-presentation': {
+              inputType: 'date',
+              maxDate: '2022-03-01',
+              minDate: '1922-03-01',
+            },
+          },
+        },
+      };
+
+      const { handleValidation } = createHeadlessForm(schemaFormatDate);
+      const validateForm = (vals) => friendlyError(handleValidation(vals));
+
+      expect(validateForm({ birthdate: '1922-02-01' })).toEqual({
+        birthdate: 'The date must be 1922-03-01 or after.',
+      });
+    });
+
     it('supports "file" field type', () => {
       const result = createHeadlessForm(
         JSONSchemaBuilder()

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -185,7 +185,7 @@ const getYupSchema = ({ inputType, ...field }) => {
     return yupSchemas.radioOrSelect(optionValues);
   }
 
-  if (field.format === 'date') {
+  if (inputType === 'date' || field.format === 'date') {
     return yupSchemas.date({ minDate: field.minDate, maxDate: field.maxDate });
   }
 


### PR DESCRIPTION
1. Description
We have detected internally that some of our forms stopped working as we were not passing the property format to some data fields.

This MR fixes this and adds some tests to prevent them from failure in the feature

2. How to test this

Instructions to how to test this internally are [here](https://remote-com.slack.com/archives/C03RWJF31U2/p1690190265877309?thread_ts=1689957612.695479&cid=C03RWJF31U2)