### PR TITLE
chore(tests): Move code in global test scope to inside beforeAll

### DIFF
--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -1714,15 +1714,22 @@ describe('createHeadlessForm', () => {
         // Then the fieldset perks.food changes (the "no" option gets removed)
 
         // Setup (arrange)
-        const { fields, handleValidation } = createHeadlessForm(schemaWithConditionalToFieldset);
+        let validateForm;
+        let fields;
+        let originalFood;
+        let perksForLowWorkHours;
 
-        const validateForm = (vals) => friendlyError(handleValidation(vals));
-        const originalFood = getField(fields, 'perks', 'food');
+        beforeAll(() => {
+          const form = createHeadlessForm(schemaWithConditionalToFieldset);
+          fields = form.fields;
+          validateForm = (vals) => friendlyError(form.handleValidation(vals));
+          originalFood = getField(fields, 'perks', 'food');
 
-        const perksForLowWorkHours = {
-          food: 'no', // this option will be removed when the condition happens.
-          retirement: 'basic',
-        };
+          perksForLowWorkHours = {
+            food: 'no', // this option will be removed when the condition happens.
+            retirement: 'basic',
+          };
+        });
 
         it('by default, the Perks.food has 4 options', () => {
           expect(originalFood.options).toHaveLength(4);


### PR DESCRIPTION
chore(tests): Move code in global test scope to inside beforeAll

### Problem:

When we need to run only a specific test (`it.only()`), we were seeing logs of `createHeadlessForm()` outside that test unit. That can cause a lot of noise if we want to debug only a specific unit test, but also seeing logs from other instances.

### Reason
That happens because we had 1 instance of `createHeadlessForm()` being called outside jest lifecycle.


### Solution
Moved that 1 instance in the global scope (inside `describe()`) to an isolated scope, using `beforeAll()`


### How to test.

A simple way can be to add `console.log()` to inside the `createHeadlessForm()`

```diff
export function createHeadlessForm(jsonSchema, customConfig = {}) {
+  console.log('Hello!')
```

And then run only one test at your choise. Eg  `it.only('returns empty result given no schema'`

You'll see the logs saying "Hello" once. But if you go to main master and do the same thing, you'll see the logs twice (Because of the other global instance)