### PR TITLE
feat(modify): Allow creating fields

### DIFF
--- a/src/modify.js
+++ b/src/modify.js
@@ -132,8 +132,8 @@ function createFields(schema, fieldsConfig) {
 
     const fieldInSchema = get(schema.properties, fieldPath);
     if (fieldInSchema) {
-      // NOTE: Not sure if we should ignore or overwrite it
-      // when it exists. Let's ignore until someone complains.
+      // Do not override/edit a field that already exists.
+      // That's the job of config.fields method.
       return;
     }
 

--- a/src/modify.js
+++ b/src/modify.js
@@ -117,7 +117,7 @@ function reorderFields(schema, configOrder) {
   return { warnings };
 }
 
-function setFields(schema, fieldsConfig) {
+function createFields(schema, fieldsConfig) {
   if (!fieldsConfig) return null;
 
   const fieldsToAdd = Object.entries(fieldsConfig);
@@ -127,7 +127,7 @@ function setFields(schema, fieldsConfig) {
 
     if (fieldAttrs.properties) {
       // Recursive to nested fields...
-      setFields(get(schema.properties, fieldPath), fieldAttrs.properties);
+      createFields(get(schema.properties, fieldPath), fieldAttrs.properties);
     }
 
     const fieldInSchema = get(schema.properties, fieldPath);
@@ -148,7 +148,8 @@ export function modify(originalSchema, config) {
 
   const resultRewrite = rewriteFields(schema, config.fields);
   rewriteAllFields(schema, config.allFields);
-  setFields(schema, config.add);
+
+  createFields(schema, config.create);
 
   const resultReorder = reorderFields(schema, config.orderRoot);
 

--- a/src/modify.js
+++ b/src/modify.js
@@ -23,12 +23,11 @@ function mergeReplaceArray(_, newVal) {
 }
 
 function standardizeAttrs(attrs) {
-  const { errorMessage, presentation, properties, ...rest } = attrs;
+  const { errorMessage, properties, ...rest } = attrs;
 
   return {
     ...rest,
     ...(errorMessage ? { 'x-jsf-errorMessage': errorMessage } : {}),
-    ...(presentation ? { 'x-jsf-presentation': presentation } : {}),
   };
 }
 
@@ -125,8 +124,6 @@ function setFields(schema, fieldsConfig) {
 
   fieldsToAdd.forEach(([shortPath, fieldAttrs]) => {
     const fieldPath = shortToFullPath(shortPath);
-
-    console.log('fieldAttrs', fieldAttrs);
 
     if (fieldAttrs.properties) {
       // Recursive to nested fields...

--- a/src/modify.js
+++ b/src/modify.js
@@ -134,9 +134,8 @@ function createFields(schema, fieldsConfig) {
     }
 
     const fieldInSchema = get(schema.properties, fieldPath);
-    const { properties, ...otherAttrs } = fieldAttrs;
 
-    if (fieldInSchema && otherAttrs) {
+    if (fieldInSchema) {
       warnings.push({
         type: WARNING_TYPES.FIELD_TO_CREATE_EXISTS,
         message: `Creating field "${shortPath}" was ignored because it already exists.`,

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -58,7 +58,7 @@ const schemaPet = {
     },
   },
   required: ['has_pet'],
-  'x-jsf-order': ['has_pet', 'pet_name'],
+  'x-jsf-order': ['has_pet', 'pet_name', 'pet_age', 'pet_fat', 'pet_address'],
   allOf: [
     {
       id: 'pet_conditional_id',
@@ -563,5 +563,27 @@ describe('modify() - set new fields', () => {
 
     // this is ignored because the field already exists [1]
     expect(result.properties.address.properties.street.title).toBe('Street');
+  });
+
+  // Enable this on PR !78
+  it.skip('reorder new fields', () => {
+    const result = modify(schemaPet, {
+      add: {
+        new_field: {
+          title: 'New field',
+          type: 'string',
+        },
+      },
+      order: {
+        fields: (originalOrder) => {
+          const newOrder = [...originalOrder];
+          return newOrder.splice(1, 0, 'new_field');
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      'x-jsf-order': ['has_pet', 'new_field', 'pet_name', 'pet_age', 'pet_fat', 'pet_address'],
+    });
   });
 });

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -558,7 +558,6 @@ describe('modify() - create fields', () => {
       },
     });
 
-    expect(result.warnings).toEqual([]);
     expect(result.schema.properties.address.properties).toMatchObject({
       ...schemaAddress.properties.address.properties,
       state: {
@@ -583,34 +582,6 @@ describe('modify() - create fields', () => {
       {
         type: 'FIELD_TO_CREATE_EXISTS',
         message: 'Creating field "address.street" was ignored because it already exists.',
-      },
-    ]);
-  });
-
-  // Enable this after PR !78 is merged
-  it.skip('reorder new created fields', () => {
-    const result = modify(schemaPet, {
-      create: {
-        new_field: {
-          title: 'New field',
-          type: 'string',
-        },
-      },
-      orderRoot: (originalOrder) => {
-        const newOrder = [...originalOrder];
-        return newOrder.splice(1, 0, 'new_field');
-      },
-    });
-
-    expect(result).toMatchObject({
-      'x-jsf-order': ['has_pet', 'new_field', 'pet_name', 'pet_age', 'pet_fat', 'pet_address'],
-    });
-
-    expect(result.warnings).toEqual([
-      {
-        type: 'ODER_MISSING_FIELDS',
-        message:
-          'Some fields got forgotten in the new order. They were automatically appended to the end: XXX, XXXX',
       },
     ]);
   });

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -501,9 +501,9 @@ describe('modify() - reoder fields', () => {
 });
 
 describe('modify() - set new fields', () => {
-  it('add base field', () => {
+  it('create base field', () => {
     const result = modify(schemaAddress, {
-      add: {
+      create: {
         new_field: {
           title: 'New field',
           type: 'string',
@@ -528,9 +528,9 @@ describe('modify() - set new fields', () => {
     expect(result.properties.address.something).toBe(undefined);
   });
 
-  it('add nested field', () => {
+  it('create nested field', () => {
     const result = modify(schemaAddress, {
-      add: {
+      create: {
         // Pointer as string
         'address.state': {
           title: 'State',
@@ -566,9 +566,9 @@ describe('modify() - set new fields', () => {
   });
 
   // Enable this on PR !78
-  it.skip('reorder new fields', () => {
+  it.skip('reorder new created fields', () => {
     const result = modify(schemaPet, {
-      add: {
+      create: {
         new_field: {
           title: 'New field',
           type: 'string',

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -497,7 +497,71 @@ describe('modify() - reoder fields', () => {
         },
       },
     });
+  });
+});
+
+describe('modify() - set new fields', () => {
+  it('add base field', () => {
+    const result = modify(schemaAddress, {
+      add: {
+        new_field: {
+          title: 'New field',
+          type: 'string',
+        },
+        address: {
+          something: 'foo',
+        },
+      },
+    });
+
+    expect(result.schema).toMatchObject({
+      properties: {
+        new_field: {
+          title: 'New field',
+          type: 'string',
+        },
+        address: schemaAddress.properties.address,
+      },
+    });
+
+    // this is ignored because the field already exists
+    expect(result.properties.address.something).toBe(undefined);
+  });
+
+  it('add nested field', () => {
+    const result = modify(schemaAddress, {
+      add: {
+        // Pointer as string
+        'address.state': {
+          title: 'State',
+        },
+        // Pointer as object
+        address: {
+          properties: {
+            district: {
+              title: 'District',
+            },
+          },
+        },
+        // this is ignored because the field already exists [1]
+        'address.street': {
+          title: 'Foo',
+        },
+      },
+    });
 
     expect(result.warnings).toEqual([]);
+    expect(result.properties.address.properties).toMatchObject({
+      ...schemaAddress.properties.address.properties,
+      state: {
+        title: 'State',
+      },
+      district: {
+        title: 'District',
+      },
+    });
+
+    // this is ignored because the field already exists [1]
+    expect(result.properties.address.properties.street.title).toBe('Street');
   });
 });

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -583,7 +583,7 @@ describe('modify() - set new fields', () => {
     });
 
     expect(result).toMatchObject({
-      'x-jsf-order': ['has_pet', 'new_field', 'pet_name', 'pet_age', 'pet_fat', 'pet_address'],
+      'x-jsf-order': ['has_pet', 'new_field'],
     });
   });
 });

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -500,7 +500,7 @@ describe('modify() - reoder fields', () => {
   });
 });
 
-describe('modify() - set new fields', () => {
+describe('modify() - create fields', () => {
   it('create base field', () => {
     const result = modify(schemaAddress, {
       create: {


### PR DESCRIPTION
Follow-up of https://github.com/remoteoss/json-schema-form/pull/71, scoped on allowing to add new fields

[Linear issue (internal)](https://linear.app/remote/issue/EXPM-631)

### New specs

Imagine the schema with 2 fields:

```js
const baseSchema = {
  properties: {
    age: {
      title: 'Age',
      type: 'integer',
    },
    family_name: {
      title: 'Family Name',
      type: 'string',
    }
  },
  'x-jsf-order': ['age', 'family_name'],
};
```

If you want to add a new field to the JSON Schema pass the following config:

```js
const { schema }  = modify(baseSchema, {
  create: {
    username: {
      title: 'Username',
      type: 'string',
    },
  }
)
```

Which will return the schema:

```js
{
  properties: {
    age: {
      title: 'Age',
      type: 'integer',
    },
    family_name: {
      title: 'Family Name',
      type: 'string',
    },
    username: {
      title: 'Username',
      type: 'string',
    }
  },
  'x-jsf-order': ['age', 'family_name'],
};
```

### Creating an existing field
If you try to create a field that already exists, it get's ignored and it returns a `warning`. 

Here's an example with the `age` field based on the `baseSchema` above. 

```js
const { schema, warnings } = modify(baseSchema, {
   create: {
     age: { title: "Your age" }
  }
})

console.log(warnings):

[{
  type: "FIELD_TO_CREATE_EXISTS",
  message: `Creating field "age" was ignored because it already exists.`,
}];
```

Check tests for more examples.

### Other features:
- Support adding nested fields
- It supports reordering new fields (check tests and MR https://github.com/remoteoss/json-schema-form/pull/78)
