### PR TITLE
feat: Nested group-array and group-array conditional schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.11.10-beta.0",
+  "version": "0.11.11-dev.20250220174843",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.11.10-beta.0",
+      "version": "0.11.11-dev.20250220174843",
       "license": "MIT",
       "dependencies": {
         "json-logic-js": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.11.10-beta.0",
+  "version": "0.11.11-dev.20250220174843",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/src/createHeadlessForm.js
+++ b/src/createHeadlessForm.js
@@ -128,10 +128,7 @@ function buildFieldParameters(name, fieldProperties, required = [], config = {},
           parentID: name,
         },
         logic
-      ).reduce((acc, obj) => {
-        acc[obj.name] = obj;
-        return acc;
-      }, {});
+      );
   }
 
   const result = {
@@ -315,12 +312,14 @@ function getFieldsFromJSONSchema(scopedJsonSchema, config, logic) {
   fieldParamsList.forEach((fieldParams) => {
     if (fieldParams.inputType === 'group-array') {
       const groupArrayItems = convertJSONSchemaPropertiesToFieldParameters(fieldParams.items);
-      const groupArrayFields = groupArrayItems.reduce((acc, groupArrayItem) => {
-        return {
-          ...acc,
-          [groupArrayItem.name]: buildField(groupArrayItem, config, scopedJsonSchema, logic),
-        };
-      }, {});
+      const groupArrayFields = groupArrayItems.map((groupArrayItem) => {
+        groupArrayItem.nameKey = groupArrayItem.name;
+        const customProperties = null; // getCustomPropertiesForField(fieldParams, config); // TODO later support in group-array
+        const composeFn = getComposeFunctionForField(groupArrayItem, !!customProperties);
+        return composeFn(groupArrayItem);
+      });
+
+      fieldParams.nameKey = fieldParams.name;
 
       fieldParams.nthFieldGroup = {
         name: fieldParams.name,

--- a/src/createHeadlessForm.js
+++ b/src/createHeadlessForm.js
@@ -313,13 +313,10 @@ function getFieldsFromJSONSchema(scopedJsonSchema, config, logic) {
     if (fieldParams.inputType === 'group-array') {
       const groupArrayItems = convertJSONSchemaPropertiesToFieldParameters(fieldParams.items);
       const groupArrayFields = groupArrayItems.map((groupArrayItem) => {
-        groupArrayItem.nameKey = groupArrayItem.name;
         const customProperties = null; // getCustomPropertiesForField(fieldParams, config); // TODO later support in group-array
         const composeFn = getComposeFunctionForField(groupArrayItem, !!customProperties);
         return composeFn(groupArrayItem);
       });
-
-      fieldParams.nameKey = fieldParams.name;
 
       fieldParams.nthFieldGroup = {
         name: fieldParams.name,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -103,9 +103,6 @@ export function compareFormValueWithSchemaValue(formValue, schemaValue) {
   //  fallback to undefined since JSON-schemas empty values come represented as null
   const currentPropertyValue =
     typeof schemaValue === 'number' ? schemaValue : schemaValue || undefined;
-  if (Array.isArray(formValue)) {
-    return formValue.some((x) => String(x) === String(currentPropertyValue));
-  }
 
   // We're using the stringified version of both values since numeric values from forms come represented as Strings.
   // By doing this, we're sure that we're comparing the same type.
@@ -198,7 +195,7 @@ export function getPrefillValues(fields, initialValues = {}) {
     switch (field.type) {
       case supportedTypes.GROUP_ARRAY: {
         initialValues[fieldName] = initialValues[fieldName]?.map((subFieldValues) =>
-          field.fields().map((subField) => getPrefillValues(subField, subFieldValues))
+          getPrefillValues(field.fields(), subFieldValues)
         );
         break;
       }
@@ -444,7 +441,7 @@ export function processNode({
             });
             newFields.push(fields);
           });
-          field.fields = () => newFields;
+          field.dynamicFields = newFields;
         }
       }
     });

--- a/src/internals/checkIfConditionMatches.js
+++ b/src/internals/checkIfConditionMatches.js
@@ -14,7 +14,10 @@ export function checkIfConditionMatchesProperties(node, formValues, formFields, 
 
   return Object.keys(node.if.properties ?? {}).every((name) => {
     const currentProperty = node.if.properties[name];
-    const value = formValues[name];
+    // const value = formValues[name];
+    const value = Array.isArray(formValues)
+      ? formValues.filter((item) => item?.[name] !== undefined).map((x) => x?.[name])
+      : formValues[name];
     const hasEmptyValue =
       typeof value === 'undefined' ||
       // NOTE: This is a "Remote API" dependency, as empty fields are sent as "null".
@@ -30,7 +33,6 @@ export function checkIfConditionMatchesProperties(node, formValues, formFields, 
       // https://json-schema.org/understanding-json-schema/reference/conditionals.html#if-then-else
       return true;
     }
-
     if (hasProperty(currentProperty, 'const')) {
       return compareFormValueWithSchemaValue(value, currentProperty.const);
     }

--- a/src/internals/checkIfConditionMatches.js
+++ b/src/internals/checkIfConditionMatches.js
@@ -14,10 +14,7 @@ export function checkIfConditionMatchesProperties(node, formValues, formFields, 
 
   return Object.keys(node.if.properties ?? {}).every((name) => {
     const currentProperty = node.if.properties[name];
-    // const value = formValues[name];
-    const value = Array.isArray(formValues)
-      ? formValues.filter((item) => item?.[name] !== undefined).map((x) => x?.[name])
-      : formValues[name];
+    const value = formValues[name];
     const hasEmptyValue =
       typeof value === 'undefined' ||
       // NOTE: This is a "Remote API" dependency, as empty fields are sent as "null".

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -422,6 +422,233 @@ describe('Conditional attributes updated', () => {
     handleValidation({ is_full_time: 'no' });
     expect(fields[1].visibilityCondition).toEqual(expect.any(Function));
   });
+
+  it('Group array nested condition', () => {
+    const { fields, handleValidation } = createHeadlessForm({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        companies: {
+          type: 'array',
+          'x-jsf-presentation': {
+            inputType: 'group-array',
+          },
+          items: {
+            type: 'object',
+            properties: {
+              company: {
+                type: 'string',
+                oneOf: [
+                  {
+                    title: 'A',
+                    const: 'A',
+                  },
+                  {
+                    title: 'B',
+                    const: 'B',
+                  },
+                ],
+                'x-jsf-presentation': {
+                  inputType: 'select',
+                },
+              },
+              role: {
+                title: 'Role',
+                oneOf: [],
+                'x-jsf-presentation': {
+                  inputType: 'select',
+                },
+              },
+            },
+            allOf: [
+              {
+                if: {
+                  properties: {
+                    company: {
+                      const: 'A',
+                    },
+                  },
+                  required: ['company'],
+                },
+                then: {
+                  properties: {
+                    role: {
+                      oneOf: [
+                        {
+                          title: 'adminA',
+                          const: 'adminA',
+                        },
+                        {
+                          title: 'userA',
+                          const: 'userA',
+                        },
+                      ],
+                      'x-jsf-presentation': {
+                        inputType: 'select',
+                      },
+                    },
+                  },
+                  required: ['role'],
+                },
+              },
+              {
+                if: {
+                  properties: {
+                    company: {
+                      const: 'B',
+                    },
+                  },
+                  required: ['company'],
+                },
+                then: {
+                  properties: {
+                    role: {
+                      oneOf: [
+                        {
+                          title: 'adminB',
+                          const: 'adminB',
+                        },
+                        {
+                          title: 'userB',
+                          const: 'userB',
+                        },
+                      ],
+                      'x-jsf-presentation': {
+                        inputType: 'select',
+                      },
+                    },
+                  },
+                  required: ['role'],
+                },
+              },
+            ],
+            required: ['company', 'role'],
+          },
+        },
+      },
+      required: ['companies'],
+    });
+
+    handleValidation({ companies: [{ company: 'A' }, { company: 'B' }] });
+    expect(fields[0].dynamicFields[0][1].options).toEqual([
+      { label: 'adminA', value: 'adminA' },
+      { label: 'userA', value: 'userA' },
+    ]);
+    expect(fields[0].dynamicFields[1][1].options).toEqual([
+      { label: 'adminB', value: 'adminB' },
+      { label: 'userB', value: 'userB' },
+    ]);
+    handleValidation({ companies: [] });
+    expect(fields[0].dynamicFields).toEqual([]);
+  });
+
+  it('select multiple conditions', () => {
+    const { fields, handleValidation } = createHeadlessForm({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        company: {
+          title: 'Select Company',
+          type: 'string',
+          description: 'Choose a company',
+          oneOf: [
+            {
+              title: 'A',
+              const: 'A',
+            },
+            {
+              title: 'B',
+              const: 'B',
+            },
+          ],
+          'x-jsf-presentation': {
+            inputType: 'select',
+          },
+        },
+        role: {
+          title: 'Role',
+          oneOf: [],
+          'x-jsf-presentation': {
+            inputType: 'select',
+          },
+        },
+      },
+      allOf: [
+        {
+          if: {
+            properties: {
+              company: {
+                const: 'A',
+              },
+            },
+            required: ['company'],
+          },
+          then: {
+            properties: {
+              role: {
+                oneOf: [
+                  {
+                    title: 'adminA',
+                    const: 'adminA',
+                  },
+                  {
+                    title: 'userA',
+                    const: 'userA',
+                  },
+                ],
+                'x-jsf-presentation': {
+                  inputType: 'select',
+                },
+              },
+            },
+            required: ['role'],
+          },
+        },
+        {
+          if: {
+            properties: {
+              company: {
+                const: 'B',
+              },
+            },
+            required: ['company'],
+          },
+          then: {
+            properties: {
+              role: {
+                oneOf: [
+                  {
+                    title: 'adminB',
+                    const: 'adminB',
+                  },
+                  {
+                    title: 'userB',
+                    const: 'userB',
+                  },
+                ],
+                'x-jsf-presentation': {
+                  inputType: 'select',
+                },
+              },
+            },
+            required: ['role'],
+          },
+        },
+      ],
+      required: ['company', 'role'],
+    });
+
+    handleValidation({ company: 'A' });
+    expect(fields[1].options).toEqual([
+      { label: 'adminA', value: 'adminA' },
+      { label: 'userA', value: 'userA' },
+    ]);
+    handleValidation({ company: 'B' });
+    expect(fields[1].options).toEqual([
+      { label: 'adminB', value: 'adminB' },
+      { label: 'userB', value: 'userB' },
+    ]);
+  });
 });
 
 describe('Conditional with a minimum value check', () => {
@@ -707,199 +934,5 @@ describe('Conditionals - bugs and code-smells', () => {
     // expect(validation1.formErrors).toEqual({
     //   field_c: 'Must be greater or equal to 5',
     // });
-  });
-
-  it('Group array nested condition', () => {
-    const { fields, handleValidation } = createHeadlessForm({
-      type: 'object',
-      additionalProperties: false,
-      properties: {
-        companies: {
-          title: 'Comapnies',
-          type: 'array',
-          default: [],
-          'x-jsf-presentation': {
-            inputType: 'group-array',
-          },
-          items: {
-            type: 'object',
-            properties: {
-              company: {
-                title: 'Select Company',
-                type: 'string',
-                description: 'Choose a company',
-                oneOf: [
-                  {
-                    title: 'A',
-                    const: 'A',
-                  },
-                  {
-                    title: 'B',
-                    const: 'B',
-                  },
-                ],
-                'x-jsf-presentation': {
-                  inputType: 'select',
-                },
-              },
-              role: {
-                title: 'Role',
-                oneOf: [],
-                'x-jsf-presentation': {
-                  inputType: 'select',
-                },
-              },
-            },
-            allOf: [
-              {
-                if: {
-                  properties: {
-                    company: {
-                      const: 'A',
-                    },
-                  },
-                  required: ['company'],
-                },
-                then: {
-                  properties: {
-                    role: {
-                      oneOf: [
-                        {
-                          title: 'admin',
-                          const: 'admin',
-                        },
-                        {
-                          title: 'user',
-                          const: 'user',
-                        },
-                      ],
-                      'x-jsf-presentation': {
-                        inputType: 'select',
-                      },
-                    },
-                  },
-                  required: ['role'],
-                },
-              },
-              {
-                if: {
-                  properties: {
-                    company: {
-                      const: 'B',
-                    },
-                  },
-                  required: ['company'],
-                },
-                then: {
-                  properties: {
-                    role: {
-                      oneOf: [
-                        {
-                          title: 'adminB',
-                          const: 'adminB',
-                        },
-                        {
-                          title: 'userB',
-                          const: 'userB',
-                        },
-                      ],
-                      'x-jsf-presentation': {
-                        inputType: 'select',
-                      },
-                    },
-                  },
-                  required: ['role'],
-                },
-              },
-            ],
-            required: ['company', 'role'],
-          },
-        },
-      },
-      required: ['companies'],
-    });
-
-    handleValidation({ companies: [{ company: 'A' }, { company: 'B' }] });
-    expect(fields[0].fields()[0].role.options).toEqual([
-      { label: 'admin', value: 'admin' },
-      { label: 'user', value: 'user' },
-    ]);
-    expect(fields[0].fields()[1].role.options).toEqual([
-      { label: 'adminB', value: 'adminB' },
-      { label: 'userB', value: 'userB' },
-    ]);
-  });
-
-  it('select multiple conditions', () => {
-    const { fields, handleValidation } = createHeadlessForm({
-      type: 'object',
-      additionalProperties: false,
-      properties: {
-        company: {
-          title: 'Select Company',
-          type: 'string',
-          description: 'Choose a company',
-          oneOf: [
-            {
-              title: 'A',
-              const: 'A',
-            },
-            {
-              title: 'B',
-              const: 'B',
-            },
-          ],
-          'x-jsf-presentation': {
-            inputType: 'select',
-          },
-        },
-        role: {
-          title: 'Role',
-          oneOf: [],
-          'x-jsf-presentation': {
-            inputType: 'select',
-          },
-        },
-      },
-      allOf: [
-        {
-          if: {
-            properties: {
-              company: {
-                const: 'A',
-              },
-            },
-            required: ['company'],
-          },
-          then: {
-            properties: {
-              role: {
-                oneOf: [
-                  {
-                    title: 'admin',
-                    const: 'admin',
-                  },
-                  {
-                    title: 'user',
-                    const: 'user',
-                  },
-                ],
-                'x-jsf-presentation': {
-                  inputType: 'select',
-                },
-              },
-            },
-            required: ['role'],
-          },
-        },
-      ],
-      required: ['company', 'role'],
-    });
-
-    handleValidation({ company: 'A' });
-    expect(fields[1].options).toEqual([
-      { label: 'admin', value: 'admin' },
-      { label: 'user', value: 'user' },
-    ]);
   });
 });

--- a/src/tests/conditions.test.js
+++ b/src/tests/conditions.test.js
@@ -708,4 +708,198 @@ describe('Conditionals - bugs and code-smells', () => {
     //   field_c: 'Must be greater or equal to 5',
     // });
   });
+
+  it('Group array nested condition', () => {
+    const { fields, handleValidation } = createHeadlessForm({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        companies: {
+          title: 'Comapnies',
+          type: 'array',
+          default: [],
+          'x-jsf-presentation': {
+            inputType: 'group-array',
+          },
+          items: {
+            type: 'object',
+            properties: {
+              company: {
+                title: 'Select Company',
+                type: 'string',
+                description: 'Choose a company',
+                oneOf: [
+                  {
+                    title: 'A',
+                    const: 'A',
+                  },
+                  {
+                    title: 'B',
+                    const: 'B',
+                  },
+                ],
+                'x-jsf-presentation': {
+                  inputType: 'select',
+                },
+              },
+              role: {
+                title: 'Role',
+                oneOf: [],
+                'x-jsf-presentation': {
+                  inputType: 'select',
+                },
+              },
+            },
+            allOf: [
+              {
+                if: {
+                  properties: {
+                    company: {
+                      const: 'A',
+                    },
+                  },
+                  required: ['company'],
+                },
+                then: {
+                  properties: {
+                    role: {
+                      oneOf: [
+                        {
+                          title: 'admin',
+                          const: 'admin',
+                        },
+                        {
+                          title: 'user',
+                          const: 'user',
+                        },
+                      ],
+                      'x-jsf-presentation': {
+                        inputType: 'select',
+                      },
+                    },
+                  },
+                  required: ['role'],
+                },
+              },
+              {
+                if: {
+                  properties: {
+                    company: {
+                      const: 'B',
+                    },
+                  },
+                  required: ['company'],
+                },
+                then: {
+                  properties: {
+                    role: {
+                      oneOf: [
+                        {
+                          title: 'adminB',
+                          const: 'adminB',
+                        },
+                        {
+                          title: 'userB',
+                          const: 'userB',
+                        },
+                      ],
+                      'x-jsf-presentation': {
+                        inputType: 'select',
+                      },
+                    },
+                  },
+                  required: ['role'],
+                },
+              },
+            ],
+            required: ['company', 'role'],
+          },
+        },
+      },
+      required: ['companies'],
+    });
+
+    handleValidation({ companies: [{ company: 'A' }, { company: 'B' }] });
+    expect(fields[0].fields()[0].role.options).toEqual([
+      { label: 'admin', value: 'admin' },
+      { label: 'user', value: 'user' },
+    ]);
+    expect(fields[0].fields()[1].role.options).toEqual([
+      { label: 'adminB', value: 'adminB' },
+      { label: 'userB', value: 'userB' },
+    ]);
+  });
+
+  it('select multiple conditions', () => {
+    const { fields, handleValidation } = createHeadlessForm({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        company: {
+          title: 'Select Company',
+          type: 'string',
+          description: 'Choose a company',
+          oneOf: [
+            {
+              title: 'A',
+              const: 'A',
+            },
+            {
+              title: 'B',
+              const: 'B',
+            },
+          ],
+          'x-jsf-presentation': {
+            inputType: 'select',
+          },
+        },
+        role: {
+          title: 'Role',
+          oneOf: [],
+          'x-jsf-presentation': {
+            inputType: 'select',
+          },
+        },
+      },
+      allOf: [
+        {
+          if: {
+            properties: {
+              company: {
+                const: 'A',
+              },
+            },
+            required: ['company'],
+          },
+          then: {
+            properties: {
+              role: {
+                oneOf: [
+                  {
+                    title: 'admin',
+                    const: 'admin',
+                  },
+                  {
+                    title: 'user',
+                    const: 'user',
+                  },
+                ],
+                'x-jsf-presentation': {
+                  inputType: 'select',
+                },
+              },
+            },
+            required: ['role'],
+          },
+        },
+      ],
+      required: ['company', 'role'],
+    });
+
+    handleValidation({ company: 'A' });
+    expect(fields[1].options).toEqual([
+      { label: 'admin', value: 'admin' },
+      { label: 'user', value: 'user' },
+    ]);
+  });
 });

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -1606,11 +1606,13 @@ describe('createHeadlessForm', () => {
             maxLength: 255,
             label: 'Child Full Name',
             name: 'full_name',
+            nameKey: 'full_name',
             required: true,
           },
           {
             type: 'date',
             name: 'birthdate',
+            nameKey: 'birthday',
             label: 'Child Birthdate',
             required: true,
             description: 'Enter your child’s date of birth',
@@ -1619,6 +1621,7 @@ describe('createHeadlessForm', () => {
           {
             type: 'radio',
             name: 'sex',
+            nameKey: 'sex',
             label: 'Child Sex',
             options: [
               {

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -63,6 +63,7 @@ import {
   schemaForErrorMessageSpecificity,
   jsfConfigForErrorMessageSpecificity,
   schemaInputTypeFile,
+  nestedGroupArrayForm,
 } from './helpers';
 import { mockConsole, restoreConsoleAndEnsureItWasNotCalled } from './testUtils';
 import { createHeadlessForm } from '@/createHeadlessForm';
@@ -1606,13 +1607,11 @@ describe('createHeadlessForm', () => {
             maxLength: 255,
             label: 'Child Full Name',
             name: 'full_name',
-            nameKey: 'full_name',
             required: true,
           },
           {
             type: 'date',
             name: 'birthdate',
-            nameKey: 'birthday',
             label: 'Child Birthdate',
             required: true,
             description: 'Enter your child’s date of birth',
@@ -1621,7 +1620,6 @@ describe('createHeadlessForm', () => {
           {
             type: 'radio',
             name: 'sex',
-            nameKey: 'sex',
             label: 'Child Sex',
             options: [
               {
@@ -1735,6 +1733,63 @@ describe('createHeadlessForm', () => {
             },
           ],
         });
+      });
+
+      it('nested "group-array" fields', () => {
+        const result = createHeadlessForm({
+          properties: {
+            nestedGroupArray: nestedGroupArrayForm,
+          },
+        });
+
+        expect(result.fields[0]).toMatchObject({
+          label: 'Parent object',
+          name: 'nestedGroupArray',
+          required: false,
+          type: 'group-array',
+          inputType: 'group-array',
+          jsonType: 'array',
+          fields: expect.any(Function),
+        });
+
+        expect(result.fields[0].fields()).toMatchObject([
+          {
+            type: 'text',
+            description: 'Simple text field',
+            maxLength: 255,
+            label: 'Outer Field',
+            name: 'notNested',
+            required: true,
+          },
+          {
+            label: 'Nested group-array',
+            name: 'nested',
+            required: true,
+            type: 'group-array',
+            inputType: 'group-array',
+            jsonType: 'array',
+            fields: expect.any(Function),
+          },
+        ]);
+
+        expect(result.fields[0].fields()[1].fields()).toMatchObject([
+          {
+            type: 'text',
+            description: 'First nested text field',
+            maxLength: 255,
+            label: 'Inner Field 1',
+            name: 'nestedField1',
+            required: true,
+          },
+          {
+            type: 'text',
+            description: 'Second nested text field',
+            maxLength: 255,
+            label: 'Inner Field 2',
+            name: 'nestedField2',
+            required: true,
+          },
+        ]);
       });
 
       it('can pass custom field attributes', () => {

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -1604,7 +1604,6 @@ describe('createHeadlessForm', () => {
             type: 'text',
             description: 'Enter your child’s full name',
             maxLength: 255,
-            nameKey: 'full_name',
             label: 'Child Full Name',
             name: 'full_name',
             required: true,
@@ -1616,7 +1615,6 @@ describe('createHeadlessForm', () => {
             required: true,
             description: 'Enter your child’s date of birth',
             maxLength: 255,
-            nameKey: 'birthdate',
           },
           {
             type: 'radio',
@@ -1635,7 +1633,6 @@ describe('createHeadlessForm', () => {
             required: true,
             description:
               'We know sex is non-binary but for insurance and payroll purposes, we need to collect this information.',
-            nameKey: 'sex',
           },
         ]);
       });

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -2327,3 +2327,59 @@ export const schemaWithCustomValidationsAndConditionals = {
     },
   ],
 };
+
+export const nestedGroupArrayForm = {
+  items: {
+    properties: {
+      notNested: {
+        description: 'Simple text field',
+        'x-jsf-presentation': {
+          inputType: 'text',
+        },
+        title: 'Outer Field',
+        type: 'string',
+        maxLength: 255,
+      },
+      nested: {
+        items: {
+          properties: {
+            nestedField1: {
+              description: 'First nested text field',
+              'x-jsf-presentation': {
+                inputType: 'text',
+              },
+              title: 'Inner Field 1',
+              type: 'string',
+              maxLength: 255,
+            },
+            nestedField2: {
+              description: 'Second nested text field',
+              'x-jsf-presentation': {
+                inputType: 'text',
+              },
+              title: 'Inner Field 2',
+              type: 'string',
+              maxLength: 255,
+            },
+          },
+          'x-jsf-order': ['nestedField1', 'nestedField2'],
+          required: ['nestedField1', 'nestedField2'],
+          type: 'object',
+        },
+        'x-jsf-presentation': {
+          inputType: 'group-array',
+        },
+        title: 'Nested group-array',
+        type: 'array',
+      },
+    },
+    'x-jsf-order': ['notNested', 'nested'],
+    required: ['notNested', 'nested'],
+    type: 'object',
+  },
+  'x-jsf-presentation': {
+    inputType: 'group-array',
+  },
+  title: 'Parent object',
+  type: 'array',
+};

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -485,13 +485,10 @@ export function buildYupSchema(field, config, logic) {
 
   function buildGroupArraySchema() {
     return object().shape(
-      propertyFields.nthFieldGroup.fields().reduce(
-        (schema, groupArrayField) => ({
-          ...schema,
-          [groupArrayField.name]: buildYupSchema(groupArrayField, config)(),
-        }),
-        {}
-      )
+      Object.keys(propertyFields.nthFieldGroup.fields()).reduce((acc, key) => {
+        acc[key] = buildYupSchema(propertyFields.nthFieldGroup.fields()[key], config);
+        return acc;
+      }, {})
     );
   }
 

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -485,10 +485,13 @@ export function buildYupSchema(field, config, logic) {
 
   function buildGroupArraySchema() {
     return object().shape(
-      Object.keys(propertyFields.nthFieldGroup.fields()).reduce((acc, key) => {
-        acc[key] = buildYupSchema(propertyFields.nthFieldGroup.fields()[key], config);
-        return acc;
-      }, {})
+      propertyFields.nthFieldGroup.fields().reduce(
+        (schema, groupArrayField) => ({
+          ...schema,
+          [groupArrayField.name]: buildYupSchema(groupArrayField, config)(),
+        }),
+        {}
+      )
     );
   }
 


### PR DESCRIPTION
- Added support for nested group arrays
- Now the group array allows to have different schemas for its objects. For example if you have conditional properties. See [issue](https://github.com/remoteoss/json-schema-form/issues/122). Added a new field "dynamicFields" that containes the schema of the items. The idea is to use items() if the schema will be the same for every item in the group array. So it is retro-compatible. But if you need the schema to change you can use dynamicFields[i] to get the schema of the item with index "i" (see the test that I added). So we will have one entry in dynamicFields for every item in the group array inserted by the user. At the begininng it will be empty and the user should use items() to get the schema of a new item. Then, when it changes the item, it should look in the dynamicFields to get the calculated schema.
- removed nameKey because it wasn't used and it was causing problems in the nested group array