### PR TITLE
fix(modify): Customize attrs as Array now overrides the value

### DIFF
--- a/src/tests/modify.test.js
+++ b/src/tests/modify.test.js
@@ -213,7 +213,7 @@ describe('modify() - basic mutations', () => {
     });
   });
 
-  it('replace field options (radio/select)', () => {
+  it('replace field attrs that are arrays (partial)', () => {
     const result = modify(schemaPet, {
       fields: {
         has_pet: (fieldAttrs) => {
@@ -250,6 +250,29 @@ describe('modify() - basic mutations', () => {
             {
               title: 'No',
               const: 'no',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('replace field attrs that are arrays (full)', () => {
+    const result = modify(schemaPet, {
+      fields: {
+        has_pet: {
+          oneOf: [{ const: 'yaaas', title: 'YAAS!' }],
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      properties: {
+        has_pet: {
+          oneOf: [
+            {
+              const: 'yaaas',
+              title: 'YAAS!',
             },
           ],
         },


### PR DESCRIPTION
Follow-up of https://github.com/remoteoss/json-schema-form/pull/75, with a new fix.

[Linear issue (internal)](https://linear.app/remote/issue/PBYR-1372)

This one was tough, I caught it while adopting `modify()` in our internal Remote codebase, check this out:

Imagine the giving JSON Schema:

```js
{
  properties: {
    has_pet: {
      title: 'Has Pet',
      oneOf: [
        { title: 'Yes', const: 'yes' },
        { title: 'No', const: 'no' },
      ],
      'x-jsf-presentation': {
        inputType: 'radio',
      },
      type: 'string',
    },
  },
};
```

And you want to customize the `has_pet` options to be just one option saying "Nop":


```js
modify(schemaPet, {
  fields: {
    has_pet: {
      oneOf: [{ const: "nop", title: "Nop" }]
    }
  },
});
```

### Before (the bug):

The `merge()` does not override arrays, it merges them based on the index, so the result would still contain the original values from the other indexes.

```js
// properties.has_pet output:
{
  oneOf: [
    { title: 'Nop', const: 'nop' }, 
    { title: 'No', const: 'no' }, // <-- We don't want this!
  ]
};
```

### Now (correct!):

I changed the behavior to override the value when it's an array, using `mergeWith`

```js
// properties.has_pet output:
{
  oneOf: [
    { title: 'Nop', const: 'nop' }, 
  ]
};
```