### PR TITLE
DEVXP-XXX: handle paths

### DIFF
--- a/next/.gitignore
+++ b/next/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /dist
+/json-schema-test-suite

--- a/next/eslint.config.mjs
+++ b/next/eslint.config.mjs
@@ -1,14 +1,3 @@
 import antfu from '@antfu/eslint-config'
 
-export default antfu({
-  ignores: [
-    // Build output
-    'dist',
-
-    // Dependencies
-    'node_modules',
-
-    // External test suite
-    'json-schema-test-suite',
-  ],
-})
+export default antfu({})

--- a/next/jest.config.mjs
+++ b/next/jest.config.mjs
@@ -49,6 +49,7 @@ const config = {
   moduleNameMapper,
   testPathIgnorePatterns,
   reporters: ['default', '<rootDir>/test/json-schema-test-suite/json-schema-test-suite-tracker.js'],
+  transformIgnorePatterns: ['<rootDir>/node_modules/json-schema-typed/'],
 }
 
 export default config

--- a/next/package.json
+++ b/next/package.json
@@ -51,7 +51,6 @@
     "jest": "^29.7.0",
     "json-schema-typed": "^8.0.1",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.3",
-    "validator": "^13.12.0"
+    "typescript": "^5.7.3"
   }
 }

--- a/next/package.json
+++ b/next/package.json
@@ -44,12 +44,14 @@
     "@babel/preset-typescript": "^7.26.0",
     "@jest/globals": "^29.7.0",
     "@jest/reporters": "^29.7.0",
+    "@types/validator": "^13.12.2",
     "babel-jest": "^29.7.0",
     "eslint": "^9.18.0",
     "generate-changelog": "^1.8.0",
     "jest": "^29.7.0",
     "json-schema-typed": "^8.0.1",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "validator": "^13.12.0"
   }
 }

--- a/next/pnpm-lock.yaml
+++ b/next/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
-      validator:
-        specifier: ^13.12.0
-        version: 13.12.0
 
 packages:
 
@@ -3145,10 +3142,6 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
-
-  validator@13.12.0:
-    resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
-    engines: {node: '>= 0.10'}
 
   vue-eslint-parser@9.4.3:
     resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}
@@ -6930,8 +6923,6 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-
-  validator@13.12.0: {}
 
   vue-eslint-parser@9.4.3(eslint@9.18.0):
     dependencies:

--- a/next/pnpm-lock.yaml
+++ b/next/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@jest/reporters':
         specifier: ^29.7.0
         version: 29.7.0
+      '@types/validator':
+        specifier: ^13.12.2
+        version: 13.12.2
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.26.0)
@@ -47,6 +50,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
+      validator:
+        specifier: ^13.12.0
+        version: 13.12.0
 
 packages:
 
@@ -1229,6 +1235,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/validator@13.12.2':
+    resolution: {integrity: sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -3137,6 +3146,10 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  validator@13.12.0:
+    resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
+    engines: {node: '>= 0.10'}
+
   vue-eslint-parser@9.4.3:
     resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}
     engines: {node: ^14.17.0 || >=16.0.0}
@@ -4575,6 +4588,8 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/validator@13.12.2': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -6915,6 +6930,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  validator@13.12.0: {}
 
   vue-eslint-parser@9.4.3(eslint@9.18.0):
     dependencies:

--- a/next/src/validation/anyOf.ts
+++ b/next/src/validation/anyOf.ts
@@ -21,6 +21,7 @@ function mergeSubSchema({ parent, subSchema }: { parent: NonBooleanJsfSchema, su
  * Validate a value against the `anyOf` keyword in a schema.
  * @param value - The value to validate.
  * @param schema - The schema that contains the `anyOf` keyword.
+ * @param path - The path to the current field being validated.
  * @returns An array of validation errors.
  * @description
  * This function checks the provided value against each subschema in the `anyOf` array.
@@ -30,7 +31,7 @@ function mergeSubSchema({ parent, subSchema }: { parent: NonBooleanJsfSchema, su
  * all conditions), the function returns an error indicating that the value should match at
  * least one schema.
  */
-export function validateAnyOf(value: SchemaValue, schema: JsfSchema): ValidationError[] {
+export function validateAnyOf(value: SchemaValue, schema: JsfSchema, path: string[] = []): ValidationError[] {
   if (!schema.anyOf || !Array.isArray(schema.anyOf)) {
     return []
   }
@@ -42,15 +43,14 @@ export function validateAnyOf(value: SchemaValue, schema: JsfSchema): Validation
     if (typeof subSchema !== 'boolean' && typeof schema !== 'boolean') {
       effectiveSubSchema = mergeSubSchema({ parent: schema, subSchema })
     }
-    const errors = validateSchema(value, effectiveSubSchema)
+    const errors = validateSchema(value, effectiveSubSchema, false, path)
     if (errors.length === 0) {
       return []
     }
   }
 
-  // TODO: decide on a path for the `anyOf` errors and also for the other keyword errors that we'll have
   return [{
-    path: [],
+    path,
     validation: 'anyOf',
     message: 'should match at least one schema',
   }]

--- a/next/src/validation/format.ts
+++ b/next/src/validation/format.ts
@@ -4,51 +4,81 @@ import type { SchemaValidationErrorType } from './schema'
 /**
  * Format validation error type
  * @description
- * According to JSON Schema 2020-12, format validation is an annotation by default.
- * It should only be treated as an assertion when explicitly configured.
+ * According to JSON Schema 2020-12:
+ * - Format validation is an annotation by default
+ * - Format validation only applies to strings
+ * - Unknown formats should be ignored
+ * - Implementations SHOULD implement validation for standard formats
+ * - Implementations MAY treat format as a no-op
  */
 export type FormatValidationErrorType = 'format'
 
 /**
  * Supported format names as defined in JSON Schema 2020-12
+ * @see https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7
  */
 export type SupportedFormat =
+  // Date and Time (RFC 3339)
   | 'date-time'
   | 'date'
   | 'time'
   | 'duration'
+  // Email
   | 'email'
   | 'idn-email'
+  // Hostname
   | 'hostname'
   | 'idn-hostname'
+  // IP Address
   | 'ipv4'
   | 'ipv6'
+  // Resource Identifiers
   | 'uri'
   | 'uri-reference'
   | 'iri'
   | 'iri-reference'
+  // UUID
   | 'uuid'
+  // Regular Expressions
+  | 'regex'
 
 // Cache compiled RegExp objects for performance
 const REGEX = {
+  // Date and Time (RFC 3339)
   dateTime: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
   date: /^\d{4}-\d{2}-\d{2}$/,
   time: /^\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/,
   duration: /^P(?:\d+Y)?(?:\d+M)?(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$/,
-  // RFC 5322 compliant email regex
+  // Email (RFC 5322)
   email: /^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i,
-  // RFC 1123 compliant hostname regex
+  // Hostname (RFC 1123)
   hostname: /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i,
+  // IP Address
   ipv4: /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d{1,2})\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d{1,2})$/,
   ipv6: /^(?:(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,7}:|(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:(?::[0-9a-fA-F]{1,4}){1,6}|:(?:(?::[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(?::[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]+|::(?:ffff(?::0{1,4})?:)?(?:(?:25[0-5]|(?:2[0-4]|1?\d)?\d)\.){3}(?:25[0-5]|(?:2[0-4]|1?\d)?\d)|(?:[0-9a-fA-F]{1,4}:){1,4}:(?:(?:25[0-5]|(?:2[0-4]|1?\d)?\d)\.){3}(?:25[0-5]|(?:2[0-4]|1?\d)?\d))$/,
+  // UUID
   uuid: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+  // Regular Expressions
+  regex: (value: string) => {
+    try {
+      const pattern = new RegExp(value)
+      return pattern instanceof RegExp
+    }
+    catch {
+      return false
+    }
+  },
 }
 
 /**
- * Built-in format validators
+ * Built-in format validators according to JSON Schema 2020-12
  * @description
- * According to JSON Schema 2020-12, implementations SHOULD implement validation
- * for these formats, but MAY choose to implement validation as a no-op.
+ * According to JSON Schema 2020-12:
+ * - Format validation is an annotation by default
+ * - Format validation only applies to strings
+ * - Unknown formats should be ignored
+ * - Implementations SHOULD implement validation for standard formats
+ * - Implementations MAY treat format as a no-op
  */
 const formatValidators: Record<SupportedFormat, (value: string) => boolean> = {
   'date-time': value => REGEX.dateTime.test(value),
@@ -97,6 +127,7 @@ const formatValidators: Record<SupportedFormat, (value: string) => boolean> = {
       return false
     }
   },
+  'regex': value => REGEX.regex(value),
   'uuid': value => REGEX.uuid.test(value),
 }
 
@@ -104,6 +135,7 @@ const formatValidators: Record<SupportedFormat, (value: string) => boolean> = {
  * Validate a string value against a format
  * @param value - The string value to validate
  * @param format - The format to validate against
+ * @param path - The path to the current field being validated
  * @returns An array of validation errors
  * @description
  * According to JSON Schema 2020-12:
@@ -112,13 +144,8 @@ const formatValidators: Record<SupportedFormat, (value: string) => boolean> = {
  * - Unknown formats should be ignored
  * - Implementations SHOULD implement validation for standard formats
  * - Implementations MAY treat format as a no-op
- * @example
- * ```ts
- * const errors = validateFormat('not-an-email', 'email')
- * console.log(errors) // [{ path: [], validation: 'format', message: 'must be a valid email format' }]
- * ```
  */
-export function validateFormat(value: string, format: string): ValidationError[] {
+export function validateFormat(value: string, format: string, path: string[] = []): ValidationError[] {
   const errors: ValidationError[] = []
 
   // Format validation only applies to strings
@@ -129,7 +156,7 @@ export function validateFormat(value: string, format: string): ValidationError[]
   const validator = formatValidators[format as SupportedFormat]
   if (validator && !validator(value)) {
     errors.push({
-      path: [],
+      path,
       validation: 'format' as SchemaValidationErrorType,
       message: `must be a valid ${format} format`,
     })

--- a/next/src/validation/format.ts
+++ b/next/src/validation/format.ts
@@ -23,7 +23,7 @@ export type FormatValidationErrorType = 'format'
  * - Since validator.js doesn't directly support IRI validation,
  *   we use isURL with relaxed character constraints
  */
-const formatValidators: Record<Format, (value: string) => boolean> = {
+const formatValidationFunctions: Record<Format, (value: string) => boolean> = {
   [Format.DateTime]: value => validator.isISO8601(value, {
     strict: true,
     strictSeparator: true,
@@ -107,7 +107,7 @@ const formatValidators: Record<Format, (value: string) => boolean> = {
     }
   },
   [Format.UUID]: value => validator.isUUID(value),
-  // TODO: Implement these (current matcher is probably not correct)
+  // TODO: Implement these properly once we get there (current matcher is probably not correct)
   // JSON Schema 2020-12 specifies these formats should be supported
   [Format.JSONPointer]: value => validator.matches(value, /^(?:\/(?:[^~/]|~0|~1)*)*$/),
   [Format.JSONPointerURIFragment]: value => validator.matches(value, /^#(?:\/(?:[\w\-.!$&'()*+,;:=@]|%[0-9a-f]{2}|~0|~1)*)*$/i),
@@ -138,8 +138,8 @@ export function validateFormat(value: string, format: string, path: string[] = [
     return errors
   }
 
-  const validator = formatValidators[format as Format]
-  if (validator && !validator(value)) {
+  const validateFn = formatValidationFunctions[format as Format]
+  if (validateFn && !validateFn(value)) {
     errors.push({
       path,
       validation: 'format' as SchemaValidationErrorType,

--- a/next/src/validation/format.ts
+++ b/next/src/validation/format.ts
@@ -1,7 +1,6 @@
 import type { ValidationError } from '../form'
 import type { SchemaValidationErrorType } from './schema'
 import { Format } from 'json-schema-typed/draft-2020-12'
-import validator from 'validator'
 
 /**
  * Format validation error type
@@ -16,69 +15,122 @@ import validator from 'validator'
 export type FormatValidationErrorType = 'format'
 
 /**
+ * Regular expression patterns for format validation
+ * These patterns are based on JSON Schema 2020-12 specifications
+ */
+const PATTERNS = {
+  // Date/Time patterns (RFC 3339)
+  DATE_TIME: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
+  DATE: /^\d{4}-\d{2}-\d{2}$/,
+  TIME: /^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/,
+
+  // Duration (ISO 8601)
+  DURATION: /^P(?!$)(?:\d+Y)?(?:\d+M)?(?:\d+D)?(?:T(?=\d)(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$/,
+
+  // Email patterns
+  EMAIL: /^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i,
+  IDN_EMAIL: /^[^\s@]+@[^\s@][^\s.@]*\.[^\s@]+$/,
+
+  // Host patterns
+  HOSTNAME: /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i,
+  IDN_HOSTNAME: /^[^\s._-].*[^\s._-]$/,
+
+  // IP address patterns
+  IPV6_PART: /^[0-9a-f]{1,4}$/i,
+
+  // URI/IRI patterns
+  PROTOCOL: /^[a-z]+:/,
+  URI_REFERENCE: /^\S*$/,
+
+  // UUID pattern (RFC 4122)
+  UUID: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+
+  // JSON Pointer patterns
+  JSON_POINTER: /^(?:\/(?:[^~/]|~0|~1)*)*$/,
+  JSON_POINTER_URI_FRAGMENT: /^#(?:\/(?:[\w\-.!$&'()*+,;:=@]|%[0-9a-f]{2}|~0|~1)*)*$/i,
+  RELATIVE_JSON_POINTER: /^(?:0|[1-9]\d*)(?:#|(?:\/(?:[^~/]|~0|~1)*)*)$/,
+
+  // URI Template (RFC 6570)
+  URI_TEMPLATE: /^(?:[!#$&'()*+,/:;=?@\w\-.~]|%[0-9a-f]{2}|\{[+#./;?&=,!@|]?(?:\w|%[0-9a-f]{2})+(?::[1-9]\d{0,3}|\*)?(?:,(?:\w|%[0-9a-f]{2})+(?::[1-9]\d{0,3}|\*)?)*\})*$/i,
+} as const
+
+/**
  * Built-in format validators according to JSON Schema 2020-12
- *
- * Note on IRI vs URI:
- * - IRI allows Unicode characters in both the domain and path
- * - Since validator.js doesn't directly support IRI validation,
- *   we use isURL with relaxed character constraints
  */
 const formatValidationFunctions: Record<Format, (value: string) => boolean> = {
-  [Format.DateTime]: value => validator.isISO8601(value, {
-    strict: true,
-    strictSeparator: true,
-  }),
-  [Format.Date]: value => validator.isISO8601(value, {
-    strict: true,
-    strictSeparator: true,
-  }),
-  // RFC 3339 time format: 23:20:50.52Z, 17:39:57-08:00
-  [Format.Time]: value => validator.matches(value, /^([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|[+-]([01]\d|2[0-3]):[0-5]\d)$/),
-  // ISO 8601 duration
-  [Format.Duration]: value => validator.matches(value, /^P(?!$)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$/),
-  [Format.Email]: value => validator.isEmail(value, {
-    allow_utf8_local_part: false,
-    require_tld: true,
-    allow_ip_domain: false,
-  }),
-  [Format.IDNEmail]: value => validator.isEmail(value, {
-    allow_utf8_local_part: true,
-    require_tld: true,
-    allow_ip_domain: false,
-  }),
-  [Format.Hostname]: value => validator.isFQDN(value, {
-    require_tld: false,
-    allow_underscores: false,
-    allow_wildcard: false,
-  }),
-  [Format.IDNHostname]: value => validator.isFQDN(value, {
-    require_tld: false,
-    allow_underscores: true,
-    allow_wildcard: false,
-  }),
-  [Format.IPv4]: value => validator.isIP(value, 4),
-  [Format.IPv6]: value => validator.isIP(value, 6),
-  [Format.URI]: value => validator.isURL(value, {
-    require_protocol: true,
-    require_valid_protocol: true,
-    protocols: ['http', 'https', 'ftp', 'sftp', 'mailto', 'file', 'data', 'irc'],
-    allow_fragments: true,
-    allow_query_components: true,
-    validate_length: true,
-  }),
-  [Format.URIReference]: value => validator.isURL(value, {
-    require_protocol: false,
-    allow_protocol_relative_urls: true,
-    protocols: ['http', 'https', 'ftp', 'sftp', 'mailto', 'file', 'data', 'irc'],
-    allow_fragments: true,
-    allow_query_components: true,
-    validate_length: true,
-  }),
-  // For IRI validation, we use isURL but allow Unicode characters
+  [Format.DateTime]: value => PATTERNS.DATE_TIME.test(value),
+  [Format.Date]: value => PATTERNS.DATE.test(value),
+  [Format.Time]: value => PATTERNS.TIME.test(value),
+  [Format.Duration]: value => PATTERNS.DURATION.test(value),
+  [Format.Email]: (value) => {
+    // Basic email validation with length limit (RFC 5321)
+    return value.length <= 254 && PATTERNS.EMAIL.test(value)
+  },
+  [Format.IDNEmail]: (value) => {
+    // More permissive email validation for IDN with length limit
+    return value.length <= 254 && PATTERNS.IDN_EMAIL.test(value)
+  },
+  [Format.Hostname]: (value) => {
+    if (value.length > 255)
+      return false
+    const labels = value.split('.')
+    return labels.every(label => PATTERNS.HOSTNAME.test(label))
+  },
+  [Format.IDNHostname]: (value) => {
+    if (value.length > 255)
+      return false
+    const labels = value.split('.')
+    return labels.every(label => label.length <= 63 && PATTERNS.IDN_HOSTNAME.test(label))
+  },
+  [Format.IPv4]: (value) => {
+    const parts = value.split('.')
+    if (parts.length !== 4)
+      return false
+    return parts.every((part) => {
+      const num = Number.parseInt(part, 10)
+      return num >= 0 && num <= 255 && part === num.toString()
+    })
+  },
+  [Format.IPv6]: (value) => {
+    const parts = value.split(':')
+    if (parts.length > 8)
+      return false
+    let hasDoubleColon = false
+    return parts.every((part) => {
+      if (part === '') {
+        if (hasDoubleColon)
+          return false
+        hasDoubleColon = true
+        return true
+      }
+      return PATTERNS.IPV6_PART.test(part)
+    })
+  },
+  [Format.URI]: (value) => {
+    try {
+      const url = new URL(value)
+      return url.protocol !== '' && PATTERNS.PROTOCOL.test(url.protocol)
+    }
+    catch {
+      return false
+    }
+  },
+  [Format.URIReference]: (value) => {
+    try {
+      if (value.startsWith('//')) {
+        return PATTERNS.URI_REFERENCE.test(value.slice(2))
+      }
+      void new URL(value, 'http://example.com')
+      return true
+    }
+    catch {
+      return false
+    }
+  },
   [Format.IRI]: (value) => {
     try {
       const url = new URL(value)
-      return url.protocol !== '' && /^[a-z]+:/.test(url.protocol)
+      return url.protocol !== '' && PATTERNS.PROTOCOL.test(url.protocol)
     }
     catch {
       return false
@@ -87,7 +139,7 @@ const formatValidationFunctions: Record<Format, (value: string) => boolean> = {
   [Format.IRIReference]: (value) => {
     try {
       if (value.startsWith('//')) {
-        return validator.matches(value.slice(2), /^\S*$/)
+        return PATTERNS.URI_REFERENCE.test(value.slice(2))
       }
       void new URL(value, 'http://example.com')
       return true
@@ -98,7 +150,6 @@ const formatValidationFunctions: Record<Format, (value: string) => boolean> = {
   },
   [Format.RegEx]: (value) => {
     try {
-      // Use 'u' flag for Unicode support as per JSON Schema 2020-12
       void new RegExp(value, 'u')
       return true
     }
@@ -106,14 +157,11 @@ const formatValidationFunctions: Record<Format, (value: string) => boolean> = {
       return false
     }
   },
-  [Format.UUID]: value => validator.isUUID(value),
-  // TODO: Implement these properly once we get there (current matcher is probably not correct)
-  // JSON Schema 2020-12 specifies these formats should be supported
-  [Format.JSONPointer]: value => validator.matches(value, /^(?:\/(?:[^~/]|~0|~1)*)*$/),
-  [Format.JSONPointerURIFragment]: value => validator.matches(value, /^#(?:\/(?:[\w\-.!$&'()*+,;:=@]|%[0-9a-f]{2}|~0|~1)*)*$/i),
-  [Format.RelativeJSONPointer]: value => validator.matches(value, /^(?:0|[1-9]\d*)(?:#|(?:\/(?:[^~/]|~0|~1)*)*)$/),
-  // URI Template (RFC 6570)
-  [Format.URITemplate]: value => validator.matches(value, /^(?:[!#$&'()*+,/:;=?@\w\-.~]|%[0-9a-f]{2}|\{[+#./;?&=,!@|]?(?:\w|%[0-9a-f]{2})+(?::[1-9]\d{0,3}|\*)?(?:,(?:\w|%[0-9a-f]{2})+(?::[1-9]\d{0,3}|\*)?)*\})*$/i),
+  [Format.UUID]: value => PATTERNS.UUID.test(value),
+  [Format.JSONPointer]: value => PATTERNS.JSON_POINTER.test(value),
+  [Format.JSONPointerURIFragment]: value => PATTERNS.JSON_POINTER_URI_FRAGMENT.test(value),
+  [Format.RelativeJSONPointer]: value => PATTERNS.RELATIVE_JSON_POINTER.test(value),
+  [Format.URITemplate]: value => PATTERNS.URI_TEMPLATE.test(value),
 }
 
 /**

--- a/next/src/validation/object.ts
+++ b/next/src/validation/object.ts
@@ -9,23 +9,24 @@ export type ObjectValidationErrorType = StringValidationErrorType
  * Validate an object against a schema
  * @param value - The value to validate
  * @param schema - The schema to validate against
+ * @param path - The path to the current field being validated
  * @returns An array of validation errors
  * @description
  * Validates each property of object against the schema while keeping track of the path to the property.
  * Each property is validated with `validateSchema`.
  */
-export function validateObject(value: SchemaValue, schema: NonBooleanJsfSchema): ValidationError[] {
+export function validateObject(
+  value: SchemaValue,
+  schema: NonBooleanJsfSchema,
+  path: string[] = [],
+): ValidationError[] {
   if (typeof schema === 'object' && schema.properties && typeof value === 'object') {
     const errors = []
     for (const [key, propertySchema] of Object.entries(schema.properties)) {
       const propertyValue = value[key]
       const propertyIsRequired = schema.required?.includes(key)
-      const propertyErrors = validateSchema(propertyValue, propertySchema, propertyIsRequired)
-      const errorsWithPath = propertyErrors.map(error => ({
-        ...error,
-        path: [`.${key}`, ...error.path],
-      }))
-      errors.push(...errorsWithPath)
+      const propertyErrors = validateSchema(propertyValue, propertySchema, propertyIsRequired, [...path, key])
+      errors.push(...propertyErrors)
     }
     return errors
   }

--- a/next/src/validation/object.ts
+++ b/next/src/validation/object.ts
@@ -1,9 +1,6 @@
 import type { ValidationError } from '../form'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
-import type { StringValidationErrorType } from './string'
 import { validateSchema } from './schema'
-
-export type ObjectValidationErrorType = StringValidationErrorType
 
 /**
  * Validate an object against a schema

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -1,6 +1,5 @@
 import type { ValidationError } from '../form'
 import type { JsfSchema, JsfSchemaType, SchemaValue } from '../types'
-import type { ObjectValidationErrorType } from './object'
 import type { StringValidationErrorType } from './string'
 import { validateAnyOf } from './anyOf'
 import { validateObject } from './object'

--- a/next/test/validation/boolean_schema.test.ts
+++ b/next/test/validation/boolean_schema.test.ts
@@ -6,11 +6,13 @@ describe('boolean schema validation', () => {
   it('returns an error if the value is false', () => {
     const schema: JsfObjectSchema = {
       type: 'object',
-      properties: { name: false },
+      properties: {
+        name: false,
+      },
     }
     const form = createHeadlessForm(schema)
 
-    expect(form.handleValidation({ name: 'anything' })).toMatchObject({ formErrors: { '.name': 'always fails' } })
+    expect(form.handleValidation({ name: 'anything' })).toMatchObject({ formErrors: { name: 'always fails' } })
     expect(form.handleValidation({})).not.toHaveProperty('formErrors')
   })
 

--- a/next/test/validation/format.test.ts
+++ b/next/test/validation/format.test.ts
@@ -33,6 +33,102 @@ describe('format validation', () => {
     })
   })
 
+  describe('time format', () => {
+    const schema: NonBooleanJsfSchema = {
+      type: 'string',
+      format: 'time',
+    }
+
+    it('should pass for valid time formats', () => {
+      expect(validateString('12:00:00Z', schema)).toHaveLength(0)
+      expect(validateString('12:00:00+01:00', schema)).toHaveLength(0)
+      expect(validateString('12:00:00.123Z', schema)).toHaveLength(0)
+      expect(validateString('15:45:30-05:00', schema)).toHaveLength(0)
+      expect(validateString('23:59:59Z', schema)).toHaveLength(0)
+    })
+
+    it('should fail for invalid time formats', () => {
+      const invalidTimes = [
+        '24:00:00Z', // Hour too high
+        '12:60:00Z', // Minute too high
+        '12:00:61Z', // Second too high
+        '12:00:00', // Missing timezone
+        '1:2:3Z', // Missing padding
+        '12:00Z', // Missing seconds
+        'not-a-time',
+      ]
+
+      invalidTimes.forEach((time) => {
+        const errors = validateString(time, schema)
+        expect(errors).toHaveLength(1)
+        expect(errors[0]).toMatchObject({
+          validation: 'format',
+          message: 'must be a valid time format',
+        })
+      })
+    })
+
+    it('should pass for non-string values', () => {
+      expect(validateString(123, schema)).toHaveLength(0)
+      expect(validateString(undefined, schema)).toHaveLength(0)
+    })
+  })
+
+  describe('duration format', () => {
+    const schema: NonBooleanJsfSchema = {
+      type: 'string',
+      format: 'duration',
+    }
+
+    it('should pass for valid ISO 8601 durations', () => {
+      const validDurations = [
+        'P1Y', // 1 year
+        'P1M', // 1 month
+        'P1D', // 1 day
+        'PT1H', // 1 hour
+        'PT1M', // 1 minute
+        'PT1S', // 1 second
+        'P1Y2M3DT4H5M6S', // Combined duration
+        'P1Y2M3D', // Date only
+        'PT4H5M6S', // Time only
+        'P0D', // Zero duration
+      ]
+
+      validDurations.forEach((duration) => {
+        expect(validateString(duration, schema)).toHaveLength(0)
+      })
+    })
+
+    it('should fail for invalid duration formats', () => {
+      const invalidDurations = [
+        'P', // Empty duration
+        'PT', // Empty time duration
+        'P1H', // Wrong position for hours
+        'PT1Y', // Wrong position for years
+        'P1.5Y', // No decimals allowed here
+        'P1M2Y', // Wrong order
+        'P1S', // Seconds must be in time part
+        'T1H', // Missing P prefix
+        'P1YT', // Empty time part
+        'not-a-duration',
+      ]
+
+      invalidDurations.forEach((duration) => {
+        const errors = validateString(duration, schema)
+        expect(errors).toHaveLength(1)
+        expect(errors[0]).toMatchObject({
+          validation: 'format',
+          message: 'must be a valid duration format',
+        })
+      })
+    })
+
+    it('should pass for non-string values', () => {
+      expect(validateString(123, schema)).toHaveLength(0)
+      expect(validateString(undefined, schema)).toHaveLength(0)
+    })
+  })
+
   describe('email format', () => {
     const schema: NonBooleanJsfSchema = {
       type: 'string',

--- a/next/test/validation/object.test.ts
+++ b/next/test/validation/object.test.ts
@@ -20,7 +20,7 @@ describe('object schema validation', () => {
     expect(form.handleValidation({})).not.toHaveProperty('formErrors')
     expect(form.handleValidation({ address: {} })).not.toHaveProperty('formErrors')
     expect(form.handleValidation({ address: 'not an object' })).toMatchObject({
-      formErrors: { '.address': 'should be object' },
+      formErrors: { address: 'should be object' },
     })
   })
 

--- a/next/test/validation/string.test.ts
+++ b/next/test/validation/string.test.ts
@@ -12,7 +12,7 @@ describe('string validation', () => {
 
     expect(result).toMatchObject({
       formErrors: {
-        '.name': 'should be string',
+        name: 'should be string',
       },
     })
   })
@@ -27,7 +27,7 @@ describe('string validation', () => {
 
     expect(result.handleValidation({ name: 'ab' })).toMatchObject({
       formErrors: {
-        '.name': 'must be at least 3 characters',
+        name: 'must be at least 3 characters',
       },
     })
 
@@ -69,7 +69,7 @@ describe('string validation', () => {
     expect(form.handleValidation({ name: '' })).not.toHaveProperty('formErrors')
     expect(form.handleValidation({ name: 'a' })).toMatchObject({
       formErrors: {
-        '.name': 'must be at most 0 characters',
+        name: 'must be at most 0 characters',
       },
     })
   })
@@ -84,7 +84,7 @@ describe('string validation', () => {
 
     expect(result.handleValidation({ name: 'ab' })).toMatchObject({
       formErrors: {
-        '.name': 'must be at least 3 characters',
+        name: 'must be at least 3 characters',
       },
     })
 
@@ -92,7 +92,7 @@ describe('string validation', () => {
 
     expect(result.handleValidation({ name: '01234567890' })).toMatchObject({
       formErrors: {
-        '.name': 'must be at most 10 characters',
+        name: 'must be at most 10 characters',
       },
     })
   })
@@ -108,7 +108,7 @@ describe('string validation', () => {
     expect(result.handleValidation({ name: 'abc' })).not.toHaveProperty('formErrors')
 
     expect(result.handleValidation({ name: '123' })).toMatchObject({
-      formErrors: { '.name': 'must match the pattern \'^[a-z]+$\'' },
+      formErrors: { name: 'must match the pattern \'^[a-z]+$\'' },
     })
   })
 })


### PR DESCRIPTION
This PR applies a couple suggestions from [this previous PR](https://github.com/remoteoss/json-schema-form/pull/128), thanks @thien-remote.

Changes are:
- adds a new package `validator` to make the validations better in `format.ts`
- uses the `Format` enum from the `json-schema-typed` package instead of our custom solution (again in `format.ts)
- adjusts the way we handle the `path` key across the package - now matching the way we do it in the original package
- some minor changes, adding comments and tests