### PR TITLE
DEVXP-2603: chore(next): use json schema test suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "next/json-schema-test-suite"]
+	path = next/json-schema-test-suite
+	url = git@github.com:json-schema-org/JSON-Schema-Test-Suite.git

--- a/next/test/validation/json_schema_test_suite.test.ts
+++ b/next/test/validation/json_schema_test_suite.test.ts
@@ -21,8 +21,8 @@ interface TestSchema {
 expect.extend({
   toBeValid(received: JsfSchema, value: SchemaValue, valid: boolean = true) {
     const form = createHeadlessForm(received, { initialValues: value })
-    const formErrors = form.handleValidation(value)
-    const pass = formErrors.formErrors !== undefined !== valid
+    const validationResult = form.handleValidation(value)
+    const pass = validationResult.formErrors !== undefined !== valid
     return {
       pass,
       message: () => `expected ${util.inspect(value)} ${valid ? 'to' : 'not to'} be valid for ${util.inspect(received)}`,

--- a/next/test/validation/json_schema_test_suite.test.ts
+++ b/next/test/validation/json_schema_test_suite.test.ts
@@ -1,4 +1,3 @@
-import type { ValidationResult } from '../../src/form'
 import type { JsfSchema, SchemaValue } from '../../src/types'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -22,7 +21,8 @@ expect.extend({
   toBeValid(received: JsfSchema, value: SchemaValue, valid: boolean = true) {
     const form = createHeadlessForm(received, { initialValues: value })
     const validationResult = form.handleValidation(value)
-    const pass = validationResult.formErrors !== undefined !== valid
+    const hasFormErrors = validationResult.formErrors !== undefined
+    const pass = hasFormErrors !== valid
     return {
       pass,
       message: () => `expected ${util.inspect(value)} ${valid ? 'to' : 'not to'} be valid for ${util.inspect(received)}`,

--- a/next/test/validation/json_schema_test_suite.test.ts
+++ b/next/test/validation/json_schema_test_suite.test.ts
@@ -41,6 +41,7 @@ describe('JSON Schema Test Suite', () => {
       describe(testSchema.description, () => {
         for (const test of testSchema.tests) {
           it(test.description, () => {
+            // TODO: properly extend the expect interface
             expect(testSchema.schema).toBeValid(test.data, test.valid)
           })
         }

--- a/next/test/validation/json_schema_test_suite.test.ts
+++ b/next/test/validation/json_schema_test_suite.test.ts
@@ -30,7 +30,7 @@ expect.extend({
   },
 })
 
-describe('JSON Schema Test Suite', () => {
+describe.skip('JSON Schema Test Suite', () => {
   const testsDir = path.join(__dirname, '..', '..', 'json-schema-test-suite', 'tests', 'draft2020-12')
   const testFiles = fs.readdirSync(testsDir).filter(file => file.endsWith('.json'))
 

--- a/next/test/validation/json_schema_test_suite.test.ts
+++ b/next/test/validation/json_schema_test_suite.test.ts
@@ -1,0 +1,50 @@
+import type { ValidationResult } from '../../src/form'
+import type { JsfSchema, SchemaValue } from '../../src/types'
+import fs from 'node:fs'
+import path from 'node:path'
+import util from 'node:util'
+import { describe, expect, it } from '@jest/globals'
+import { createHeadlessForm } from '../../src'
+
+interface Test {
+  description: string
+  data: SchemaValue
+  valid: boolean
+}
+
+interface TestSchema {
+  description: string
+  schema: JsfSchema
+  tests: Test[]
+}
+
+expect.extend({
+  toBeValid(received: JsfSchema, value: SchemaValue, valid: boolean = true) {
+    const form = createHeadlessForm(received, { initialValues: value })
+    const formErrors = form.handleValidation(value)
+    const pass = formErrors.formErrors !== undefined !== valid
+    return {
+      pass,
+      message: () => `expected ${util.inspect(value)} ${valid ? 'to' : 'not to'} be valid for ${util.inspect(received)}`,
+    }
+  },
+})
+
+describe('JSON Schema Test Suite', () => {
+  const testsDir = path.join(__dirname, '..', '..', 'json-schema-test-suite', 'tests', 'draft2020-12')
+  const testFiles = fs.readdirSync(testsDir).filter(file => file.endsWith('.json'))
+
+  for (const file of testFiles) {
+    const testFile: TestSchema[] = JSON.parse(fs.readFileSync(path.join(testsDir, file), 'utf8'))
+
+    for (const testSchema of testFile) {
+      describe(testSchema.description, () => {
+        for (const test of testSchema.tests) {
+          it(test.description, () => {
+            expect(testSchema.schema).toBeValid(test.data, test.valid)
+          })
+        }
+      })
+    }
+  }
+})


### PR DESCRIPTION
This adds the json schema test suite repo as a submodule and defines a test for each test case from the test suite dynamically.