### PR TITLE
feat(modify): BREAKING CHANGE - Change the return result to include warnings

### DIFF
--- a/src/modify.js
+++ b/src/modify.js
@@ -80,10 +80,22 @@ function rewriteAllFields(schema, configCallback, context) {
 
 export function modify(originalSchema, config) {
   const schema = JSON.parse(JSON.stringify(originalSchema));
+  let warn = []; // To be implemented in next PRs.
 
+  // All these functions mutate "schema",
+  // that's why we create a copy above
   rewriteFields(schema, config.fields);
 
   rewriteAllFields(schema, config.allFields);
 
-  return schema;
+  if (!config.muteWarningTip) {
+    console.warn(
+      'json-schema-form modify(): Make sure you log the returned `warn` as they highlight possible bugs in your modifications. To mute this log, pass `muteWarningTip: true` to the config.'
+    );
+  }
+
+  return {
+    schema,
+    warn: warn.length > 0 ? warn : undefined,
+  };
 }


### PR DESCRIPTION
Follow-up of https://github.com/remoteoss/json-schema-form/pull/71.

[Linear issue (internal)](https://linear.app/remote/issue/pbyr-1417)

Now the result is an object with both `schema` and `warn`. The `warn` will be an array of all warnings highlighting unexpected changes. This can help you spot and avoid possible bugs with your modifications.

### Before

```js
const schema = modify(yourSchema, config)
```

### Now

```js
const { schema, warn } = modify(yourSchema, config)
```

When using `modify()`, it will also log a `console.log` by default calling you out to handle the `warn` on your behalf. For example, report the `warn` to your error tracking systems.

You can disable the log by passing `muteWarningTip`

```js
const { schema, warn } = modify(yourSchema, {
  muteWarningTip: true,
})
```


Full discussion in another PR https://github.com/remoteoss/json-schema-form/pull/80#discussion_r1684195117