### PR TITLE
fix(conditionals): Certain conditions were failing due to lack of context

### DIFF
--- a/src/checkIfConditionMatches.js
+++ b/src/checkIfConditionMatches.js
@@ -59,10 +59,8 @@ export function checkIfConditionMatchesProperties(node, formValues, formFields, 
 
     return validateFieldSchema(
       {
-        options: field.options,
-        // @TODO/CODE SMELL. We are passing the property (raw field), but buildYupSchema() expected the output field.
-        ...{ ...field, ...currentProperty },
-        inputType: field.inputType,
+        ...field,
+        ...currentProperty,
         required: true,
       },
       value

--- a/src/checkIfConditionMatches.js
+++ b/src/checkIfConditionMatches.js
@@ -61,7 +61,7 @@ export function checkIfConditionMatchesProperties(node, formValues, formFields, 
       {
         options: field.options,
         // @TODO/CODE SMELL. We are passing the property (raw field), but buildYupSchema() expected the output field.
-        ...currentProperty,
+        ...{ ...field, ...currentProperty },
         inputType: field.inputType,
         required: true,
       },

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -439,11 +439,10 @@ describe('Conditional with a minimum value check', () => {
             required: ['salary'],
           },
           then: {
-            required: ['employee_knows', 'reason'],
+            required: ['reason'],
           },
           else: {
             properties: {
-              employee_knows: false,
               reason: false,
             },
           },
@@ -451,13 +450,8 @@ describe('Conditional with a minimum value check', () => {
       ],
       properties: {
         salary: {
-          title: 'Annual gross salary',
           type: 'number',
-          'x-jsf-errorMessage': {
-            type: 'Please, use US standard currency format. Ex: 1024.12',
-          },
           'x-jsf-presentation': {
-            currency: 'EUR',
             inputType: 'money',
           },
         },
@@ -465,54 +459,23 @@ describe('Conditional with a minimum value check', () => {
           oneOf: [
             {
               const: 'reason_one',
-              title: 'Reason One',
             },
             {
               const: 'reason_two',
-              title: 'Reason Two',
             },
           ],
-          title: 'Reason for salary decrease',
           type: 'string',
-          'x-jsf-presentation': {
-            inputType: 'select',
-          },
-        },
-        employee_knows: {
-          oneOf: [
-            {
-              const: 'yes',
-              title: 'Yes',
-            },
-            {
-              const: 'no',
-              title: 'No',
-            },
-            {
-              const: null,
-            },
-          ],
-          title: 'Was the employee informed?',
-          type: ['string', 'null'],
-          'x-jsf-presentation': {
-            inputType: 'radio',
-          },
         },
       },
       required: ['salary'],
       type: 'object',
-      'x-jsf-logic': {
-        validations: {},
-      },
     };
+
     const { handleValidation } = createHeadlessForm(schema, { strictInputType: false });
     expect(handleValidation({ salary: 120000 }).formErrors).toEqual(undefined);
     expect(handleValidation({ salary: 1000 }).formErrors).toEqual({
       reason: 'Required field',
-      employee_knows: 'Required field',
     });
-    expect(
-      handleValidation({ salary: 1000, reason: 'reason_one', employee_knows: 'yes' }).formErrors
-    ).toEqual(undefined);
+    expect(handleValidation({ salary: 1000, reason: 'reason_one' }).formErrors).toEqual(undefined);
   });
 });


### PR DESCRIPTION
Consider the following schema: 

```json
{
  "additionalProperties": false,
  "allOf": [
    {
      "if": {
        "properties": {
          "salary": {
            "maximum": 119999
          }
        },
        "required": ["salary"]
      },
      "then": {
        "required": ["reason"]
      },
      "else": {
        "properties": {
          "reason": false
        }
      }
    }
  ],
  "properties": {
    "salary": {
      "type": "number",
      "x-jsf-presentation": {
        "inputType": "money"
      }
    },
    "reason": {
      "oneOf": [
        {
          "const": "reason_one"
        },
        {
          "const": "reason_two"
        }
      ],
      "type": "string"
    }
  },
  "required": ["salary"],
  "type": "object"
}
```

With the presence of the `x-jsf-presentation` in the `salary` field, it is causing a `Error: Cannot read properties of undefined (reading 'isValidSync')` error to occur.

To fix this in this PR, we must ensure all existing properties are being passed down to further conditionals being evaluated. 