### PR TITLE
feat(modify): Add x-jsf-presentation shorthand

### DIFF
--- a/src/modify.js
+++ b/src/modify.js
@@ -19,10 +19,11 @@ function mergeReplaceArray(_, newVal) {
 }
 
 function standardizeAttrs(attrs) {
-  const { errorMessage, properties, ...rest } = attrs;
+  const { errorMessage, presentation, properties, ...rest } = attrs;
 
   return {
     ...rest,
+    ...(presentation ? { 'x-jsf-presentation': presentation } : {}),
     ...(errorMessage ? { 'x-jsf-errorMessage': errorMessage } : {}),
   };
 }

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -356,7 +356,7 @@ describe('modify() - basic mutations', () => {
     });
   });
 
-  it('error message', () => {
+  it('customize x-jsf-errorMessage (shorthand)', () => {
     const result = modify(schemaPet, {
       fields: {
         pet_age: (fieldAttrs) => {
@@ -389,6 +389,46 @@ describe('modify() - basic mutations', () => {
             street: {
               'x-jsf-errorMessage': {
                 required: 'Your pet cannot live in the street.',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('customize x-jsf-presentation (shorthand)', () => {
+    const result = modify(schemaPet, {
+      fields: {
+        pet_age: () => {
+          return {
+            presentation: {
+              'data-foo': 123,
+            },
+          };
+        },
+        'pet_address.street': {
+          errorMessage: {
+            'data-foo': 456,
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        pet_age: {
+          'x-jsf-presentation': {
+            ...result.properties.pet_age['x-jsf-presentation'],
+            'data-foo': 123,
+          },
+        },
+        pet_address: {
+          properties: {
+            street: {
+              'x-jsf-errorMessage': {
+                ...result.properties.pet_address.properties.street['x-jsf-presentation'],
+                'data-foo': 456,
               },
             },
           },

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -415,7 +415,7 @@ describe('modify() - basic mutations', () => {
       },
     });
 
-    expect(result).toMatchObject({
+    expect(result.schema).toMatchObject({
       properties: {
         pet_age: {
           'x-jsf-presentation': {

--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -419,7 +419,7 @@ describe('modify() - basic mutations', () => {
       properties: {
         pet_age: {
           'x-jsf-presentation': {
-            ...result.properties.pet_age['x-jsf-presentation'],
+            ...schemaPet.properties.pet_age['x-jsf-presentation'],
             'data-foo': 123,
           },
         },
@@ -427,7 +427,7 @@ describe('modify() - basic mutations', () => {
           properties: {
             street: {
               'x-jsf-errorMessage': {
-                ...result.properties.pet_address.properties.street['x-jsf-presentation'],
+                ...schemaPet.properties.pet_address.properties.street['x-jsf-presentation'],
                 'data-foo': 456,
               },
             },


### PR DESCRIPTION
Follow-up of https://github.com/remoteoss/json-schema-form/pull/75, but now also allowing to customize `x-jsf-presentation` more easily with just `presentation`:

[Linear issue (internal)](https://linear.app/remote/issue/RMT-777)

### Before:

```js
modify(schemaPet, {
  fields: {
    pet_age: {
      'x-jsf-presentation': {
        'data-foo': 123,
      },
    }
  },
});
```

### Now

```js
modify(schemaPet, {
  fields: {
    pet_age: {
      presentation: {
        'data-foo': 123,
      },
    },
  },
});
```