### PR TITLE
fix(next): add buildFieldsSchema that will we called instead of builfFieldsObject

### DIFF
--- a/next/src/field/object.ts
+++ b/next/src/field/object.ts
@@ -3,7 +3,7 @@ import type { Field } from './type'
 import { setCustomOrder } from '../custom/order'
 import { buildFieldSingle } from './single'
 
-export function buildFieldObject(params: {
+export function buildFieldsObject(params: {
   schema: JSONSchema
 }): Field[] {
   const { schema } = params

--- a/next/src/field/schema.ts
+++ b/next/src/field/schema.ts
@@ -1,0 +1,18 @@
+import type { JsfSchema } from '../types'
+import type { Field } from './type'
+import { buildFieldsObject } from './object'
+
+export function buildFieldsSchema(params: {
+  schema: JsfSchema
+}): Field[] {
+  const { schema } = params
+
+  if (typeof schema === 'boolean')
+    return []
+
+  if (schema.type === 'object') {
+    return buildFieldsObject({ schema })
+  }
+
+  return []
+}

--- a/next/src/field/single.ts
+++ b/next/src/field/single.ts
@@ -1,6 +1,6 @@
 import type { JsfSchema } from '../types'
 import type { Field } from './type'
-import { buildFieldObject } from './object'
+import { buildFieldsObject } from './object'
 
 /**
  * Build a single UI field from a single schema property
@@ -23,7 +23,7 @@ export function buildFieldSingle(params: {
 
   // Recursive for objects
   if (schema.type === 'object') {
-    field.fields = buildFieldObject({ schema })
+    field.fields = buildFieldsObject({ schema })
   }
 
   return field

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -1,7 +1,7 @@
 import type { Field } from './field/type'
 import type { JsfSchema, SchemaValue } from './types'
 import type { SchemaValidationErrorType } from './validation/schema'
-import { buildFieldObject } from './field/object'
+import { buildFieldsSchema } from './field/schema'
 import { validateSchema } from './validation/schema'
 
 interface FormResult {
@@ -93,7 +93,7 @@ function buildFields(params: {
   if (typeof schema === 'boolean')
     return []
 
-  const fields: Field[] = buildFieldObject({ schema })
+  const fields: Field[] = buildFieldsSchema({ schema })
 
   return fields
 }


### PR DESCRIPTION
`buildFieldsSchema` should be the main entry point for building fields. This also makes recursing easier because everything that has subschemas can call `buildFieldsSchema` instead of having to decide whether to call `buildFieldSingle` or `buildFieldsObject`. 