### PR TITLE
feat(modify): Allow customize fields order

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,6 @@
     "curly": ["error", "multi-line"],
     "arrow-body-style": 0,
     "default-case": 0,
-
     "import/order": [
       "warn",
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "curly": ["error", "multi-line"],
     "arrow-body-style": 0,
     "default-case": 0,
+
     "import/order": [
       "warn",
       {
@@ -25,6 +26,9 @@
         }
       }
     ],
-    "no-unused-vars": ["error", { "ignoreRestSiblings": true }]
+    "no-unused-vars": [
+      "error",
+      { "ignoreRestSiblings": true, "destructuredArrayIgnorePattern": "_" }
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,9 +26,6 @@
         }
       }
     ],
-    "no-unused-vars": [
-      "error",
-      { "ignoreRestSiblings": true, "destructuredArrayIgnorePattern": "_" }
-    ]
+    "no-unused-vars": ["error", { "ignoreRestSiblings": true }]
   }
 }

--- a/src/modify.js
+++ b/src/modify.js
@@ -125,7 +125,7 @@ export function modify(originalSchema, config) {
   const resultRewrite = rewriteFields(schema, config.fields);
   rewriteAllFields(schema, config.allFields);
 
-  const resultReorder = reorderFields(schema, config.rootOrder);
+  const resultReorder = reorderFields(schema, config.orderRoot);
 
   if (!config.muteLogging) {
     console.warn(

--- a/src/modify.js
+++ b/src/modify.js
@@ -4,7 +4,7 @@ import mergeWith from 'lodash/mergeWith';
 
 const WARNING_TYPES = {
   FIELD_TO_CHANGE_NOT_FOUND: 'FIELD_TO_CHANGE_NOT_FOUND',
-  ODER_MISSING_FIELDS: 'ODER_MISSING_FIELDS',
+  ORDER_MISSING_FIELDS: 'ORDER_MISSING_FIELDS',
 };
 /**
  *
@@ -104,7 +104,7 @@ function reorderFields(schema, configOrder) {
 
   if (remaining.length > 0) {
     warnings.push({
-      type: WARNING_TYPES.ODER_MISSING_FIELDS,
+      type: WARNING_TYPES.ORDER_MISSING_FIELDS,
       message: `Some fields got forgotten in the new order. They were automatically appended: ${remaining.join(
         ', '
       )}`,

--- a/src/modify.js
+++ b/src/modify.js
@@ -109,9 +109,9 @@ function reorderFields(schema, orderCallback) {
   const remaining = difference(originalOrder, orderConfig.order);
 
   const finalOrder =
-    orderConfig.rest === 'end'
-      ? [...orderConfig.order, ...remaining]
-      : [...remaining, ...orderConfig.order];
+    orderConfig.rest === 'start'
+      ? [...remaining, ...orderConfig.order]
+      : [...orderConfig.order, ...remaining];
 
   schema['x-jsf-order'] = finalOrder;
 }

--- a/src/modify.js
+++ b/src/modify.js
@@ -21,11 +21,7 @@ function mergeReplaceArray(_, newVal) {
 }
 
 function standardizeAttrs(attrs) {
-  const {
-    errorMessage, // this is the key that will be renamed
-    properties, // destructured because of recursive call afterwards
-    ...rest
-  } = attrs;
+  const { errorMessage, properties, ...rest } = attrs;
 
   return {
     ...rest,
@@ -105,10 +101,11 @@ function reorderFields(schema, configOrder) {
   const originalOrder = schema['x-jsf-order'];
   const orderConfig = typeof configOrder === 'function' ? configOrder(originalOrder) : configOrder;
   const remaining = difference(originalOrder, orderConfig);
+
   if (remaining.length > 0) {
     warnings.push({
       type: WARNING_TYPES.ODER_MISSING_FIELDS,
-      message: `Some fields got forgotten in the new order. They were automatically appended to the end: ${remaining.join(
+      message: `Some fields got forgotten in the new order. They were automatically appended: ${remaining.join(
         ', '
       )}`,
     });

--- a/src/modify.js
+++ b/src/modify.js
@@ -108,12 +108,7 @@ function reorderFields(schema, orderCallback) {
   const orderConfig = orderCallback(originalOrder);
   const remaining = difference(originalOrder, orderConfig.order);
 
-  const finalOrder =
-    orderConfig.rest === 'start'
-      ? [...remaining, ...orderConfig.order]
-      : [...orderConfig.order, ...remaining];
-
-  schema['x-jsf-order'] = finalOrder;
+  schema['x-jsf-order'] = [...orderConfig.order, ...remaining];
 }
 
 export function modify(originalSchema, config) {

--- a/src/modify.js
+++ b/src/modify.js
@@ -98,7 +98,7 @@ function reorderFields(schema, configOrder) {
   if (!configOrder) return { warnings: null };
 
   const warnings = [];
-  const originalOrder = schema['x-jsf-order'];
+  const originalOrder = schema['x-jsf-order'] || [];
   const orderConfig = typeof configOrder === 'function' ? configOrder(originalOrder) : configOrder;
   const remaining = difference(originalOrder, orderConfig);
 

--- a/src/modify.js
+++ b/src/modify.js
@@ -4,6 +4,7 @@ import mergeWith from 'lodash/mergeWith';
 
 const WARNING_TYPES = {
   FIELD_TO_CHANGE_NOT_FOUND: 'FIELD_TO_CHANGE_NOT_FOUND',
+  ODER_MISSING_FIELDS: 'ODER_MISSING_FIELDS',
 };
 /**
  *
@@ -106,7 +107,7 @@ function reorderFields(schema, configOrder) {
   const remaining = difference(originalOrder, orderConfig);
   if (remaining.length > 0) {
     warnings.push({
-      type: 'reorderFields',
+      type: WARNING_TYPES.ODER_MISSING_FIELDS,
       message: `Some fields got forgotten in the new order. They were automatically appended to the end: ${remaining.join(
         ', '
       )}`,

--- a/src/modify.js
+++ b/src/modify.js
@@ -101,14 +101,14 @@ function rewriteAllFields(schema, configCallback, context) {
   });
 }
 
-function reorderFields(schema, orderCallback) {
-  if (!orderCallback) return null;
+function reorderFields(schema, configOrder) {
+  if (!configOrder) return null;
 
   const originalOrder = schema['x-jsf-order'];
-  const orderConfig = orderCallback(originalOrder);
-  const remaining = difference(originalOrder, orderConfig.order);
+  const orderConfig = typeof configOrder === 'function' ? configOrder(originalOrder) : configOrder;
+  const remaining = difference(originalOrder, orderConfig.fields);
 
-  schema['x-jsf-order'] = [...orderConfig.order, ...remaining];
+  schema['x-jsf-order'] = [...orderConfig.fields, ...remaining];
 }
 
 export function modify(originalSchema, config) {

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -410,14 +410,14 @@ describe('modify() - reoder fields', () => {
       order: () => {
         return {
           order: ['field_c', 'field_a', 'field_b'],
-          // rest: 'start', default behavior
+          // rest: 'end', default behavior
         };
       },
     });
 
-    // 💡 Note how the missing field (field_d) was added to the start as safety measure.
+    // 💡 Note how the missing field (field_d) was added to the end as safety measure.
     expect(result).toMatchObject({
-      'x-jsf-order': ['field_d', 'field_c', 'field_a', 'field_b'],
+      'x-jsf-order': ['field_c', 'field_a', 'field_b', 'field_d'],
     });
   });
 
@@ -432,14 +432,14 @@ describe('modify() - reoder fields', () => {
       order: () => {
         return {
           order: ['field_c', 'field_a', 'field_b'],
-          rest: 'end',
+          rest: 'start',
         };
       },
     });
 
     // 💡 Note how the missing field (field_d) was added to the end as safety measure.
     expect(result).toMatchObject({
-      'x-jsf-order': ['field_c', 'field_a', 'field_b', 'field_d'],
+      'x-jsf-order': ['field_d', 'field_c', 'field_a', 'field_b'],
     });
   });
 

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -479,9 +479,7 @@ describe('modify() - reoder fields', () => {
       'x-jsf-order': ['address', 'age'],
     };
 
-    // Approach A - API based on field scope.
-    // Downside: The root order() is misleading?
-    const resultA = modify(baseExample, {
+    const result = modify(baseExample, {
       fields: {
         address: {
           order: (original) => {
@@ -498,29 +496,7 @@ describe('modify() - reoder fields', () => {
       },
     });
 
-    // Approach B - API based on order scope.
-    // Downside - harder to isolate customizations per fieldset
-    /*
-    const resultB = modify(baseExample, {
-      order: () => {
-        return {
-          order: (original) => {
-            return original.reverse(); // ['age', 'address']
-          },
-          fields: {
-            address: {
-              order: (original) => {
-                return {
-                  order: original.reverse(), // ['city', 'zipcode', 'first_line']
-                };
-              },
-            },
-          },
-        };
-      },
-    });
-    */
-    expect(resultA).toMatchObject({
+    expect(result).toMatchObject({
       properties: {
         address: {
           'x-jsf-order': ['city', 'zipcode', 'first_line'],

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -417,7 +417,7 @@ describe('modify() - reoder fields', () => {
 
     expect(result.warnings).toMatchObject([
       {
-        type: 'reorderFields',
+        type: 'ODER_MISSING_FIELDS',
         message:
           'Some fields got forgotten in the new order. They were automatically appended to the end: field_a, field_d',
       },

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -424,6 +424,24 @@ describe('modify() - reoder fields', () => {
     ]);
   });
 
+  it('reorder fields - basic usage fallback', () => {
+    const baseExample = {
+      properties: {
+        /* does not matter */
+      },
+    };
+    const result = modify(baseExample, {
+      orderRoot: ['field_c', 'field_b'],
+    });
+
+    // Does not explode if it doesn't have an original order.
+    expect(result.schema).toMatchObject({
+      'x-jsf-order': ['field_c', 'field_b'],
+    });
+
+    expect(result.warnings).toEqual([]);
+  });
+
   it('reorder fields -  as callback based on original order', () => {
     const baseExample = {
       properties: {

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -417,7 +417,7 @@ describe('modify() - reoder fields', () => {
 
     expect(result.warnings).toMatchObject([
       {
-        type: 'ODER_MISSING_FIELDS',
+        type: 'ORDER_MISSING_FIELDS',
         message:
           'Some fields got forgotten in the new order. They were automatically appended: field_a, field_d',
       },
@@ -444,7 +444,7 @@ describe('modify() - reoder fields', () => {
     // NOTE: A better API is needed but we decided to not implement it yet
     // as we didn't agreed on the best DX. Check PR #78 for proposed APIs.
     // Until then this is the workaround.
-    // Note the warning "ODER_MISSING_FIELDS" won't be added.
+    // Note the warning "ORDER_MISSING_FIELDS" won't be added.
 
     const baseExample = {
       properties: {

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -410,7 +410,6 @@ describe('modify() - reoder fields', () => {
       order: () => {
         return {
           order: ['field_c', 'field_a', 'field_b'],
-          // rest: 'end', default behavior
         };
       },
     });
@@ -418,28 +417,6 @@ describe('modify() - reoder fields', () => {
     // 💡 Note how the missing field (field_d) was added to the end as safety measure.
     expect(result).toMatchObject({
       'x-jsf-order': ['field_c', 'field_a', 'field_b', 'field_d'],
-    });
-  });
-
-  it('reorder fields - basic usage as "end"', () => {
-    const baseExample = {
-      properties: {
-        /* does not matter */
-      },
-      'x-jsf-order': ['field_a', 'field_b', 'field_c', 'field_d'],
-    };
-    const result = modify(baseExample, {
-      order: () => {
-        return {
-          order: ['field_c', 'field_a', 'field_b'],
-          rest: 'start',
-        };
-      },
-    });
-
-    // 💡 Note how the missing field (field_d) was added to the end as safety measure.
-    expect(result).toMatchObject({
-      'x-jsf-order': ['field_d', 'field_c', 'field_a', 'field_b'],
     });
   });
 

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -407,7 +407,7 @@ describe('modify() - reoder fields', () => {
       'x-jsf-order': ['field_a', 'field_b', 'field_c', 'field_d'],
     };
     const result = modify(baseExample, {
-      rootOrder: ['field_c', 'field_b'],
+      orderRoot: ['field_c', 'field_b'],
     });
 
     // 💡 Note how the missing field (field_d) was added to the end as safety measure.
@@ -432,7 +432,7 @@ describe('modify() - reoder fields', () => {
       'x-jsf-order': ['field_a', 'field_b', 'field_c', 'field_d'],
     };
     const result = modify(baseExample, {
-      rootOrder: (original) => original.reverse(),
+      orderRoot: (original) => original.reverse(),
     });
 
     expect(result.schema).toMatchObject({

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -399,7 +399,7 @@ describe('modify() - basic mutations', () => {
 });
 
 describe('modify() - reoder fields', () => {
-  it('reorder fields - basic usage as "start"', () => {
+  it('reorder fields - basic usage', () => {
     const baseExample = {
       properties: {
         /* does not matter */
@@ -407,10 +407,8 @@ describe('modify() - reoder fields', () => {
       'x-jsf-order': ['field_a', 'field_b', 'field_c', 'field_d'],
     };
     const result = modify(baseExample, {
-      order: () => {
-        return {
-          order: ['field_c', 'field_a', 'field_b'],
-        };
+      order: {
+        fields: ['field_c', 'field_a', 'field_b'],
       },
     });
 
@@ -430,7 +428,7 @@ describe('modify() - reoder fields', () => {
     const result = modify(baseExample, {
       order: (original) => {
         return {
-          order: original.reverse(),
+          fields: original.reverse(),
         };
       },
     });
@@ -461,14 +459,14 @@ describe('modify() - reoder fields', () => {
         address: {
           order: (original) => {
             return {
-              order: original.reverse(), // ['city', 'zipcode', 'first_line']
+              fields: original.reverse(), // ['city', 'zipcode', 'first_line']
             };
           },
         },
       },
       order: (original) => {
         return {
-          order: original.reverse(), // ['age', 'address']
+          fields: original.reverse(), // ['age', 'address']
         };
       },
     });

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -419,7 +419,7 @@ describe('modify() - reoder fields', () => {
       {
         type: 'ODER_MISSING_FIELDS',
         message:
-          'Some fields got forgotten in the new order. They were automatically appended to the end: field_a, field_d',
+          'Some fields got forgotten in the new order. They were automatically appended: field_a, field_d',
       },
     ]);
   });
@@ -480,6 +480,6 @@ describe('modify() - reoder fields', () => {
       },
     });
 
-    expect(result.warnings).toBeNull();
+    expect(result.warnings).toEqual([]);
   });
 });

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -443,7 +443,8 @@ describe('modify() - reoder fields', () => {
   it('reorder fields in fieldsets (through config.fields)', () => {
     // NOTE: A better API is needed but we decided to not implement it yet
     // as we didn't agreed on the best DX. Check PR #78 for proposed APIs.
-    // Until then this is the workaround:
+    // Until then this is the workaround.
+    // Note the warning "ODER_MISSING_FIELDS" won't be added.
 
     const baseExample = {
       properties: {
@@ -479,6 +480,6 @@ describe('modify() - reoder fields', () => {
       },
     });
 
-    expect(result.warn).toBeUndefined();
+    expect(result.warnings).toBeNull();
   });
 });


### PR DESCRIPTION
Follow-up of https://github.com/remoteoss/json-schema-form/pull/71, scoped on customizing the order of fields.

This MR can only be merged after #83 

[Linear issue (internal)](https://linear.app/remote/issue/PBYR-1363)


### New specs

Imagine the schema below with 4 fields:

```js
{
  properties: {
    /* does not matter */
  },
  'x-jsf-order': ['field_a', 'field_b', 'field_c', 'field_d'],
};

```

To reorder the fields, pass the given config:

```js
const result = modify(schema, {
  orderRoot: ['field_d', 'field_c', 'field_a', 'field_b',];
});
```

The new order will be: `['field_d', 'field_c', 'field_a', 'field_b',];`.

### As callback

You also have access to the original order using a callback:

```js
const result = modify(baseExample, {
  orderRoot: (original) => original.reverse(),
});
```

The new order will be  `['field_d', 'field_c', 'field_b', 'field_a']`. 


### Missing fields 

By default, any missing field will the automatically appended to the final order. 

In this example, the missing fields field_a and field_c are still included in the final order.

```js
const { schema, warnings }  = modify(schema, {
  orderRoot: ['field_b', 'field_d'];
});

console.log(warning)
{
  type: 'ODER_MISSING_FIELDS',
  message: 'Some fields got forgotten in the new order. They were automatically appended to the end: field_a, field_c',
},

```
---

#### Features NOT included:
- `orderRoot` supporting nested fields (fieldsets). (check tests for workaround)
