### PR TITLE
Create modify() utility for better customizations

### DIFF
--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -113,3 +113,28 @@ export function createHeadlessForm(
   jsonSchema: JSONSchemaObjectType,
   customConfig?: JSFConfig
 ): HeadlessFormOutput;
+
+type MutationsConfig = {
+  /**
+   * An object with the list of fields to be mutated.
+   */
+  fields: Record<string, unknown>;
+  /**
+   * a callback function that applies a mutation to all the fields.
+   * @param fieldName
+   * @param fieldAttrs
+   * @returns
+   */
+  allFields: (fieldName: string, fieldAttrs: Record<string, unknown>) => Record<string, unknown>;
+};
+
+export function modify(
+  /**
+   * The original JSON schema to be modified.
+   */
+  originalSchema: JSONSchemaObjectType,
+  /**
+   * The configuration object containing the fields and allFields properties.
+   */
+  config?: Mutations
+);

--- a/json-schema-form.d.ts
+++ b/json-schema-form.d.ts
@@ -136,5 +136,5 @@ export function modify(
   /**
    * The configuration object containing the fields and allFields properties.
    */
-  config?: Mutations
+  config?: MutationsConfig
 );

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { createHeadlessForm } from './createHeadlessForm';
+export { modify } from './modify';
 
 export { pickXKey } from './internals/helpers';
 export { buildCompleteYupSchema } from './yupSchema';

--- a/src/modify.js
+++ b/src/modify.js
@@ -1,0 +1,77 @@
+import get from 'lodash/get';
+import merge from 'lodash/merge';
+
+/**
+ *
+ * @param {*} path
+ * @example
+ * shortToFullPath('foo.bar') // 'foo.properties.bar'
+ */
+function shortToFullPath(path) {
+  return path.replace('.', '.properties.');
+}
+
+function standardizeAttrs(attrs) {
+  const { errorMessage, properties, ...rest } = attrs;
+
+  return {
+    ...rest,
+    ...(errorMessage ? { 'x-jsf-errorMessage': errorMessage } : {}),
+  };
+}
+
+function rewriteFields(schema, fieldsConfig) {
+  if (!fieldsConfig) return null;
+
+  const fieldsToModify = Object.entries(fieldsConfig);
+
+  fieldsToModify.forEach(([shortPath, mutation]) => {
+    const fieldPath = shortToFullPath(shortPath);
+
+    if (!get(schema.properties, fieldPath)) {
+      return; // Ignore field non existent in original schema.
+    }
+
+    const fieldAttrs = get(schema.properties, fieldPath);
+    const fieldChanges = typeof mutation === 'function' ? mutation(fieldAttrs) : mutation;
+
+    merge(get(schema.properties, fieldPath), {
+      ...fieldAttrs,
+      ...standardizeAttrs(fieldChanges),
+    });
+
+    if (fieldChanges.properties) {
+      rewriteFields(get(schema.properties, fieldPath), fieldChanges.properties);
+    }
+  });
+}
+
+function rewriteAllFields(schema, configCallback, context) {
+  if (!configCallback) return null;
+  const parentName = context?.parent;
+
+  Object.entries(schema.properties).forEach(([fieldName, fieldAttrs]) => {
+    const fullName = parentName ? `${parentName}.${fieldName}` : fieldName;
+    merge(get(schema.properties, fieldName), {
+      ...fieldAttrs,
+      ...configCallback(fullName, fieldAttrs),
+    });
+
+    // Nested fields, go recursive (fieldset)
+    if (fieldAttrs.properties) {
+      rewriteAllFields(fieldAttrs, configCallback, {
+        parent: fieldName,
+      });
+    }
+  });
+}
+
+export function modify(originalSchema, config) {
+  const schema = JSON.parse(JSON.stringify(originalSchema));
+
+  rewriteFields(schema, config.fields);
+
+  rewriteAllFields(schema, config.allFields);
+
+  return schema;
+}

--- a/src/modify.js
+++ b/src/modify.js
@@ -66,6 +66,20 @@ function rewriteAllFields(schema, configCallback, context) {
   });
 }
 
+/**
+ * @typedef Mutations
+ * @type {object}
+ * @property {object} fields - an object with the list of fields to be mutated.
+ * @property {(fieldName: string, fieldAttrs: object) => object} allFields - a callback function that applies a mutation to all the fields.
+ */
+
+/**
+ * Modifies the original schema based on the provided configuration.
+ *
+ * @param {object} originalSchema - The original JSON schema to be modified.
+ * @param {Mutations} config - The configuration object containing the fields and allFields properties.
+ * @returns {object} - The modified JSON schema.
+ */
 export function modify(originalSchema, config) {
   const schema = JSON.parse(JSON.stringify(originalSchema));
 

--- a/src/modify.js
+++ b/src/modify.js
@@ -66,20 +66,6 @@ function rewriteAllFields(schema, configCallback, context) {
   });
 }
 
-/**
- * @typedef Mutations
- * @type {object}
- * @property {object} fields - an object with the list of fields to be mutated.
- * @property {(fieldName: string, fieldAttrs: object) => object} allFields - a callback function that applies a mutation to all the fields.
- */
-
-/**
- * Modifies the original schema based on the provided configuration.
- *
- * @param {object} originalSchema - The original JSON schema to be modified.
- * @param {Mutations} config - The configuration object containing the fields and allFields properties.
- * @returns {object} - The modified JSON schema.
- */
 export function modify(originalSchema, config) {
   const schema = JSON.parse(JSON.stringify(originalSchema));
 

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -1,0 +1,301 @@
+import { modify } from '../modify';
+
+const schemaPet = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    has_pet: {
+      title: 'Has Pet',
+      description: 'Do you have a pet?',
+      oneOf: [
+        {
+          title: 'Yes',
+          const: 'yes',
+        },
+        {
+          title: 'No',
+          const: 'no',
+        },
+      ],
+      'x-jsf-presentation': {
+        inputType: 'radio',
+      },
+      type: 'string',
+    },
+    pet_name: {
+      title: "Pet's name",
+      description: "What's your pet's name?",
+      'x-jsf-presentation': {
+        inputType: 'text',
+      },
+      type: 'string',
+    },
+    pet_age: {
+      title: "Pet's age in months",
+      maximum: 24,
+      'x-jsf-presentation': {
+        inputType: 'number',
+      },
+      'x-jsf-errorMessage': {
+        maximum: 'Your pet cannot be older than 24 months.',
+      },
+      type: 'integer',
+    },
+    pet_fat: {
+      title: 'Pet fat percentage',
+      'x-jsf-presentation': {
+        inputType: 'number',
+        percentage: true,
+      },
+      type: 'integer',
+    },
+    pet_address: {
+      properties: {
+        street: {
+          title: 'Street',
+        },
+      },
+    },
+  },
+  required: ['has_pet'],
+  'x-jsf-order': ['has_pet', 'pet_name'],
+  allOf: [
+    {
+      id: 'pet_conditional_id',
+      if: {
+        properties: {
+          has_pet: {
+            const: 'yes',
+          },
+        },
+        required: ['has_pet'],
+      },
+      then: {
+        required: ['pet_name', 'pet_age', 'pet_fat'],
+      },
+      else: {
+        properties: {
+          pet_name: false,
+          pet_age: false,
+          pet_fat: false,
+        },
+      },
+    },
+  ],
+};
+
+const schemaAddress = {
+  properties: {
+    address: {
+      properties: {
+        street: {
+          title: 'Street',
+        },
+        number: {
+          title: 'Number',
+        },
+        city: {
+          title: 'City',
+        },
+      },
+    },
+  },
+};
+
+describe('modify() - basic mutations', () => {
+  it('replace base field', () => {
+    const result = modify(schemaPet, {
+      fields: {
+        pet_name: {
+          title: 'Your pet name',
+        },
+        has_pet: (fieldAttrs) => {
+          const options = fieldAttrs.oneOf?.map(({ title }) => title).join(' or ') || '';
+          return {
+            title: 'Pet owner',
+            description: `Do you own a pet? ${options}?`, // "Do you own a pet? Yes or No?"
+          };
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        pet_name: {
+          title: 'Your pet name',
+        },
+        has_pet: {
+          title: 'Pet owner',
+          description: 'Do you own a pet? Yes or No?',
+        },
+      },
+    });
+  });
+
+  it('replace nested field', () => {
+    const result = modify(schemaAddress, {
+      fields: {
+        'address.street': {
+          title: 'Street name',
+        },
+        'address.city': () => ({
+          title: 'City name',
+        }),
+        address: (fieldAttrs) => {
+          console.log(fieldAttrs.properties.street);
+          return {
+            properties: {
+              number: { title: 'Door number' },
+            },
+          };
+        },
+        // TODO: write test to nested field
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        address: {
+          properties: {
+            street: {
+              title: 'Street name',
+            },
+            number: {
+              title: 'Door number',
+            },
+            city: {
+              title: 'City name',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('replace all fields', () => {
+    const result = modify(schemaPet, {
+      allFields: (fieldName, fieldAttrs) => {
+        const { inputType, percentage } = fieldAttrs?.['x-jsf-presentation'] || {};
+
+        if (inputType === 'number' && percentage === true) {
+          return {
+            styleDecimals: 2,
+          };
+        }
+
+        return {
+          dataFoo: 'abc',
+        };
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        has_pet: {
+          dataFoo: 'abc',
+        },
+        pet_name: {
+          dataFoo: 'abc',
+        },
+        pet_age: {
+          dataFoo: 'abc',
+        },
+        pet_fat: {
+          styleDecimals: 2,
+        },
+        pet_address: {
+          properties: {
+            street: {
+              dataFoo: 'abc',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('replace field options (radio/select)', () => {
+    const result = modify(schemaPet, {
+      fields: {
+        has_pet: (fieldAttrs) => {
+          const labelsMap = {
+            yes: 'Yes, I have',
+          };
+
+          return {
+            oneOf: fieldAttrs.oneOf.map((option) => {
+              const customTitle = labelsMap[option.const];
+              if (!customTitle) {
+                // TODO - test this
+                // console.error('The option is not handled.');
+                return option;
+              }
+              return {
+                ...option,
+                title: customTitle,
+              };
+            }),
+          };
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        has_pet: {
+          oneOf: [
+            {
+              title: 'Yes, I have',
+              const: 'yes',
+            },
+            {
+              title: 'No',
+              const: 'no',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('error message', () => {
+    const result = modify(schemaPet, {
+      fields: {
+        pet_age: (fieldAttrs) => {
+          return {
+            errorMessage: {
+              minimum: `We only accept pets up to ${fieldAttrs.maximum} months old.`,
+              required: 'We need to know your pet name.',
+            },
+          };
+        },
+        'pet_address.street': {
+          errorMessage: {
+            required: 'Your pet cannot live in the street.',
+          },
+        },
+      },
+      // ...
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        pet_age: {
+          'x-jsf-errorMessage': {
+            minimum: `We only accept pets up to 24 months old.`,
+            required: 'We need to know your pet name.',
+          },
+        },
+        pet_address: {
+          properties: {
+            street: {
+              'x-jsf-errorMessage': {
+                required: 'Your pet cannot live in the street.',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -141,8 +141,7 @@ describe('modify() - basic mutations', () => {
         'address.city': () => ({
           title: 'City name',
         }),
-        address: (fieldAttrs) => {
-          console.log(fieldAttrs.properties.street);
+        address: () => {
           return {
             properties: {
               number: { title: 'Door number' },


### PR DESCRIPTION
Note: This PR is heavily inspired by [this pull request](https://github.com/remoteoss/json-schema-form/pull/71) that will be divided into smaller PRs.

### Problem
Currently, doing customizations to JSON Schemas is quite fragile and we don't have any specs to allow it.

### Proposal
Move JSON Schema customizations to happen before the schema is parsed.

- Before: createHeadlessForm() (with customizations) → Form output
- Proposal: customizations → createHeadlessForm() → Form output

This reduces the complexity inside createHeadlessForm(), solving existing limitations and bugs.
Additionally it has a clear separation of concerns “customizations VS parsing”

```
// Before:
const form = createHeadlessForm(jsonSchema, {
  customProperties: { 
    my_field: {
      description: "My new description."
    }
  }
); 


// New:
const newSchema = modify(schema, {
  fields: {
    my_field: {
      description: "My new description."
    }
  }
})

const form = createHeadlessForm(newSchema)
```

The `modify` function allows safer customizations such as:

- change base and nested fields attributes, by name or a custom selector
- change error messages