### PR TITLE
Draft: Create modify() module for better customizations

### DIFF
--- a/src/modify.js
+++ b/src/modify.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-unused-vars
+export function modify(schema, config) {
+  return null; // TODO after specs are approved
+}

--- a/src/modify.js
+++ b/src/modify.js
@@ -1,4 +1,5 @@
 // eslint-disable-next-line no-unused-vars
 export function modify(schema, config) {
+  // ...
   return null; // TODO after specs are approved
 }

--- a/src/modify.js
+++ b/src/modify.js
@@ -32,7 +32,6 @@ function isConditionalReferencingAnyPickedField(condition, fieldsToPick) {
 
   const inIf = intersection(ifCondition.required, fieldsToPick);
 
-  console.log({ inIf });
   if (inIf.length > 0) {
     return true;
   }
@@ -50,8 +49,6 @@ function isConditionalReferencingAnyPickedField(condition, fieldsToPick) {
   const inElse =
     intersection(elseCondition.required, fieldsToPick) ||
     intersection(Object.keys(elseCondition.properties), fieldsToPick);
-
-  console.log({ inElse });
 
   if (inElse.length > 0) {
     return true;

--- a/src/modify.js
+++ b/src/modify.js
@@ -1,5 +1,83 @@
-// eslint-disable-next-line no-unused-vars
-export function modify(schema, config) {
-  // ...
-  return null; // TODO after specs are approved
+import get from 'lodash/get';
+// import set from 'lodash/set';
+import merge from 'lodash/merge';
+import { difference } from 'lodash';
+
+/**
+ *
+ * @param {*} path
+ * @example
+ * shortToFullPath('foo.bar') // 'foo.properties.bar'
+ */
+function shortToFullPath(path) {
+  return path.replace('.', '.properties.');
+}
+
+function rewriteFields(schema, fieldsConfig) {
+  if (!fieldsConfig) return null;
+
+  const fieldsToModify = Object.entries(fieldsConfig);
+
+  fieldsToModify.forEach(([shortPath, mutation]) => {
+    const fieldPath = shortToFullPath(shortPath);
+
+    if (!get(schema.properties, fieldPath)) {
+      return; // Ignore field non existent in original schema.
+    }
+
+    const fieldAttrs = get(schema.properties, fieldPath);
+    const fieldChanges = typeof mutation === 'function' ? mutation(fieldAttrs) : mutation;
+
+    merge(get(schema.properties, fieldPath), {
+      ...fieldAttrs,
+      ...fieldChanges,
+    });
+  });
+}
+
+function rewriteAllFields(schema, configCallback, context) {
+  if (!configCallback) return null;
+  const parentName = context?.parent;
+
+  Object.entries(schema.properties).forEach(([fieldName, fieldAttrs]) => {
+    const fullName = parentName ? `${parentName}.${fieldName}` : fieldName;
+    merge(get(schema.properties, fieldName), {
+      ...fieldAttrs,
+      ...configCallback(fullName, fieldAttrs),
+    });
+
+    // Nested, go recursive (fieldset)
+    if (fieldAttrs.properties) {
+      rewriteAllFields(fieldAttrs, configCallback, {
+        parent: fieldName,
+      });
+    }
+  });
+}
+
+function reorderFields(schema, orderCallback) {
+  if (!orderCallback) return null;
+
+  const originalOrder = schema['x-jsf-order'];
+  const orderConfig = orderCallback(originalOrder);
+  const remaining = difference(originalOrder, orderConfig.order);
+
+  const finalOrder =
+    orderConfig.rest === 'end'
+      ? [...orderConfig.order, ...remaining]
+      : [...remaining, ...orderConfig.order];
+
+  schema['x-jsf-order'] = finalOrder;
+}
+
+export function modify(originalSchema, config) {
+  const schema = JSON.parse(JSON.stringify(originalSchema));
+
+  // All these functions mutate "schema",
+  // that's why we create a copy of originalSchema.
+  rewriteFields(schema, config.fields);
+  rewriteAllFields(schema, config.allFields);
+  reorderFields(schema, config.order);
+
+  return schema;
 }

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -181,6 +181,53 @@ describe('modify() - attributes', () => {
     });
   });
 
+  it('replace field options (radio/select)', () => {
+    const result = modify(schemaPet, {
+      fields: {
+        has_pet: {
+          oneOf: (oneOf) => {
+            const labelsMap = {
+              yes: 'Yes, I have',
+            };
+
+            return oneOf.map((option) => {
+              const customTitle = labelsMap[option.const];
+              if (!customTitle) {
+                console.error('The option is not handled.');
+                return option;
+              }
+              return {
+                ...option,
+                title: customTitle,
+              };
+            });
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        has_pet: {
+          oneOf: [
+            {
+              oneOf: [
+                {
+                  title: 'Yes, I have',
+                  const: 'yes',
+                },
+                {
+                  title: 'No',
+                  const: 'no',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('error message', () => {
     const result = modify(schemaPet, {
       fields: {

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -3,8 +3,9 @@ import { modify } from '../modify';
 /**
  * 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧
  * WIP — In progress
+ * Please review all tests explaining each spec.
  * Tests with it.skip() are still not implemented.
- * Please review all specs explained with tests.
+ * Thank you :)
  * 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧
  */
 
@@ -40,9 +41,9 @@ const schemaPet = {
     },
     pet_age: {
       title: "Pet's age in months",
+      maximum: 24,
       'x-jsf-presentation': {
         inputType: 'number',
-        maximum: 24,
       },
       'x-jsf-errorMessage': {
         maximum: 'Your pet cannot be older than 24 months.',
@@ -252,7 +253,8 @@ describe('modify() - attributes', () => {
             oneOf: fieldAttrs.oneOf.map((option) => {
               const customTitle = labelsMap[option.const];
               if (!customTitle) {
-                console.error('The option is not handled.');
+                // TODO - test this
+                // console.error('The option is not handled.');
                 return option;
               }
               return {
@@ -283,11 +285,11 @@ describe('modify() - attributes', () => {
     });
   });
 
-  it.skip('error message', () => {
+  it('error message', () => {
     const result = modify(schemaPet, {
       fields: {
-        pet_name: (fieldAttrs) => {
-          //console.log(fieldsAttrs.maximum) // 24
+        pet_age: (fieldAttrs) => {
+          // console.log(fieldAttrs); // 24
           return {
             // [*3]
             // note how we don't need to write "x-jsf-errorMessage" - sugar syntax.
@@ -297,18 +299,32 @@ describe('modify() - attributes', () => {
             },
           };
         },
+        'pet_address.street': {
+          errorMessage: {
+            required: 'Your pet cannot live in the street.',
+          },
+        },
       },
       // ...
     });
 
     expect(result).toMatchObject({
       properties: {
-        pet_name: {
+        pet_age: {
           'x-jsf-errorMessage': {
             // maximum: (before) 'Your pet cannot be older than 24 months.',
             minimum: `We only accept pets up to 24 months old.`,
             // required: (before) undefined
             required: 'We need to know your pet name.',
+          },
+        },
+        pet_address: {
+          properties: {
+            street: {
+              'x-jsf-errorMessage': {
+                required: 'Your pet cannot live in the street.',
+              },
+            },
           },
         },
       },
@@ -383,16 +399,20 @@ describe('modify() - attributes', () => {
 const schemaTickets = {
   properties: {
     age: {
-      /* ... */
+      title: 'Age',
+      type: 'integer',
     },
-    quatity: {
-      /* ... */
+    quantity: {
+      title: 'Quantity',
+      type: 'integer',
     },
     has_premium: {
-      /* ... */
+      title: 'Premium',
+      type: 'string',
     },
     premium_id: {
-      /* ... */
+      title: 'Premium ID',
+      type: 'boolean',
     },
   },
   'x-jsf-order': ['age', 'quantity', 'has_premium', 'premium_id'],
@@ -420,25 +440,34 @@ const schemaTickets = {
 
 describe('modify() - structures', () => {
   // [*6]
-  it.skip('pick fields - basic', () => {
+  it('pick fields - basic', () => {
     const result = modify(schemaTickets, {
       pick: {
         fields: ['quantity'],
       },
     });
 
+    console.log('xx', result);
     // Note how the other fields got discarded,
     // as well the order and allOf got reduced.
-    expect(result).toMatchObject({
-      properties: {
-        quatity: {
-          /*...*/
-        },
+    expect(result.properties).toEqual({
+      quantity: {
+        title: 'Quantity',
+        type: 'integer',
       },
-      'x-jsf-order': ['quantity'],
-      // ...
     });
+    expect(result.properties.age).toBeUndefined();
+    expect(result.properties.has_premium).toBeUndefined();
+    expect(result.properties.premium_id).toBeUndefined();
+
+    expect(result['x-jsf-order']).toEqual(['quantity']);
+    expect(result.allOf).toEqual([]); // conditional got removed.
   });
+
+  it.todo('pick fields - keep related conditionals');
+
+  it.todo('pick fields - nested fieldsets');
+
   it.skip('pick fields - with conditionals', () => {
     const result = modify(schemaTickets, {
       pick: {
@@ -478,7 +507,7 @@ describe('modify() - structures', () => {
         age: {
           /* ... */
         },
-        quatity: {
+        quantity: {
           /* ... */
         },
       },

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -706,7 +706,36 @@ describe.skip('modify() -> mutations based on form values', () => {
     [] TODO: Write a unit test + playground demo showing this
     [] Blocker - we need a simple playground for JSF - do NOT use Dragon for this.
 */
-  it.skip('maybe calculateDynamicProperties()... ?', () => {});
+  it.skip('maybe calculateDynamicProperties()... ?', () => {
+    // eslint-disable-next-line no-unused-vars
+    const result = modify(schemaPet, {
+      fields: {
+        pet_age: {
+          'x-jsf-presentation': {
+            // eslint-disable-next-line no-unused-vars
+            onChange: (fieldAttrs, values) => {
+              // ... some side effect...
+            },
+            calculateDynamicProperties: () => {},
+            // eslint-disable-next-line no-undef
+            Component: MyReactComponentOrWhatever,
+          },
+        },
+      },
+    });
+
+    // Usage
+    // const { fields } = createHeadlessForm(result, {
+    //   customProperties: <--- deprecated...
+    // });
+
+    // fields.map((field) => {
+    //   const Component = field.Component || MyComponent
+    //   ... <Component onChange={() =>{
+    //     field.onChange(field, values)
+    //   }}/>
+    // })
+  });
 
   it.skip('maybe onChange() side effects - a black box... ?', () => {});
 });

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -1,11 +1,11 @@
 import { modify } from '../modify';
 
 /**
- * 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧
- * None of this is implemented yet.
- * Just specs explained with tests.
- * For review first.
- * 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧
+ * 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧
+ * WIP — In progress
+ * Tests with it.skip() are still not implemented.
+ * Please review all specs explained with tests.
+ * 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧 🚧
  */
 
 const schemaPet = {
@@ -57,6 +57,13 @@ const schemaPet = {
       },
       type: 'integer',
     },
+    pet_address: {
+      properties: {
+        street: {
+          title: 'Street',
+        },
+      },
+    },
   },
   required: ['has_pet'],
   'x-jsf-order': ['has_pet', 'pet_name'],
@@ -85,6 +92,24 @@ const schemaPet = {
   ],
 };
 
+const schemaAddress = {
+  properties: {
+    address: {
+      properties: {
+        street: {
+          title: 'Street',
+        },
+        number: {
+          title: 'Number',
+        },
+        city: {
+          title: 'City',
+        },
+      },
+    },
+  },
+};
+
 const imagineSomeBasicSchema = {
   /* ... */
 };
@@ -108,14 +133,14 @@ describe('modify() - attributes', () => {
   it('replace base field', () => {
     const result = modify(schemaPet, {
       fields: {
-        has_pet: {
-          title: 'Pet owner',
+        pet_name: {
+          title: 'Your pet name',
         },
         // Q:❓[*1] Do you find it useful to be a callback function instead?
         // You can access any raw attribute from the field to do whatever verification you need,
         // but remember to be cautious, as the attrs value might change.
-        has_pet_2: (fieldAttrs) => {
-          const options = fieldAttrs.oneOf?.map(({ title }) => title).join('or ') || '';
+        has_pet: (fieldAttrs) => {
+          const options = fieldAttrs.oneOf?.map(({ title }) => title).join(' or ') || '';
           return {
             title: 'Pet owner',
             description: `Do you own a pet? ${options}?`, // "Do you own a pet? Yes or No?"
@@ -126,6 +151,9 @@ describe('modify() - attributes', () => {
 
     expect(result).toMatchObject({
       properties: {
+        pet_name: {
+          title: 'Your pet name',
+        },
         has_pet: {
           title: 'Pet owner',
           description: 'Do you own a pet? Yes or No?',
@@ -135,8 +163,7 @@ describe('modify() - attributes', () => {
   });
 
   it('replace nested field', () => {
-    const baseAddress = {}; // TODO - imagine it is a fieldset, { address: { street, number, city } }
-    const result = modify(baseAddress, {
+    const result = modify(schemaAddress, {
       fields: {
         'address.street': {
           title: 'Street name',
@@ -156,7 +183,12 @@ describe('modify() - attributes', () => {
           properties: {
             street: {
               title: 'Street name',
-              number: 'Door number',
+            },
+            number: {
+              title: 'Door number',
+            },
+            city: {
+              title: 'City',
             },
           },
         },
@@ -168,7 +200,7 @@ describe('modify() - attributes', () => {
     const result = modify(schemaPet, {
       // [*2] This is a callback recursive through all fields
       allFields: (fieldName, fieldAttrs) => {
-        const { inputType, percentage } = fieldAttrs.presentation;
+        const { inputType, percentage } = fieldAttrs?.['x-jsf-presentation'] || {};
 
         // This is based on a real example I remember from G.codebase.
         if (inputType === 'number' && percentage === true) {
@@ -196,6 +228,13 @@ describe('modify() - attributes', () => {
         },
         pet_fat: {
           styleDecimals: 2,
+        },
+        pet_address: {
+          properties: {
+            street: {
+              dataFoo: 'abc', // recursive works too.
+            },
+          },
         },
       },
     });
@@ -231,16 +270,12 @@ describe('modify() - attributes', () => {
         has_pet: {
           oneOf: [
             {
-              oneOf: [
-                {
-                  title: 'Yes, I have',
-                  const: 'yes',
-                },
-                {
-                  title: 'No',
-                  const: 'no',
-                },
-              ],
+              title: 'Yes, I have',
+              const: 'yes',
+            },
+            {
+              title: 'No',
+              const: 'no',
             },
           ],
         },
@@ -248,7 +283,7 @@ describe('modify() - attributes', () => {
     });
   });
 
-  it('error message', () => {
+  it.skip('error message', () => {
     const result = modify(schemaPet, {
       fields: {
         pet_name: (fieldAttrs) => {
@@ -305,8 +340,10 @@ describe('modify() - attributes', () => {
     });
   });
 
+  it.todo('reorder fields in fieldsets');
+
   // Q:❓ Would this be useful for first version or too advanced?
-  it('customize conditional effects', () => {
+  it.skip('customize conditional effects', () => {
     const result = modify(schemaPet, {
       conditionals: {
         // The idea is to target a conditional by its id. (new!)
@@ -383,7 +420,7 @@ const schemaTickets = {
 
 describe('modify() - structures', () => {
   // [*6]
-  it('pick fields - basic', () => {
+  it.skip('pick fields - basic', () => {
     const result = modify(schemaTickets, {
       pick: {
         fields: ['quantity'],
@@ -402,7 +439,7 @@ describe('modify() - structures', () => {
       // ...
     });
   });
-  it('pick fields - with conditionals', () => {
+  it.skip('pick fields - with conditionals', () => {
     const result = modify(schemaTickets, {
       pick: {
         fields: ['has_premium'],
@@ -430,7 +467,7 @@ describe('modify() - structures', () => {
   });
 
   // Q:❓ [*7] Would this be really needed?
-  it('omit fields - basic usage', () => {
+  it.skip('omit fields - basic usage', () => {
     const result = modify(schemaTickets, {
       omit: 'has_premium',
     });
@@ -451,7 +488,7 @@ describe('modify() - structures', () => {
   });
 
   // [*8]
-  it('split fields - basic', () => {
+  it.skip('split fields - basic', () => {
     const result = modify(imagineSomeBasicSchema, {
       split: {
         // 💡 Note how "*" is mandatory to ensure
@@ -502,7 +539,7 @@ describe('modify() - structures', () => {
   // Outcome A - Throw an error and fail — not cool in production.
   // Outcome B - Fix the form gracefully, and log warning (onWarn).
   //             Add the missing field to the same step. (see below)
-  it('split fields - handling condional fields - missing field', () => {
+  it.skip('split fields - handling condional fields - missing field', () => {
     const result = modify(schemaTickets, {
       split: {
         parts: [
@@ -549,7 +586,7 @@ describe('modify() - structures', () => {
   // Outcome A - Throw an error and fail — not cool in production.
   // Outcome B - Fix the form gracefully, and log error (onError)
   //             Move the dependent field to the same step. (see bellow)
-  it('split fields - handling condional fields - disconneted fields', () => {
+  it.skip('split fields - handling condional fields - disconneted fields', () => {
     const result = modify(schemaTickets, {
       split: {
         // 💡 note how "premium_id" is in the wrong step.

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -85,12 +85,15 @@ const schemaPet = {
   ],
 };
 
+const imagineSomeBasicSchema = {};
+
 describe('modify() - attributes', () => {
   it('replace base field', () => {
     const result = modify(schemaPet, {
       fields: {
         has_pet: {
           title: 'Pet owner',
+          // Q:❓[*1] Do you find it useful to every attribute to support a callback function?
           description: (fieldAttrs) => {
             // You can access any raw field attribute to do whatever verification you need,
             // but remember to be cautious, as they might change.
@@ -143,7 +146,7 @@ describe('modify() - attributes', () => {
 
   it('replace all fields', () => {
     const result = modify(schemaPet, {
-      // This is a callback recursive through all fields
+      // [*2] This is a callback recursive through all fields
       allFields: (fieldName, fieldAttrs) => {
         const { inputType, percentage } = fieldAttrs.presentation;
 
@@ -184,8 +187,10 @@ describe('modify() - attributes', () => {
         pet_name: (fieldAttrs) => {
           //console.log(fieldsAttrs.maximum) // 24
           return {
+            // [*3]
             errorMessage: {
               minimum: `We only accept pets up to ${fieldAttrs.maximum} months old.`,
+              required: 'We need to know your pet name.',
             },
           };
         },
@@ -199,6 +204,8 @@ describe('modify() - attributes', () => {
           'x-jsf-errorMessage': {
             // maximum: (before) 'Your pet cannot be older than 24 months.',
             minimum: `We only accept pets up to 24 months old.`,
+            // required: (before) undefined
+            required: 'We need to know your pet name.',
           },
         },
       },
@@ -215,6 +222,7 @@ describe('modify() - attributes', () => {
     const result = modify(baseExample, {
       // eslint-disable-next-line no-unused-vars
       order: (originalOrder) => {
+        // [*4]
         // console.log(order) // ['field_a', 'field_b', 'field_c', 'field_d']
         return {
           order: ['field_c', 'field_a', 'field_b'],
@@ -306,6 +314,7 @@ const schemaTickets = {
 };
 
 describe('modify() - structures', () => {
+  // [*6]
   it('pick fields - basic', () => {
     const result = modify(schemaTickets, {
       pick: {
@@ -352,7 +361,7 @@ describe('modify() - structures', () => {
     });
   });
 
-  // Q:❓ Would this be really needed?
+  // Q:❓ [*7] Would this be really needed?
   it('omit fields - basic usage', () => {
     const result = modify(schemaTickets, {
       omit: 'has_premium',
@@ -373,9 +382,9 @@ describe('modify() - structures', () => {
     });
   });
 
+  // [*8]
   it('split fields - basic', () => {
-    // eslint-disable-next-line no-undef
-    const result = modify(someSchema, {
+    const result = modify(imagineSomeBasicSchema, {
       split: {
         // 💡 Note how "*" is mandatory to ensure
         // remaining fields has a fallback place.

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -1,0 +1,504 @@
+import { modify } from '../modify';
+
+const schemaPet = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    has_pet: {
+      title: 'Has Pet',
+      description: 'Do you have a pet?',
+      oneOf: [
+        {
+          title: 'Yes',
+          const: 'yes',
+        },
+        {
+          title: 'No',
+          const: 'no',
+        },
+      ],
+      'x-jsf-presentation': {
+        inputType: 'radio',
+      },
+      type: 'string',
+    },
+    pet_name: {
+      title: "Pet's name",
+      description: "What's your pet's name?",
+      'x-jsf-presentation': {
+        inputType: 'text',
+      },
+      type: 'string',
+    },
+    pet_age: {
+      title: "Pet's age in months",
+      'x-jsf-presentation': {
+        inputType: 'number',
+        maximum: 24,
+      },
+      'x-jsf-errorMessage': {
+        maximum: 'Your pet cannot be older than 24 months.',
+      },
+      type: 'integer',
+    },
+    pet_fat: {
+      title: 'Pet fat percentage',
+      'x-jsf-presentation': {
+        inputType: 'number',
+        percentage: true,
+      },
+      type: 'integer',
+    },
+  },
+  required: ['has_pet'],
+  'x-jsf-order': ['has_pet', 'pet_name'],
+  allOf: [
+    {
+      id: 'pet_conditional_id',
+      if: {
+        properties: {
+          has_pet: {
+            const: 'yes',
+          },
+        },
+        required: ['has_pet'],
+      },
+      then: {
+        required: ['pet_name', 'pet_age', 'pet_fat'],
+      },
+      else: {
+        properties: {
+          pet_name: false,
+          pet_age: false,
+          pet_fat: false,
+        },
+      },
+    },
+  ],
+};
+
+describe('modify() - attributes', () => {
+  it('replace base field', () => {
+    const result = modify(schemaPet, {
+      fields: {
+        has_pet: {
+          title: 'Pet owner',
+          description: (fieldAttrs) => {
+            // You can access any raw field attribute to do whatever verification you need,
+            // but remember to be cautious, as they might change.
+            const options = fieldAttrs.oneOf?.map(({ title }) => title).join('or ') || '';
+            return `Do you own a pet? ${options}?`;
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        has_pet: {
+          title: 'Pet owner',
+          description: 'Do you own a pet? Yes or No?',
+        },
+      },
+    });
+  });
+
+  it('replace nested field', () => {
+    const baseAddress = {}; // TODO - imagine it is a fieldset, { address: { street, number, city } }
+    const result = modify(baseAddress, {
+      fields: {
+        'address.street': {
+          title: 'Street name',
+        },
+        // Q:❓ or manual nesting — both would work.
+        address: {
+          properties: {
+            number: { title: 'Door number' },
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        address: {
+          properties: {
+            street: {
+              title: 'Street name',
+              number: 'Door number',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('replace all fields', () => {
+    const result = modify(schemaPet, {
+      // This is a callback recursive through all fields
+      allFields: (fieldName, fieldAttrs) => {
+        const { inputType, percentage } = fieldAttrs.presentation;
+
+        // This is based on a real example I remember from G.codebase.
+        if (inputType === 'number' && percentage === true) {
+          return {
+            styleDecimals: 2,
+          };
+        }
+
+        return {
+          dataFoo: 'abc',
+        };
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        has_pet: {
+          dataFoo: 'abc',
+        },
+        pet_name: {
+          dataFoo: 'abc',
+        },
+        pet_age: {
+          dataFoo: 'abc',
+        },
+        pet_fat: {
+          styleDecimals: 2,
+        },
+      },
+    });
+  });
+
+  it('error message', () => {
+    const result = modify(schemaPet, {
+      fields: {
+        pet_name: (fieldAttrs) => {
+          //console.log(fieldsAttrs.maximum) // 24
+          return {
+            errorMessage: {
+              minimum: `We only accept pets up to ${fieldAttrs.maximum} months old.`,
+            },
+          };
+        },
+      },
+      // ...
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        pet_name: {
+          'x-jsf-errorMessage': {
+            // maximum: (before) 'Your pet cannot be older than 24 months.',
+            minimum: `We only accept pets up to 24 months old.`,
+          },
+        },
+      },
+    });
+  });
+
+  it('reorder fields', () => {
+    const baseExample = {
+      properties: {
+        /*...*/
+      },
+      'x-jsf-order': ['field_a', 'field_b', 'field_c', 'field_d'],
+    };
+    const result = modify(baseExample, {
+      // eslint-disable-next-line no-unused-vars
+      order: (originalOrder) => {
+        // console.log(order) // ['field_a', 'field_b', 'field_c', 'field_d']
+        return {
+          order: ['field_c', 'field_a', 'field_b'],
+          rest: 'start', // 'start' | 'end'
+        };
+      },
+    });
+
+    // 💡 Note how the missing field (field_d) got automatically added as safety measure.
+    expect(result).toMatchObject({
+      'x-jsf-order': ['field_d', 'field_c', 'field_a', 'field_b'],
+    });
+  });
+
+  // Q:❓ Would this be useful for first version or too advanced?
+  it('customize conditional effects', () => {
+    const result = modify(schemaPet, {
+      conditionals: {
+        // The idea is to target a conditional by its id. (new!)
+        pet_conditional_id: {
+          else: {
+            has_pet: {
+              description: 'You should think about finding one.',
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      allOf: [
+        {
+          id: 'pet_conditional_id',
+          if: {
+            /*...*/
+          },
+          then: {
+            /*...*/
+          },
+          else: {
+            properties: {
+              has_pet: {
+                description: 'You should think about finding one.',
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+});
+
+const schemaTickets = {
+  properties: {
+    age: {
+      /* ... */
+    },
+    quatity: {
+      /* ... */
+    },
+    has_premium: {
+      /* ... */
+    },
+    premium_id: {
+      /* ... */
+    },
+  },
+  'x-jsf-order': ['age', 'quantity', 'has_premium', 'premium_id'],
+  allOf: [
+    {
+      if: {
+        properties: {
+          has_premium: {
+            const: 'yes',
+          },
+        },
+        required: ['has_premium'],
+      },
+      then: {
+        required: ['premium_id'],
+      },
+      else: {
+        properties: {
+          premium_id: false,
+        },
+      },
+    },
+  ],
+};
+
+describe('modify() - structures', () => {
+  it('pick fields - basic', () => {
+    const result = modify(schemaTickets, {
+      pick: {
+        fields: ['quantity'],
+      },
+    });
+
+    // Note how the other fields got discarded,
+    // as well the order and allOf got reduced.
+    expect(result).toMatchObject({
+      properties: {
+        quatity: {
+          /*...*/
+        },
+      },
+      'x-jsf-order': ['quantity'],
+      // ...
+    });
+  });
+  it('pick fields - with conditionals', () => {
+    const result = modify(schemaTickets, {
+      pick: {
+        fields: ['has_premium'],
+        onWarn: (ex) => {
+          // A field depends on this one, which was automatically added.
+          // "premium_id" added as it depends on "has_premium".
+          console.warn('Pick was adjusted', ex.message);
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        has_premium: {
+          /*...*/
+        },
+        premium_id: {
+          /*...*/
+        },
+      },
+      allOf: [
+        // the same as schemaTickets
+      ],
+    });
+  });
+
+  // Q:❓ Would this be really needed?
+  it('omit fields - basic usage', () => {
+    const result = modify(schemaTickets, {
+      omit: 'has_premium',
+    });
+
+    // Note how both "has_premium" and the respective conditional got removed.
+    expect(result).toMatchObject({
+      properties: {
+        age: {
+          /* ... */
+        },
+        quatity: {
+          /* ... */
+        },
+      },
+      'x-jsf-order': ['age', 'quantity'],
+      allOf: [],
+    });
+  });
+
+  it('split fields - basic', () => {
+    // eslint-disable-next-line no-undef
+    const result = modify(someSchema, {
+      split: {
+        // 💡 Note how "*" is mandatory to ensure
+        // remaining fields has a fallback place.
+        // otherwise the split will fail.
+        parts: [
+          ['field_a', 'field_b'],
+          ['field_c', '*'],
+        ],
+        onError: (ex) => {
+          console.error('Split failed', ex.message);
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      parts: [
+        // Part 1
+        {
+          properties: {
+            field_a: {
+              /* ... */
+            },
+            field_b: {
+              /* ... */
+            },
+          },
+        },
+        // Part 2
+        {
+          properties: {
+            field_c: {
+              /* ... */
+            },
+            field_d: {
+              // come from the wild "*" selector.
+              /* ... */
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  // CONTINUE HEREEE!
+  //  it.todo('split fields - handling condional fields - Approach A', () => {
+  //    const result = modify(someSchema, {
+  //      split: {
+  //        // 💡 Note how "*" is mandatory to ensure
+  //        // remaining fields has a fallback place.
+  //        // otherwise the split will fail.
+  //        parts: [
+  //          ['field_a', 'field_b'],
+  //          ['field_c', '*'],
+  //        ],
+  //        onError: (ex) => {
+  //          log('Split failed', ex.message);
+  //        },
+  //      },
+  //    });
+
+  //    expect(result).toMatchObject({
+  //      parts: [
+  //        // Part 1
+  //        {
+  //          properties: {
+  //            field_a: {
+  //              /* ... */
+  //            },
+  //            field_b: {
+  //              /* ... */
+  //            },
+  //          },
+  //        },
+  //        // Part 2
+  //        {
+  //          properties: {
+  //            field_c: {
+  //              /* ... */
+  //            },
+  //            field_d: {
+  //              // come from the wild "*" selector.
+  //              /* ... */
+  //            },
+  //          },
+  //        },
+  //      ],
+  //    });
+  //  });
+
+  //  it.todo('split fields - handling condional fields - Approach B', () => {
+  //    const result = modify(someSchema, {
+  //      split: {
+  //        // 💡 Note how "*" is mandatory to ensure
+  //        // remaining fields has a fallback place.
+  //        // otherwise the split will fail.
+  //        parts: [
+  //          ['field_a', 'field_b'],
+  //          ['field_c', '*'],
+  //        ],
+  //        onError: (ex) => {
+  //          log('Split failed', ex.message);
+  //        },
+  //      },
+  //    });
+
+  //    expect(result).toMatchObject({
+  //      parts: [
+  //        // Part 1
+  //        {
+  //          properties: {
+  //            field_a: {
+  //              /* ... */
+  //            },
+  //            field_b: {
+  //              /* ... */
+  //            },
+  //          },
+  //        },
+  //        // Part 2
+  //        {
+  //          properties: {
+  //            field_c: {
+  //              /* ... */
+  //            },
+  //            field_d: {
+  //              // come from the wild "*" selector.
+  //              /* ... */
+  //            },
+  //          },
+  //        },
+  //      ],
+  //    });
+  //  });
+});

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -85,7 +85,24 @@ const schemaPet = {
   ],
 };
 
-const imagineSomeBasicSchema = {};
+const imagineSomeBasicSchema = {
+  /* ... */
+};
+
+/*
+modify() Options:
+
+{
+  fields,
+  allFields,
+  order,
+  conditionals,
+  pick,
+  omit,
+  split, 
+}
+
+*/
 
 describe('modify() - attributes', () => {
   it('replace base field', () => {
@@ -93,13 +110,16 @@ describe('modify() - attributes', () => {
       fields: {
         has_pet: {
           title: 'Pet owner',
-          // Q:❓[*1] Do you find it useful to every attribute to support a callback function?
-          description: (fieldAttrs) => {
-            // You can access any raw field attribute to do whatever verification you need,
-            // but remember to be cautious, as they might change.
-            const options = fieldAttrs.oneOf?.map(({ title }) => title).join('or ') || '';
-            return `Do you own a pet? ${options}?`;
-          },
+        },
+        // Q:❓[*1] Do you find it useful to be a callback function instead?
+        // You can access any raw attribute from the field to do whatever verification you need,
+        // but remember to be cautious, as the attrs value might change.
+        has_pet_2: (fieldAttrs) => {
+          const options = fieldAttrs.oneOf?.map(({ title }) => title).join('or ') || '';
+          return {
+            title: 'Pet owner',
+            description: `Do you own a pet? ${options}?`, // "Do you own a pet? Yes or No?"
+          };
         },
       },
     });
@@ -184,13 +204,13 @@ describe('modify() - attributes', () => {
   it('replace field options (radio/select)', () => {
     const result = modify(schemaPet, {
       fields: {
-        has_pet: {
-          oneOf: (oneOf) => {
-            const labelsMap = {
-              yes: 'Yes, I have',
-            };
+        has_pet: (fieldAttrs) => {
+          const labelsMap = {
+            yes: 'Yes, I have',
+          };
 
-            return oneOf.map((option) => {
+          return {
+            oneOf: fieldAttrs.oneOf.map((option) => {
               const customTitle = labelsMap[option.const];
               if (!customTitle) {
                 console.error('The option is not handled.');
@@ -200,8 +220,8 @@ describe('modify() - attributes', () => {
                 ...option,
                 title: customTitle,
               };
-            });
-          },
+            }),
+          };
         },
       },
     });
@@ -235,6 +255,7 @@ describe('modify() - attributes', () => {
           //console.log(fieldsAttrs.maximum) // 24
           return {
             // [*3]
+            // note how we don't need to write "x-jsf-errorMessage" - sugar syntax.
             errorMessage: {
               minimum: `We only accept pets up to ${fieldAttrs.maximum} months old.`,
               required: 'We need to know your pet name.',
@@ -290,9 +311,9 @@ describe('modify() - attributes', () => {
       conditionals: {
         // The idea is to target a conditional by its id. (new!)
         pet_conditional_id: {
-          else: {
+          then: {
             has_pet: {
-              description: 'You should think about finding one.',
+              description: 'Glad you have a pet!',
             },
           },
         },


### PR DESCRIPTION
## Problem

Currently, doing customizations to JSON Schemas is quite fragile and we don't have any specs to allow it.

## Proposal

Move JSON Schema customizations to happen *before the* schema is parsed.

- Before: `createHeadlessForm()` (with customizations) → Form output
- Proposal: customizations → `createHeadlessForm()` → Form output

This reduces the complexity inside `createHeadlessForm()`, solving existing limitations and bugs.
Additionally it has a clear separation of concerns “customizations VS parsing”

```js
// Before:
const form = createHeadlessForm(jsonSchema, {
  customProperties: { 
    my_field: {
      description: "My new description."
    }
  }
); 


// New:
const newSchema = modify(schema, {
  fields: {
    my_field: {
      description: "My new description."
    }
  }
})

const form = createHeadlessForm(newSchema)

```

### Features considered:

The new `modify()` module would allow safer customizations like:
- change base and nested fields attributes, by name or a custom selector
- change error messages
- change conditional effects (`then` and `else`)
- reorder the form fields
- pick or omit specific fields from a json schema (root and recursive)
- split the json schema into multiple parts (steps)
- change conditionals effects (?unclear)
- advanced modifications based on form values. (?unclear)

Check the test file to know more about each case, and which ones are implemented or just drafts.

----

Linear issue [https://linear.app/remote/issue/PBYR-1363](https://linear.app/remote/issue/PBYR-1363)