### PR TITLE
draft: Gracefully handle when multiple conditional branches are true

### DIFF
--- a/src/createHeadlessForm.js
+++ b/src/createHeadlessForm.js
@@ -334,7 +334,7 @@ function getFieldsFromJSONSchema(scopedJsonSchema, config, logic) {
  * @param {Object} jsonSchema - JSON Schema
  * @param {JsfConfig} customConfig - Config
  */
-export function createHeadlessForm(jsonSchema, customConfig = {}) {
+export function createHeadlessForm(jsonSchema = { properties: {} }, customConfig = {}) {
   const config = {
     strictInputType: true,
     ...customConfig,
@@ -346,7 +346,7 @@ export function createHeadlessForm(jsonSchema, customConfig = {}) {
 
     const handleValidation = handleValuesChange(fields, jsonSchema, config, logic);
 
-    updateFieldsProperties(
+    const { fieldsResult } = updateFieldsProperties(
       fields,
       getPrefillValues(fields, config.initialValues),
       jsonSchema,
@@ -355,6 +355,7 @@ export function createHeadlessForm(jsonSchema, customConfig = {}) {
 
     return {
       fields,
+      fieldsResult,
       handleValidation,
       isError: false,
     };

--- a/src/createHeadlessForm.js
+++ b/src/createHeadlessForm.js
@@ -346,7 +346,7 @@ export function createHeadlessForm(jsonSchema = { properties: {} }, customConfig
 
     const handleValidation = handleValuesChange(fields, jsonSchema, config, logic);
 
-    const { fieldsResult } = updateFieldsProperties(
+    updateFieldsProperties(
       fields,
       getPrefillValues(fields, config.initialValues),
       jsonSchema,
@@ -355,7 +355,6 @@ export function createHeadlessForm(jsonSchema = { properties: {} }, customConfig
 
     return {
       fields,
-      fieldsResult,
       handleValidation,
       isError: false,
     };

--- a/src/jsonLogic.js
+++ b/src/jsonLogic.js
@@ -445,6 +445,7 @@ export function processJSONLogicNode({
   parentID,
   logic,
 }) {
+  let result = {};
   const requiredFields = new Set(accRequired);
 
   if (node.allOf) {
@@ -452,7 +453,8 @@ export function processJSONLogicNode({
       .map((allOfNode) =>
         processJSONLogicNode({ node: allOfNode, formValues, formFields, logic, parentID })
       )
-      .forEach(({ required: allOfItemRequired }) => {
+      .forEach(({ required: allOfItemRequired, result: fieldsResult }) => {
+        result = { ...result, ...fieldsResult };
         allOfItemRequired.forEach(requiredFields.add, requiredFields);
       });
   }
@@ -478,7 +480,7 @@ export function processJSONLogicNode({
       nextNode = node.else;
     }
     if (nextNode) {
-      const { required: branchRequired } = processNode({
+      const { required: branchRequired, fieldsResult } = processNode({
         node: nextNode,
         formValues,
         formFields,
@@ -486,9 +488,12 @@ export function processJSONLogicNode({
         logic,
         parentID,
       });
+      Object.entries(fieldsResult).forEach(([key, value]) => {
+        result[key] = { ...result[key], ...value };
+      });
       branchRequired.forEach((field) => requiredFields.add(field));
     }
   }
 
-  return { required: requiredFields };
+  return { required: requiredFields, result };
 }

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -500,8 +500,8 @@ describe('Ensure multiple conditions are applied at the same time', () => {
         },
       ],
     };
-    const { handleValidation } = createHeadlessForm(schema, { strictInputType: false });
-    const { fieldsResult } = handleValidation({ word: 'hello' });
-    expect(fieldsResult.word).toMatchObject({ maxLength: 5, description: 'I am a description' });
+    const { fields, handleValidation } = createHeadlessForm(schema, { strictInputType: false });
+    handleValidation({ word: 'hello' });
+    expect(fields[0]).toMatchObject({ maxLength: 5, description: 'I am a description' });
   });
 });

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -479,3 +479,29 @@ describe('Conditional with a minimum value check', () => {
     expect(handleValidation({ salary: 1000, reason: 'reason_one' }).formErrors).toEqual(undefined);
   });
 });
+
+describe('Ensure multiple conditions are applied at the same time', () => {
+  it('Should apply multiple conditions at the same time', () => {
+    const schema = {
+      additionalProperties: false,
+      properties: {
+        word: {
+          type: 'string',
+        },
+      },
+      allOf: [
+        {
+          if: { properties: { word: { const: 'hello' } }, required: ['word'] },
+          then: { properties: { word: { maxLength: 5 } } },
+        },
+        {
+          if: { properties: { word: { const: 'hello' } }, required: ['word'] },
+          then: { properties: { word: { description: 'I am a description' } } },
+        },
+      ],
+    };
+    const { handleValidation } = createHeadlessForm(schema, { strictInputType: false });
+    const { fieldsResult } = handleValidation({ word: 'hello' });
+    expect(fieldsResult.word).toMatchObject({ maxLength: 5, description: 'I am a description' });
+  });
+});


### PR DESCRIPTION
Consider the following schema:

```json
{
  "additionalProperties": false,
  "properties": {
    "word": {
      "type": "string"
    }
  },
  "allOf": [
    {
      "if": {
        "properties": { "word": { "const": "hello" } },
        "required": ["word"]
      },
      "then": { "properties": { "word": { "maxLength": 5 } } }
    },
    {
      "if": {
        "properties": { "word": { "const": "hello" } },
        "required": ["word"]
      },
      "then": {
        "properties": { "word": { "description": "I am a description" } }
      }
    }
  ]
}
```

When the field `word` has a value of `hello`, you'd expect the attributes to be the following:

```
{
  name: 'word',
  description: 'I am a description',
  maxLength: 5
}
```

This in the `main` branch does not work at the moment correctly, because on every evaluation of successfully valid conditional branch that we apply, we also run [`removeConditionalStateAttributes`](https://github.com/remoteoss/json-schema-form/blob/main/src/helpers.js#L43-L53). This means that the expected result only happens [here](https://github.com/remoteoss/json-schema-form/blob/main/src/helpers.js#L298).

But, we have no way of saying "keep the results from ALL branches before removing whats stale". It considers the previously evaluated branch as stale. 

What I've done here makes a unit test for this pass... but I haven't fully battle tested. And I very much hate the solution and I'm convinced theres a better way to do this that isn't as truly abhorrent as this. 