### PR TITLE
fix(select): Support integer values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.11.11-beta.0",
+  "version": "0.11.12-dev.20250313084704",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/json-schema-form",
-      "version": "0.11.11-beta.0",
+      "version": "0.11.12-dev.20250313084704",
       "license": "MIT",
       "dependencies": {
         "json-logic-js": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/json-schema-form",
-  "version": "0.11.11-beta.0",
+  "version": "0.11.12-dev.20250313084704",
   "description": "Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -63,6 +63,7 @@ import {
   schemaForErrorMessageSpecificity,
   jsfConfigForErrorMessageSpecificity,
   schemaInputTypeFile,
+  schemaWithSelectInteger,
 } from './helpers';
 import { mockConsole, restoreConsoleAndEnsureItWasNotCalled } from './testUtils';
 import { createHeadlessForm } from '@/createHeadlessForm';
@@ -656,6 +657,27 @@ describe('createHeadlessForm', () => {
             },
           ],
         });
+      });
+
+      it('supports "select" field with integer values', async () => {
+        const { handleValidation } = createHeadlessForm(schemaWithSelectInteger);
+        const validateForm = (vals) => friendlyError(handleValidation(vals));
+
+        // Check for invalid option
+        expect(
+          validateForm({
+            account_type: 4,
+          })
+        ).toEqual({
+          account_type: 'The option 4 is not valid.',
+        });
+
+        // Check for valid option
+        expect(
+          validateForm({
+            account_type: 1,
+          })
+        ).toBeUndefined();
       });
     });
     describe('support "radio" field type', () => {

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -2327,3 +2327,24 @@ export const schemaWithCustomValidationsAndConditionals = {
     },
   ],
 };
+
+export const schemaWithSelectInteger = {
+  additionalProperties: false,
+  type: 'object',
+  properties: {
+    account_type: {
+      title: 'Select an account type',
+      description: '',
+      'x-jsf-presentation': {
+        inputType: 'select',
+      },
+      oneOf: [
+        { title: 'Normal User', const: 0 },
+        { title: 'Business', const: 1 },
+        { title: 'Services Provider', const: 2 },
+      ],
+      type: 'integer',
+    },
+  },
+  required: [],
+};

--- a/src/yupSchema.js
+++ b/src/yupSchema.js
@@ -273,6 +273,8 @@ const getYupSchema = ({ inputType, ...field }) => {
     switch (type) {
       case 'number':
         return yupSchemas.radioOrSelectNumber(optionValues);
+      case 'integer':
+        return yupSchemas.radioOrSelectNumber(optionValues);
       case 'boolean':
         return yupSchemas.radioOrSelectBoolean(optionValues);
       default:
@@ -513,7 +515,8 @@ export function buildYupSchema(field, config, logic) {
     validators.push(withFile);
   }
 
-  if (jsonType === 'integer') {
+  const hasOptions = field.options?.length > 0;
+  if (jsonType === 'integer' && !hasOptions) {
     validators.push(withInteger);
   }
 


### PR DESCRIPTION
This PR is an attempt to fix the issue described in #115 to be able to use integer values in select elements.

It simply handles an integers like a number is handled already in a select and prevents the withInteger schema from being added.