### PR TITLE
fix(select/radio): Support oneOf[].pattern validation

### DIFF
--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -57,6 +57,7 @@ import {
   schemaInputTypeNumberWithPercentage,
   schemaForErrorMessageSpecificity,
   jsfConfigForErrorMessageSpecificity,
+  mockPatternOneOf,
 } from './helpers';
 import { mockConsole, restoreConsoleAndEnsureItWasNotCalled } from './testUtils';
 
@@ -1483,6 +1484,45 @@ describe('createHeadlessForm', () => {
           },
         ],
       });
+    });
+
+    it('supports oneOf pattern validation', () => {
+      const result = createHeadlessForm(
+        JSONSchemaBuilder()
+          .addInput({
+            phone_number: mockPatternOneOf,
+          })
+          .build()
+      );
+
+      expect(result).toMatchObject({
+        fields: [
+          {
+            label: 'Phone number',
+            name: 'phone_number',
+            type: 'tel',
+            required: false,
+            options: [
+              {
+                label: 'Portugal',
+                pattern: '^(\\+351)[0-9]{9,}$',
+              },
+              {
+                label: 'United Kingdom (UK)',
+                pattern: '^(\\+44)[0-9]*',
+              },
+            ],
+          },
+        ],
+      });
+
+      const fieldValidator = result.fields[0].schema;
+
+      expect(fieldValidator.isValidSync('+351123123123')).toBe(true);
+      expect(() => fieldValidator.validateSync('+35100')).toThrowError(
+        'The option "+35100" is not valid.'
+      );
+      expect(fieldValidator.isValidSync(undefined)).toBe(true);
     });
 
     describe('supports "fieldset" field type', () => {

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -1487,13 +1487,11 @@ describe('createHeadlessForm', () => {
     });
 
     it('supports oneOf pattern validation', () => {
-      const result = createHeadlessForm(
-        JSONSchemaBuilder()
-          .addInput({
-            phone_number: mockPatternOneOf,
-          })
-          .build()
-      );
+      const result = createHeadlessForm({
+        properties: {
+          phone_number: mockPatternOneOf,
+        },
+      });
 
       expect(result).toMatchObject({
         fields: [

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -39,6 +39,7 @@ import {
   mockFileInput,
   mockRadioCardInput,
   mockRadioCardExpandableInput,
+  mockTelWithPattern,
   mockTextInput,
   mockTextInputDeprecated,
   mockNumberInput,
@@ -57,7 +58,6 @@ import {
   schemaInputTypeNumberWithPercentage,
   schemaForErrorMessageSpecificity,
   jsfConfigForErrorMessageSpecificity,
-  mockPatternOneOf,
 } from './helpers';
 import { mockConsole, restoreConsoleAndEnsureItWasNotCalled } from './testUtils';
 
@@ -1487,11 +1487,7 @@ describe('createHeadlessForm', () => {
     });
 
     it('supports oneOf pattern validation', () => {
-      const result = createHeadlessForm({
-        properties: {
-          phone_number: mockPatternOneOf,
-        },
-      });
+      const result = createHeadlessForm(mockTelWithPattern);
 
       expect(result).toMatchObject({
         fields: [
@@ -1507,7 +1503,19 @@ describe('createHeadlessForm', () => {
               },
               {
                 label: 'United Kingdom (UK)',
-                pattern: '^(\\+44)[0-9]*',
+                pattern: '^(\\+44)[0-9]{1,}$',
+              },
+              {
+                label: 'Bolivia',
+                pattern: '^(\\+591)[0-9]{9,}$',
+              },
+              {
+                label: 'Canada',
+                pattern: '^(\\+1)(206|224)[0-9]{1,}$',
+              },
+              {
+                label: 'United States',
+                pattern: '^(\\+1)[0-9]{1,}$',
               },
             ],
           },

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -458,22 +458,44 @@ export const mockCheckboxInput = {
   type: 'string',
 };
 
-export const mockPatternOneOf = {
-  title: 'Phone number',
-  type: 'string',
-  'x-jsf-presentation': {
-    inputType: 'tel',
+export const mockTelWithPattern = {
+  properties: {
+    phone_number: {
+      title: 'Phone number',
+      description: 'Enter your telephone number',
+      type: 'string',
+      'x-jsf-presentation': {
+        inputType: 'tel',
+      },
+      oneOf: [
+        {
+          title: 'Portugal',
+          pattern: '^(\\+351)[0-9]{9,}$',
+          'x-jsf-presentation': { meta: { countryCode: '351' } },
+        },
+        {
+          title: 'United Kingdom (UK)',
+          pattern: '^(\\+44)[0-9]{1,}$',
+          'x-jsf-presentation': { meta: { countryCode: '44' } },
+        },
+        {
+          title: 'Bolivia',
+          pattern: '^(\\+591)[0-9]{9,}$',
+          'x-jsf-presentation': { meta: { countryCode: '591' } },
+        },
+        {
+          title: 'Canada',
+          pattern: '^(\\+1)(206|224)[0-9]{1,}$',
+          'x-jsf-presentation': { meta: { countryCode: '1' } },
+        },
+        {
+          title: 'United States',
+          pattern: '^(\\+1)[0-9]{1,}$',
+          'x-jsf-presentation': { meta: { countryCode: '1' } },
+        },
+      ],
+    },
   },
-  oneOf: [
-    {
-      title: 'Portugal',
-      pattern: '^(\\+351)[0-9]{9,}$',
-    },
-    {
-      title: 'United Kingdom (UK)',
-      pattern: '^(\\+44)[0-9]*',
-    },
-  ],
 };
 
 /**

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -458,6 +458,24 @@ export const mockCheckboxInput = {
   type: 'string',
 };
 
+export const mockPatternOneOf = {
+  title: 'Phone number',
+  type: 'string',
+  'x-jsf-presentation': {
+    inputType: 'tel',
+  },
+  oneOf: [
+    {
+      title: 'Portugal',
+      pattern: '^(\\+351)[0-9]{9,}$',
+    },
+    {
+      title: 'United Kingdom (UK)',
+      pattern: '^(\\+44)[0-9]*',
+    },
+  ],
+};
+
 /**
  * Compose a schema with lower chance of human error
  * @param {Object} schema version

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -70,7 +70,7 @@ const yupSchemas = {
         if (value === '') {
           return undefined; // [1]
         }
-        if (options?.includes(null)) {
+        if (options?.some((option) => option.value === null)) {
           return value;
         }
         return value === null
@@ -99,9 +99,35 @@ const yupSchemas = {
           Check the PR#18 and tests for more details.
         */
       })
-      .oneOf(options, ({ value }) => {
-        return `The option ${JSON.stringify(value)} is not valid.`;
-      });
+      .test(
+        /* 
+          Custom test determines if the value either:
+           - Matches a specific option by value
+           - Matches a pattern
+          If the option is undefined do not test, to allow for optional fields. 
+         */
+        'matchesOptionOrPattern',
+        ({ value }) => `The option ${JSON.stringify(value)} is not valid.`,
+        (value) => {
+          if (value === undefined) {
+            return true; // [2]
+          }
+
+          const exactMatch = options.some((option) => option.value === value);
+
+          if (exactMatch) {
+            return true;
+          }
+
+          const patternMatch = options.some((option) => option.pattern?.test(value));
+
+          if (patternMatch) {
+            return true;
+          }
+
+          return false;
+        }
+      );
   },
   date: ({ minDate, maxDate }) => {
     let dateString = string()
@@ -170,7 +196,10 @@ const getJsonTypeInArray = (jsonType) =>
     : jsonType; // eg "string"
 
 const getOptions = (field) => {
-  const allValues = field.options?.map((option) => option.value);
+  const allValues = field.options?.map((option) => ({
+    value: option.value,
+    pattern: option.pattern ? new RegExp(option.pattern) : null,
+  }));
 
   const isOptionalWithNull =
     Array.isArray(field.jsonType) &&
@@ -179,7 +208,7 @@ const getOptions = (field) => {
     // Otherwise the JSON Schema validator will fail as explained in PR#18
     field.jsonType.includes('null');
 
-  return isOptionalWithNull ? [...allValues, null] : allValues;
+  return isOptionalWithNull ? [...allValues, { option: null }] : allValues;
 };
 
 const getYupSchema = ({ inputType, ...field }) => {


### PR DESCRIPTION
Add oneOf pattern validation.
 - If the options in a oneOf contain a value, validation remains the same as it currently is.
 - If the options contain a regex pattern, use that to test the value.

How:
 - Update `radioOrSelect` yup schema
 - Add test