### PR TITLE
chore(conditionals): Highlight bugs related to validations and conditional fields 

### DIFF
--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -626,4 +626,20 @@ describe('Conditionals - bugs and code-smells', () => {
     // The error should be something like:
     // expect(validation2.formErrors).toEqual({ pet_name: 'Not allowed.'});
   });
+
+  it('Given values from hidden fields, it mutates the values (bug behavior)', () => {
+    const { handleValidation } = createHeadlessForm(schemaHasPet);
+
+    const newValues = { has_pet: 'no', pet_name: 'Max' };
+
+    const validation = handleValidation(newValues);
+
+    expect(newValues).toEqual({
+      has_pet: 'no',
+      pet_name: null, // BUG! 🐛 Should still be "Max", should not be mutated.
+    });
+
+    // Same bug as explained in the previous test.
+    expect(validation.formErrors).toBeUndefined();
+  });
 });

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -642,4 +642,86 @@ describe('Conditionals - bugs and code-smells', () => {
     // Same bug as explained in the previous test.
     expect(validation.formErrors).toBeUndefined();
   });
+
+  it('Given multiple conditionals to the same field, it only applies the last one (bug behavior) - case 1', () => {
+    const { handleValidation } = createHeadlessForm(
+      {
+        additionalProperties: false,
+        properties: {
+          field_a: { type: 'string' },
+          field_b: { type: 'string' },
+          field_c: { type: 'number' },
+        },
+        allOf: [
+          {
+            if: {
+              properties: { field_a: { const: 'yes' } },
+              required: ['field_a'],
+            },
+            then: { properties: { field_c: { minimum: 30 } } },
+          },
+          {
+            if: {
+              properties: { field_b: { const: 'yes' } },
+              required: ['field_b'],
+            },
+            then: { properties: { field_c: { minimum: 10 } } },
+          },
+        ],
+      },
+      {
+        strictInputType: false,
+      }
+    );
+
+    const validation = handleValidation({ field_a: 'yes', field_b: 'yes', field_c: 5 });
+    expect(validation.formErrors).toEqual({
+      // BUG: 🐛 it should be "Must be greater or equal to 30"
+      field_c: 'Must be greater or equal to 10',
+    });
+  });
+
+  it('Given multiple conditionals to the same field, it only applies the last one (bug behavior) - case 2', () => {
+    const { handleValidation } = createHeadlessForm(
+      {
+        additionalProperties: false,
+        properties: {
+          field_a: { type: 'string' },
+          field_b: { type: 'string' },
+          field_c: { type: 'number' },
+        },
+        allOf: [
+          {
+            if: {
+              properties: { field_a: { const: 'yes' } },
+              required: ['field_a'],
+            },
+            then: { properties: { field_c: { minimum: 5 } } },
+          },
+          {
+            if: {
+              properties: { field_b: { const: 'yes' } },
+              required: ['field_b'],
+            },
+            then: { properties: { field_c: { maximum: 10 } } },
+          },
+        ],
+      },
+      {
+        strictInputType: false,
+      }
+    );
+
+    const validation1 = handleValidation({ field_a: 'yes', field_b: 'yes', field_c: 12 });
+    expect(validation1.formErrors).toEqual({
+      field_c: 'Must be smaller or equal to 10',
+    });
+
+    const validation2 = handleValidation({ field_a: 'yes', field_b: 'yes', field_c: 3 });
+    // BUG: 🐛 it should be "Must be greater or equal to 5"
+    expect(validation2.formErrors).toBeUndefined();
+    // expect(validation1.formErrors).toEqual({
+    //   field_c: 'Must be greater or equal to 5',
+    // });
+  });
 });

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -592,7 +592,7 @@ describe('Conditionals - bugs and code-smells', () => {
     ],
   };
 
-  it('Given values from hidden fields, it does not thrown an error (bug behavior)', () => {
+  it('Given values from hidden fields, it does not thrown an error (@bug)', () => {
     const { fields, handleValidation } = createHeadlessForm(schemaHasPet, {
       strictInputType: false,
     });
@@ -614,7 +614,7 @@ describe('Conditionals - bugs and code-smells', () => {
     // expect(validation2.formErrors).toEqual({ pet_name: 'Not allowed.'});
   });
 
-  it('Given values from hidden fields, it mutates the values (bug behavior)', () => {
+  it('Given values from hidden fields, it mutates the values (@bug)', () => {
     const { handleValidation } = createHeadlessForm(schemaHasPet, {
       strictInputType: false,
     });
@@ -632,7 +632,7 @@ describe('Conditionals - bugs and code-smells', () => {
     expect(validation.formErrors).toBeUndefined();
   });
 
-  it('Given multiple conditionals to the same field, it only applies the last one (bug behavior) - case 1', () => {
+  it('Given multiple conditionals to the same field, it only applies the last one (@bug) - case 1', () => {
     const { handleValidation } = createHeadlessForm(
       {
         additionalProperties: false,
@@ -670,7 +670,7 @@ describe('Conditionals - bugs and code-smells', () => {
     });
   });
 
-  it('Given multiple conditionals to the same field, it only applies the last one (bug behavior) - case 2', () => {
+  it('Given multiple conditionals to the same field, it only applies the last one (@bug) - case 2', () => {
     const { handleValidation } = createHeadlessForm(
       {
         additionalProperties: false,

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -549,8 +549,8 @@ describe('Conditional with literal booleans', () => {
 });
 
 describe('Conditionals - bugs and code-smells', () => {
-  // Why do these bugs happens?
-  // To be honest we never realized it until years later.
+  // Why do we have these bugs?
+  // To be honest we never realized it much later later.
   // We will fix them in the next major version.
 
   const schemaHasPet = {
@@ -561,26 +561,13 @@ describe('Conditionals - bugs and code-smells', () => {
         title: 'Has Pet',
         description: 'Do you have a pet?',
         oneOf: [
-          {
-            title: 'Yes',
-            const: 'yes',
-          },
-          {
-            title: 'No',
-            const: 'no',
-          },
+          { title: 'Yes', const: 'yes' },
+          { title: 'No', const: 'no' },
         ],
-        'x-jsf-presentation': {
-          inputType: 'radio',
-        },
         type: 'string',
       },
       pet_name: {
         title: "Pet's name",
-        description: "What's your pet's name?",
-        'x-jsf-presentation': {
-          inputType: 'text',
-        },
         type: 'string',
       },
     },
@@ -589,9 +576,7 @@ describe('Conditionals - bugs and code-smells', () => {
       {
         if: {
           properties: {
-            has_pet: {
-              const: 'yes',
-            },
+            has_pet: { const: 'yes' },
           },
           required: ['has_pet'],
         },
@@ -608,7 +593,9 @@ describe('Conditionals - bugs and code-smells', () => {
   };
 
   it('Given values from hidden fields, it does not thrown an error (bug behavior)', () => {
-    const { fields, handleValidation } = createHeadlessForm(schemaHasPet);
+    const { fields, handleValidation } = createHeadlessForm(schemaHasPet, {
+      strictInputType: false,
+    });
 
     const petNameField = fields[1];
 
@@ -628,7 +615,9 @@ describe('Conditionals - bugs and code-smells', () => {
   });
 
   it('Given values from hidden fields, it mutates the values (bug behavior)', () => {
-    const { handleValidation } = createHeadlessForm(schemaHasPet);
+    const { handleValidation } = createHeadlessForm(schemaHasPet, {
+      strictInputType: false,
+    });
 
     const newValues = { has_pet: 'no', pet_name: 'Max' };
 

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -599,19 +599,14 @@ describe('Conditionals - bugs and code-smells', () => {
 
     const petNameField = fields[1];
 
-    const validation1 = handleValidation({ has_pet: 'yes' });
-    expect(petNameField.isVisible).toBe(true);
-    expect(validation1.formErrors).toEqual({
-      pet_name: 'Required field',
-    });
-
-    const validation2 = handleValidation({ has_pet: 'no', pet_name: 'Max' });
+    const validation = handleValidation({ has_pet: 'no', pet_name: 'Max' });
     expect(petNameField.isVisible).toBe(false);
+
     // Bug: 🐛 It does not thrown an error,
     // but it should to be compliant with JSON Schema specs.
-    expect(validation2.formErrors).toBeUndefined();
+    expect(validation.formErrors).toBeUndefined();
     // The error should be something like:
-    // expect(validation2.formErrors).toEqual({ pet_name: 'Not allowed.'});
+    // expect(validation.formErrors).toEqual({ pet_name: 'Not allowed.'});
   });
 
   it('Given values from hidden fields, it mutates the values (@bug)', () => {


### PR DESCRIPTION
I've added a few tests highlighting existing bugs in JSF. For awareness and to make sure they get solved when the next major version is developed:

* c525914 - multiple conditionals to the same field are not applied 
* 0403f72 - values passed to handleValidation are mutated, but should not 
* e232aba - conditional hidden fields should throw an error, but they do not

[Internal ticket](https://linear.app/remote/issue/DEVXP-2535)