### PR TITLE
chore(json-logic): Add skipped broken unit test for missing json-logic `reduce` support

### DIFF
--- a/src/jsonLogic.js
+++ b/src/jsonLogic.js
@@ -399,7 +399,6 @@ function checkRuleIntegrity(
     subRule.map((item) => {
       const isVar = item !== null && typeof item === 'object' && Object.hasOwn(item, 'var');
       if (isVar) {
-        if (Array.isArray(item.var)) return; // Is an accumlator for reduce and can't be checked.
         const exists = jsonLogic.apply({ var: removeIndicesFromPath(item.var) }, data);
         if (exists === null) {
           throw Error(errorMessage(item));

--- a/src/jsonLogic.js
+++ b/src/jsonLogic.js
@@ -399,6 +399,7 @@ function checkRuleIntegrity(
     subRule.map((item) => {
       const isVar = item !== null && typeof item === 'object' && Object.hasOwn(item, 'var');
       if (isVar) {
+        if (Array.isArray(item.var)) return; // Is an accumlator for reduce and can't be checked.
         const exists = jsonLogic.apply({ var: removeIndicesFromPath(item.var) }, data);
         if (exists === null) {
           throw Error(errorMessage(item));

--- a/src/tests/jsonLogic.fixtures.js
+++ b/src/tests/jsonLogic.fixtures.js
@@ -984,3 +984,51 @@ export const schemaWithTwoValidationsWhereOneOfThemIsAppliedConditionally = {
     },
   ],
 };
+
+export const schemaWithReduceAccumulator = {
+  properties: {
+    work_days: {
+      items: {
+        anyOf: [
+          { const: 'monday', title: 'Monday' },
+          { const: 'tuesday', title: 'Tuesday' },
+          { const: 'wednesday', title: 'Wednesday' },
+          { const: 'thursday', title: 'Thursday' },
+          { const: 'friday', title: 'Friday' },
+          { const: 'saturday', title: 'Saturday' },
+          { const: 'sunday', title: 'Sunday' },
+        ],
+      },
+      type: 'array',
+      uniqueItems: true,
+      'x-jsf-presentation': {
+        inputType: 'select',
+      },
+    },
+    working_hours_per_day: {
+      type: 'number',
+    },
+    working_hours_per_week: {
+      type: 'number',
+      'x-jsf-logic-computedAttrs': {
+        const: 'computed_work_hours_per_week',
+        defaultValue: 'computed_work_hours_per_week',
+        title: '{{computed_work_hours_per_week}} hours per week',
+      },
+    },
+  },
+  'x-jsf-logic': {
+    computedValues: {
+      computed_work_hours_per_week: {
+        rule: {
+          '*': [
+            { var: 'working_hours_per_day' },
+            {
+              reduce: [{ var: 'work_days' }, { '+': [{ var: ['accumulator', 0] }, 1] }, 0],
+            },
+          ],
+        },
+      },
+    },
+  },
+};

--- a/src/tests/jsonLogic.test.js
+++ b/src/tests/jsonLogic.test.js
@@ -244,7 +244,7 @@ describe('jsonLogic: cross-values validations', () => {
     });
   });
 
-  describe('Reduce', () => {
+  describe.todo('Reduce', () => {
     it('reduce: working_hours_per_day * work_days', () => {
       const { fields, handleValidation } = createHeadlessForm(schemaWithReduceAccumulator, {
         strictInputType: false,

--- a/src/tests/jsonLogic.test.js
+++ b/src/tests/jsonLogic.test.js
@@ -34,6 +34,7 @@ import {
   schemaWithUnknownVariableInValidations,
   schemaWithValidationThatDoesNotExistOnProperty,
   badSchemaThatWillNotSetAForcedValue,
+  schemaWithReduceAccumulator,
 } from './jsonLogic.fixtures';
 import { mockConsole, restoreConsoleAndEnsureItWasNotCalled } from './testUtils';
 import { createHeadlessForm } from '@/createHeadlessForm';
@@ -240,6 +241,22 @@ describe('jsonLogic: cross-values validations', () => {
       expect(handleValidation({ field_a: 4, field_b: 1, field_c: 2 }).formErrors).toEqual(
         undefined
       );
+    });
+  });
+
+  describe('Reduce', () => {
+    it('reduce: working_hours_per_day * work_days', () => {
+      const { fields, handleValidation } = createHeadlessForm(schemaWithReduceAccumulator, {
+        strictInputType: false,
+      });
+      handleValidation({
+        work_days: ['monday', 'tuesday'],
+        working_hours_per_day: 8,
+      });
+      const field = fields.find((i) => i.name === 'working_hours_per_week');
+      expect(field.const).toEqual(16);
+      expect(field.default).toEqual(16);
+      expect(field.label).toEqual('16 hours per week');
     });
   });
 

--- a/src/tests/jsonLogic.test.js
+++ b/src/tests/jsonLogic.test.js
@@ -244,7 +244,8 @@ describe('jsonLogic: cross-values validations', () => {
     });
   });
 
-  describe.todo('Reduce', () => {
+  // TODO: Implement this test.
+  describe.skip('Reduce', () => {
     it('reduce: working_hours_per_day * work_days', () => {
       const { fields, handleValidation } = createHeadlessForm(schemaWithReduceAccumulator, {
         strictInputType: false,


### PR DESCRIPTION
This was a bug brought up internally when trying to create a schema similar to the test case. This is because of a false assumption on my side where I didn't need to account for "temp variables" that are indeed supported in json logic for cases like `reduce`.