### PR TITLE
chore(hotfix): Ignore internal attributes from conditional attributes removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.7.4-dev.20231107114922",
+  "version": "0.7.4-dev.20231107125305",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.7.4-dev.20231107114922",
+      "version": "0.7.4-dev.20231107125305",
       "license": "MIT",
       "dependencies": {
         "json-logic-js": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.7.4-dev.20231107125305",
+  "version": "0.7.2-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.7.4-dev.20231107125305",
+      "version": "0.7.2-beta.0",
       "license": "MIT",
       "dependencies": {
         "json-logic-js": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.7.3-beta.0",
+  "version": "0.7.4-dev.20231107114922",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.7.3-beta.0",
+      "version": "0.7.4-dev.20231107114922",
       "license": "MIT",
       "dependencies": {
         "json-logic-js": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.7.3-beta.0",
+  "version": "0.7.4-dev.20231107114922",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.7.4-dev.20231107114922",
+  "version": "0.7.4-dev.20231107125305",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.7.4-dev.20231107125305",
+  "version": "0.7.2-beta.0",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,7 +24,10 @@ const dynamicInternalJsfAttrs = [
   'calculateConditionalProperties', // driven from conditionals
   'calculateCustomValidationProperties', // To be deprecated in favor of json-logic
   'scopedJsonSchema', // The respective JSON Schema
-  'Component', // HOTFIX/TODO Internal customizations, check test conditions.test.js for more info.
+
+  // HOTFIX/TODO Internal customizations, check test conditions.test.js for more info.
+  'Component',
+  'calculateDynamicProperties',
 ];
 const dynamicInternalJsfAttrsObj = Object.fromEntries(
   dynamicInternalJsfAttrs.map((k) => [k, true])

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,6 +24,7 @@ const dynamicInternalJsfAttrs = [
   'calculateConditionalProperties', // driven from conditionals
   'calculateCustomValidationProperties', // To be deprecated in favor of json-logic
   'scopedJsonSchema', // The respective JSON Schema
+  'Component', // HOTFIX/TODO Internal customizations, check test conditions.test.js for more info.
 ];
 const dynamicInternalJsfAttrsObj = Object.fromEntries(
   dynamicInternalJsfAttrs.map((k) => [k, true])

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -396,6 +396,7 @@ describe('Conditional attributes updated', () => {
         customProperties: {
           salary_period: {
             Component: '<A React Component>',
+            calculateDynamicProperties: () => true,
           },
         },
       }
@@ -403,13 +404,16 @@ describe('Conditional attributes updated', () => {
 
     // It's there by default
     expect(fields[1].Component).toBe('<A React Component>');
+    expect(fields[1].calculateDynamicProperties).toEqual(expect.any(Function));
 
     // Given "Yes", it stays there too.
     handleValidation({ is_full_time: 'yes' });
     expect(fields[1].Component).toBe('<A React Component>');
+    expect(fields[1].calculateDynamicProperties).toEqual(expect.any(Function));
 
     // Given "No", it stays there too.
     handleValidation({ is_full_time: 'no' });
     expect(fields[1].Component).toBe('<A React Component>');
+    expect(fields[1].calculateDynamicProperties).toEqual(expect.any(Function));
   });
 });

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -358,4 +358,58 @@ describe('Conditional attributes updated', () => {
       ],
     });
   });
+
+  it('Keeps custom attribute Component (fieldAttrsFromJsf) (hotfix temporary)', () => {
+    // This is necessary as hotfix because we (Remote) use it internally.
+    // Not cool, we'll need a better solution asap.
+    const { fields, handleValidation } = createHeadlessForm(
+      {
+        properties: {
+          is_full_time: { type: 'string', oneOf: [{ const: 'yes' }, { const: 'no' }] },
+          salary_period: {
+            type: 'string',
+            title: 'Salary period',
+            oneOf: [
+              { title: 'Weekly', const: 'weekly' },
+              { title: 'Monthly', const: 'monthly' },
+            ],
+          },
+        },
+        allOf: [
+          {
+            if: {
+              properties: { is_full_time: { const: 'yes' } },
+              required: ['is_full_time'],
+            },
+            then: {
+              properties: {
+                salary_period: {
+                  description: 'We recommend montlhy.',
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        strictInputType: false,
+        customProperties: {
+          salary_period: {
+            Component: '<A React Component>',
+          },
+        },
+      }
+    );
+
+    // It's there by default
+    expect(fields[1].Component).toBe('<A React Component>');
+
+    // Given "Yes", it stays there too.
+    handleValidation({ is_full_time: 'yes' });
+    expect(fields[1].Component).toBe('<A React Component>');
+
+    // Given "No", it stays there too.
+    handleValidation({ is_full_time: 'no' });
+    expect(fields[1].Component).toBe('<A React Component>');
+  });
 });


### PR DESCRIPTION
Follow-up of #57, adds `Component` and `calculateDynamicProperties` as one of the attrs to be ignored during conditional attributes.