### PR TITLE
chore(next): DEVXP-2682: centralize error messages

### DIFF
--- a/next/src/errors/index.ts
+++ b/next/src/errors/index.ts
@@ -22,6 +22,8 @@ export type SchemaValidationErrorType =
    */
   | 'multipleOf' | 'maximum' | 'exclusiveMaximum' | 'minimum' | 'exclusiveMinimum'
 
+export type ValidationErrorPath = Array<string | number>
+
 /**
  * Validation error for schema
  */
@@ -38,7 +40,7 @@ export interface ValidationError {
    * ['address', 'street'] // nested field error
    * ['value', 'allOf', 0] // schema composition error
    */
-  path: (string | number)[]
+  path: ValidationErrorPath
   /**
    * The type of validation error
    * @example

--- a/next/src/errors/index.ts
+++ b/next/src/errors/index.ts
@@ -1,0 +1,46 @@
+/**
+ * The type of validation error
+ * @description
+ * This type is used to determine the type of validation error that occurred.
+ */
+export type SchemaValidationErrorType =
+  /**
+   * Core validation keywords
+   */
+  | 'type' | 'required' | 'valid' | 'const' | 'enum'
+  /**
+   * Schema composition keywords (allOf, anyOf, oneOf, not)
+   * These keywords apply subschemas in a logical manner according to JSON Schema spec
+   */
+  | 'anyOf' | 'oneOf' | 'not'
+  /**
+   * String validation keywords
+   */
+  | 'format' | 'minLength' | 'maxLength' | 'pattern'
+  /**
+   * Number validation keywords
+   */
+  | 'multipleOf' | 'maximum' | 'exclusiveMaximum' | 'minimum' | 'exclusiveMinimum'
+
+/**
+ * Validation error for schema
+ */
+export interface ValidationError {
+  /**
+   * The path to the field that has the error
+   * - For field-level errors: array of field names (e.g., ['address', 'street'])
+   * - For schema-level errors: empty array []
+   * - For nested validations: full path to the field (e.g., ['address', 'street', 'number'])
+   * @example
+   * [] // schema-level error
+   * ['username'] // field-level error
+   * ['address', 'street'] // nested field error
+   */
+  path: string[]
+  /**
+   * The type of validation error
+   * @example
+   * 'required'
+   */
+  validation: SchemaValidationErrorType
+}

--- a/next/src/errors/index.ts
+++ b/next/src/errors/index.ts
@@ -31,12 +31,14 @@ export interface ValidationError {
    * - For field-level errors: array of field names (e.g., ['address', 'street'])
    * - For schema-level errors: empty array []
    * - For nested validations: full path to the field (e.g., ['address', 'street', 'number'])
+   * - For schema composition: includes array indices (e.g., ['value', 'allOf', 0])
    * @example
    * [] // schema-level error
    * ['username'] // field-level error
    * ['address', 'street'] // nested field error
+   * ['value', 'allOf', 0] // schema composition error
    */
-  path: string[]
+  path: (string | number)[]
   /**
    * The type of validation error
    * @example

--- a/next/src/errors/messages.ts
+++ b/next/src/errors/messages.ts
@@ -18,12 +18,12 @@ export function getErrorMessage(
     case 'const':
       return `The only accepted value is ${JSON.stringify(schema.const)}`
     case 'enum':
-      return `The option "${JSON.stringify(value)}" is not valid.`
+      return `The option "${valueToString(value)}" is not valid.`
     // Schema composition
     case 'anyOf':
-      return `The option "${JSON.stringify(value)}" is not valid.`
+      return `The option "${valueToString(value)}" is not valid.`
     case 'oneOf':
-      return `The option "${JSON.stringify(value)}" is not valid.`
+      return `The option "${valueToString(value)}" is not valid.`
     case 'not':
       return 'The value must not satisfy the provided schema'
     // String validation
@@ -84,4 +84,11 @@ function getTypeErrorMessage(schemaType: JsfSchemaType | JsfSchemaType[] | undef
     default:
       return schemaType ? `The value must be ${schemaType}` : 'Invalid value'
   }
+}
+
+function valueToString(value: SchemaValue): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  return JSON.stringify(value)
 }

--- a/next/src/errors/messages.ts
+++ b/next/src/errors/messages.ts
@@ -1,0 +1,87 @@
+import type { SchemaValidationErrorType } from '.'
+import type { JsfSchemaType, NonBooleanJsfSchema, SchemaValue } from '../types'
+import { randexp } from 'randexp'
+
+export function getErrorMessage(
+  schema: NonBooleanJsfSchema,
+  value: SchemaValue,
+  validation: SchemaValidationErrorType,
+): string {
+  switch (validation) {
+    // Core validation
+    case 'type':
+      return getTypeErrorMessage(schema.type)
+    case 'required':
+      return 'Required field'
+    case 'valid':
+      return 'Always fails'
+    case 'const':
+      return `The only accepted value is ${JSON.stringify(schema.const)}`
+    case 'enum':
+      return `The option "${JSON.stringify(value)}" is not valid.`
+    // Schema composition
+    case 'anyOf':
+      return `The option "${JSON.stringify(value)}" is not valid.`
+    case 'oneOf':
+      return `The option "${JSON.stringify(value)}" is not valid.`
+    case 'not':
+      return 'The value must not satisfy the provided schema'
+    // String validation
+    case 'minLength':
+      return `Please insert at least ${schema.minLength} characters`
+    case 'maxLength':
+      return `Please insert up to ${schema.maxLength} characters`
+    case 'pattern':
+      return `Must have a valid format. E.g. ${randexp(schema.pattern || '')}`
+    case 'format':
+      if (schema.format === 'email') {
+        return 'Please enter a valid email address'
+      }
+      return `Must be a valid ${schema.format} format`
+    // Number validation
+    case 'multipleOf':
+      return `Must be a multiple of ${schema.multipleOf}`
+    case 'maximum':
+      return `Must be smaller or equal to ${schema.maximum}`
+    case 'exclusiveMaximum':
+      return `Must be smaller than ${schema.exclusiveMaximum}`
+    case 'minimum':
+      return `Must be greater or equal to ${schema.minimum}`
+    case 'exclusiveMinimum':
+      return `Must be greater than ${schema.exclusiveMinimum}`
+  }
+}
+
+/**
+ * Get the appropriate type error message based on the schema type
+ */
+function getTypeErrorMessage(schemaType: JsfSchemaType | JsfSchemaType[] | undefined): string {
+  if (Array.isArray(schemaType)) {
+    // Map 'integer' to 'number' in error messages
+    const formattedTypes = schemaType.map((type) => {
+      if (type === 'integer')
+        return 'number'
+      return type
+    })
+
+    return `The value must be a ${formattedTypes.join(' or ')}`
+  }
+
+  switch (schemaType) {
+    case 'number':
+    case 'integer':
+      return 'The value must be a number'
+    case 'boolean':
+      return 'The value must be a boolean'
+    case 'null':
+      return 'The value must be null'
+    case 'string':
+      return 'The value must be a string'
+    case 'object':
+      return 'The value must be an object'
+    case 'array':
+      return 'The value must be an array'
+    default:
+      return schemaType ? `The value must be ${schemaType}` : 'Invalid value'
+  }
+}

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -129,15 +129,27 @@ function getSchemaAndValueAtPath(rootSchema: JsfSchema, rootValue: SchemaValue, 
           currentValue = currentValue[Number(segment)]
         }
       }
+      // Skip the 'allOf', 'anyOf', and 'oneOf' segments, the next segment will be the index
       else if (segment === 'allOf' && currentSchema.allOf) {
-        // Skip the 'allOf' segment, the next segment will be the index
         continue
       }
-      else if (currentSchema.allOf && !Number.isNaN(Number(segment))) {
-        // If we have a numeric segment and we're in an allOf context, get the subschema
+      else if (segment === 'anyOf' && currentSchema.anyOf) {
+        continue
+      }
+      else if (segment === 'oneOf' && currentSchema.oneOf) {
+        continue
+      }
+      // If we have we are in a composition context, get the subschema
+      else if (currentSchema.allOf || currentSchema.anyOf || currentSchema.oneOf) {
         const index = Number(segment)
-        if (index >= 0 && index < currentSchema.allOf.length) {
+        if (currentSchema.allOf && index >= 0 && index < currentSchema.allOf.length) {
           currentSchema = currentSchema.allOf[index]
+        }
+        else if (currentSchema.anyOf && index >= 0 && index < currentSchema.anyOf.length) {
+          currentSchema = currentSchema.anyOf[index]
+        }
+        else if (currentSchema.oneOf && index >= 0 && index < currentSchema.oneOf.length) {
+          currentSchema = currentSchema.oneOf[index]
         }
       }
     }

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -247,7 +247,7 @@ function validate(value: SchemaValue, schema: JsfSchema, options: ValidationOpti
   const errorsWithMessages = addErrorMessages(value, schema, errors)
   const processedErrors = applyCustomErrorMessages(errorsWithMessages, schema)
 
-  const formErrors = validationErrorsToFormErrors(processedErrors, schema, value)
+  const formErrors = validationErrorsToFormErrors(processedErrors)
 
   if (formErrors) {
     result.formErrors = formErrors

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -56,11 +56,16 @@ function validationErrorsToFormErrors(errors: ValidationErrorWithMessage[]): For
       return result
     }
 
-    // For allOf validation errors, show the error at the field level
-    const allOfIndex = path.indexOf('allOf')
-    if (allOfIndex !== -1) {
-      // Get the field path (everything before 'allOf')
-      const fieldPath = path.slice(0, allOfIndex)
+    // For allOf/anyOf/oneOf validation errors, show the error at the field level
+    const compositionKeywords = ['allOf', 'anyOf', 'oneOf']
+    const compositionIndex = compositionKeywords.reduce((index, keyword) => {
+      const keywordIndex = path.indexOf(keyword)
+      return keywordIndex !== -1 ? keywordIndex : index
+    }, -1)
+
+    if (compositionIndex !== -1) {
+      // Get the field path (everything before the composition keyword)
+      const fieldPath = path.slice(0, compositionIndex)
       let current = result
 
       // Process all segments except the last one (which will hold the message)

--- a/next/src/validation/composition.ts
+++ b/next/src/validation/composition.ts
@@ -34,8 +34,9 @@ export function validateAllOf(
     return []
   }
 
-  for (const subSchema of schema.allOf) {
-    const errors = validateSchema(value, subSchema, false, path)
+  for (let i = 0; i < schema.allOf.length; i++) {
+    const subSchema = schema.allOf[i]
+    const errors = validateSchema(value, subSchema, false, [...path, 'allOf', i])
     if (errors.length > 0) {
       return errors
     }

--- a/next/src/validation/composition.ts
+++ b/next/src/validation/composition.ts
@@ -5,7 +5,7 @@
  * @see {@link https://json-schema.org/understanding-json-schema/reference/combining.html Schema Composition}
  */
 
-import type { ValidationError } from '../form'
+import type { ValidationError } from '../errors'
 import type { JsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 
@@ -80,7 +80,6 @@ export function validateAnyOf(
     {
       path,
       validation: 'anyOf',
-      message: `The option "${value}" is not valid.`,
     },
   ]
 }
@@ -127,7 +126,6 @@ export function validateOneOf(
       {
         path,
         validation: 'oneOf',
-        message: `The option "${value}" is not valid.`,
       },
     ]
   }
@@ -137,7 +135,6 @@ export function validateOneOf(
       {
         path,
         validation: 'oneOf',
-        message: `The option "${value}" is not valid.`,
       },
     ]
   }
@@ -173,12 +170,12 @@ export function validateNot(
 
   if (typeof schema.not === 'boolean') {
     return schema.not
-      ? [{ path, validation: 'not', message: 'The value must not satisfy the provided schema' }]
+      ? [{ path, validation: 'not' }]
       : []
   }
 
   const notErrors = validateSchema(value, schema.not, false, path)
   return notErrors.length === 0
-    ? [{ path, validation: 'not', message: 'The value must not satisfy the provided schema' }]
+    ? [{ path, validation: 'not' }]
     : []
 }

--- a/next/src/validation/composition.ts
+++ b/next/src/validation/composition.ts
@@ -5,7 +5,7 @@
  * @see {@link https://json-schema.org/understanding-json-schema/reference/combining.html Schema Composition}
  */
 
-import type { ValidationError } from '../errors'
+import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { JsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 
@@ -28,7 +28,7 @@ import { validateSchema } from './schema'
 export function validateAllOf(
   value: SchemaValue,
   schema: JsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (!schema.allOf || !Array.isArray(schema.allOf)) {
     return []
@@ -64,7 +64,7 @@ export function validateAllOf(
 export function validateAnyOf(
   value: SchemaValue,
   schema: JsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (!schema.anyOf || !Array.isArray(schema.anyOf)) {
     return []
@@ -104,7 +104,7 @@ export function validateAnyOf(
 export function validateOneOf(
   value: SchemaValue,
   schema: JsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (!schema.oneOf || !Array.isArray(schema.oneOf)) {
     return []
@@ -163,7 +163,7 @@ export function validateOneOf(
 export function validateNot(
   value: SchemaValue,
   schema: JsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (schema.not === undefined) {
     return []

--- a/next/src/validation/conditions.ts
+++ b/next/src/validation/conditions.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../form'
+import type { ValidationError } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 

--- a/next/src/validation/conditions.ts
+++ b/next/src/validation/conditions.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../errors'
+import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 
@@ -6,7 +6,7 @@ export function validateCondition(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
   required: boolean,
-  path: string[],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (schema.if === undefined) {
     return []

--- a/next/src/validation/const.ts
+++ b/next/src/validation/const.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../form'
+import type { ValidationError } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { deepEqual } from './util'
 
@@ -25,7 +25,7 @@ export function validateConst(
 
   if (!deepEqual(schema.const, value)) {
     return [
-      { path, validation: 'const', message: `The only accepted value is ${JSON.stringify(schema.const)}` },
+      { path, validation: 'const' },
     ]
   }
 

--- a/next/src/validation/const.ts
+++ b/next/src/validation/const.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../errors'
+import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { deepEqual } from './util'
 
@@ -17,7 +17,7 @@ import { deepEqual } from './util'
 export function validateConst(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (schema.const === undefined) {
     return []

--- a/next/src/validation/enum.ts
+++ b/next/src/validation/enum.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../errors'
+import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { deepEqual } from './util'
 
@@ -20,7 +20,7 @@ import { deepEqual } from './util'
 export function validateEnum(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (schema.enum === undefined) {
     return []

--- a/next/src/validation/enum.ts
+++ b/next/src/validation/enum.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../form'
+import type { ValidationError } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { deepEqual } from './util'
 
@@ -28,7 +28,7 @@ export function validateEnum(
 
   if (!schema.enum.some(enumValue => deepEqual(enumValue, value))) {
     return [
-      { path, validation: 'enum', message: `The option ${JSON.stringify(value)} is not valid.` },
+      { path, validation: 'enum' },
     ]
   }
 

--- a/next/src/validation/format.ts
+++ b/next/src/validation/format.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../errors'
+import type { ValidationError, ValidationErrorPath } from '../errors'
 import { Format } from 'json-schema-typed/draft-2020-12'
 
 /**
@@ -182,7 +182,7 @@ const formatValidationFunctions: Record<Format, (value: string) => boolean> = {
 export function validateFormat(
   value: string,
   format: string,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   const errors: ValidationError[] = []
 

--- a/next/src/validation/format.ts
+++ b/next/src/validation/format.ts
@@ -1,5 +1,4 @@
-import type { ValidationError } from '../form'
-import type { SchemaValidationErrorType } from './schema'
+import type { ValidationError } from '../errors'
 import { Format } from 'json-schema-typed/draft-2020-12'
 
 /**
@@ -194,14 +193,7 @@ export function validateFormat(
 
   const validateFn = formatValidationFunctions[format as Format]
   if (validateFn && !validateFn(value)) {
-    errors.push({
-      path,
-      validation: 'format' as SchemaValidationErrorType,
-      message:
-        format === 'email'
-          ? 'Please enter a valid email address'
-          : `Must be a valid ${format} format`,
-    })
+    errors.push({ path, validation: 'format' })
   }
 
   return errors

--- a/next/src/validation/number.ts
+++ b/next/src/validation/number.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../errors'
+import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { getSchemaType } from './schema'
 
@@ -19,7 +19,7 @@ import { getSchemaType } from './schema'
 export function validateNumber(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   const errors: ValidationError[] = []
   const schemaType = getSchemaType(schema)

--- a/next/src/validation/number.ts
+++ b/next/src/validation/number.ts
@@ -1,13 +1,6 @@
-import type { ValidationError } from '../form'
+import type { ValidationError } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { getSchemaType } from './schema'
-
-export type NumberValidationErrorType =
-  | 'multipleOf'
-  | 'maximum'
-  | 'exclusiveMaximum'
-  | 'minimum'
-  | 'exclusiveMinimum'
 
 /**
  * Validate a number against a schema
@@ -41,47 +34,27 @@ export function validateNumber(
 
   // MultipleOf validation - dividing value by multipleOf must have no remainder
   if (schema.multipleOf !== undefined && value % schema.multipleOf !== 0) {
-    errors.push({
-      path,
-      validation: 'multipleOf',
-      message: `Must be a multiple of ${schema.multipleOf}`,
-    })
+    errors.push({ path, validation: 'multipleOf' })
   }
 
   // Maximum validation - value must be less than or equal to maximum
   if (schema.maximum !== undefined && value > schema.maximum) {
-    errors.push({
-      path,
-      validation: 'maximum',
-      message: `Must be smaller or equal to ${schema.maximum}`,
-    })
+    errors.push({ path, validation: 'maximum' })
   }
 
   // ExclusiveMaximum validation - value must be less than exclusiveMaximum
   if (schema.exclusiveMaximum !== undefined && value >= schema.exclusiveMaximum) {
-    errors.push({
-      path,
-      validation: 'exclusiveMaximum',
-      message: `Must be smaller than ${schema.exclusiveMaximum}`,
-    })
+    errors.push({ path, validation: 'exclusiveMaximum' })
   }
 
   // Minimum validation - value must be greater than or equal to minimum
   if (schema.minimum !== undefined && value < schema.minimum) {
-    errors.push({
-      path,
-      validation: 'minimum',
-      message: `Must be greater or equal to ${schema.minimum}`,
-    })
+    errors.push({ path, validation: 'minimum' })
   }
 
   // ExclusiveMinimum validation - value must be greater than exclusiveMinimum
   if (schema.exclusiveMinimum !== undefined && value <= schema.exclusiveMinimum) {
-    errors.push({
-      path,
-      validation: 'exclusiveMinimum',
-      message: `Must be greater than ${schema.exclusiveMinimum}`,
-    })
+    errors.push({ path, validation: 'exclusiveMinimum' })
   }
 
   return errors

--- a/next/src/validation/object.ts
+++ b/next/src/validation/object.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../errors'
+import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 import { isObjectValue } from './util'
@@ -16,7 +16,7 @@ import { isObjectValue } from './util'
 export function validateObject(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (typeof schema === 'object' && schema.properties && isObjectValue(value)) {
     const errors = []

--- a/next/src/validation/object.ts
+++ b/next/src/validation/object.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../form'
+import type { ValidationError } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 import { isObjectValue } from './util'

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../errors'
+import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { JsfSchema, JsfSchemaType, SchemaValue } from '../types'
 import { validateAllOf, validateAnyOf, validateNot, validateOneOf } from './composition'
 import { validateCondition } from './conditions'
@@ -45,7 +45,7 @@ export function getSchemaType(schema: JsfSchema): JsfSchemaType | JsfSchemaType[
 function validateType(
   value: SchemaValue,
   schema: JsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   const schemaType = getSchemaType(schema)
 
@@ -126,7 +126,7 @@ export function validateSchema(
   value: SchemaValue,
   schema: JsfSchema,
   required: boolean = false,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   // Handle undefined values and boolean schemas first
   if (value === undefined && required) {

--- a/next/src/validation/string.ts
+++ b/next/src/validation/string.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../errors'
+import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateFormat } from './format'
 import { getSchemaType } from './schema'
@@ -18,7 +18,7 @@ import { getSchemaType } from './schema'
 export function validateString(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  path: string[] = [],
+  path: ValidationErrorPath = [],
 ): ValidationError[] {
   const errors: ValidationError[] = []
   const schemaType = getSchemaType(schema)

--- a/next/src/validation/string.ts
+++ b/next/src/validation/string.ts
@@ -1,23 +1,7 @@
-import type { ValidationError } from '../form'
+import type { ValidationError } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
-import { randexp } from 'randexp'
 import { validateFormat } from './format'
 import { getSchemaType } from './schema'
-
-export type StringValidationErrorType =
-  /**
-   * String length validation
-   */
-  | 'minLength'
-  | 'maxLength'
-  /**
-   * String pattern validation
-   */
-  | 'pattern'
-  /**
-   * String format validation
-   */
-  | 'format'
 
 /**
  * Validate a string against a schema
@@ -51,32 +35,18 @@ export function validateString(
 
   // Length validation
   if (schema.minLength !== undefined && valueLength < schema.minLength) {
-    errors.push({
-      path,
-      validation: 'minLength',
-      message: `Please insert at least ${schema.minLength} characters`,
-    })
+    errors.push({ path, validation: 'minLength' })
   }
 
   if (schema.maxLength !== undefined && valueLength > schema.maxLength) {
-    errors.push({
-      path,
-      validation: 'maxLength',
-      message: `Please insert up to ${schema.maxLength} characters`,
-    })
+    errors.push({ path, validation: 'maxLength' })
   }
 
   // Pattern validation
   if (schema.pattern !== undefined) {
     const pattern = new RegExp(schema.pattern)
     if (!pattern.test(value)) {
-      // Generate an example that matches the pattern
-      const randomPlaceholder = randexp(schema.pattern)
-      errors.push({
-        path,
-        validation: 'pattern',
-        message: `Must have a valid format. E.g. ${randomPlaceholder}`,
-      })
+      errors.push({ path, validation: 'pattern' })
     }
   }
 

--- a/next/test/errors/messages.test.ts
+++ b/next/test/errors/messages.test.ts
@@ -72,7 +72,7 @@ describe('validation error messages', () => {
       })
 
       expect(result.formErrors).toMatchObject({
-        status: 'The option "\"invalid\"" is not valid.',
+        status: 'The option "invalid" is not valid.',
         priority: 'The option "4" is not valid.',
       })
     })
@@ -570,7 +570,7 @@ describe('validation error messages', () => {
 
       expect(result1.formErrors).toBe(undefined)
       expect(result2.formErrors).toMatchObject({
-        nested: 'The option "\"ab\"" is not valid.',
+        nested: 'The option "ab" is not valid.',
       })
     })
   })

--- a/next/test/errors/messages.test.ts
+++ b/next/test/errors/messages.test.ts
@@ -1,0 +1,515 @@
+import type { JsfObjectSchema } from '../../src/types'
+import { describe, expect, it } from '@jest/globals'
+import { createHeadlessForm } from '../../src'
+
+describe('validation error messages', () => {
+  describe('core validation errors', () => {
+    it('shows appropriate type error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          string: { type: 'string' },
+          number: { type: 'number' },
+          boolean: { type: 'boolean' },
+          object: { type: 'object' },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        string: 123,
+        number: 'not a number',
+        boolean: 'not a boolean',
+        object: 'not an object',
+      })
+
+      expect(result.formErrors).toMatchObject({
+        string: 'The value must be a string',
+        number: 'The value must be a number',
+        boolean: 'The value must be a boolean',
+        object: 'The value must be an object',
+      })
+    })
+
+    it('shows required field error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+        required: ['name', 'age'],
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({})
+
+      expect(result.formErrors).toMatchObject({
+        name: 'Required field',
+        age: 'Required field',
+      })
+    })
+
+    it('shows enum validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          status: {
+            type: 'string',
+            enum: ['active', 'inactive', 'pending'],
+          },
+          priority: {
+            type: 'number',
+            enum: [1, 2, 3],
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        status: 'invalid',
+        priority: 4,
+      })
+
+      expect(result.formErrors).toMatchObject({
+        status: 'The option "\"invalid\"" is not valid.',
+        priority: 'The option "4" is not valid.',
+      })
+    })
+
+    it('shows const validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          type: {
+            type: 'string',
+            const: 'user',
+          },
+          version: {
+            type: 'number',
+            const: 1,
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        type: 'admin',
+        version: 2,
+      })
+
+      expect(result.formErrors).toMatchObject({
+        type: 'The only accepted value is "user"',
+        version: 'The only accepted value is 1',
+      })
+    })
+  })
+
+  describe('string validation errors', () => {
+    it('shows string length validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          shortString: {
+            type: 'string',
+            minLength: 5,
+          },
+          longString: {
+            type: 'string',
+            maxLength: 3,
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        shortString: 'abc',
+        longString: 'toolong',
+      })
+
+      expect(result.formErrors).toMatchObject({
+        shortString: 'Please insert at least 5 characters',
+        longString: 'Please insert up to 3 characters',
+      })
+    })
+
+    it('shows pattern validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          alphanumeric: {
+            type: 'string',
+            pattern: '^[a-zA-Z0-9]+$',
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        alphanumeric: 'special@characters!',
+      })
+
+      // Pattern error includes a random example, so we just check it starts with the right message
+      expect(result.formErrors?.alphanumeric).toMatch(/^Must have a valid format. E.g./)
+    })
+
+    it('shows format validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          email: {
+            type: 'string',
+            format: 'email',
+          },
+          uri: {
+            type: 'string',
+            format: 'uri',
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        email: 'not-an-email',
+        uri: 'not-a-uri',
+      })
+
+      expect(result.formErrors).toMatchObject({
+        email: 'Please enter a valid email address',
+        uri: 'Must be a valid uri format',
+      })
+    })
+  })
+
+  describe('number validation errors', () => {
+    it('shows minimum and maximum validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          min: {
+            type: 'number',
+            minimum: 5,
+          },
+          max: {
+            type: 'number',
+            maximum: 10,
+          },
+          exclusive: {
+            type: 'number',
+            exclusiveMinimum: 0,
+            exclusiveMaximum: 100,
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        min: 3,
+        max: 15,
+        exclusive: 0,
+      })
+
+      expect(result.formErrors).toMatchObject({
+        min: 'Must be greater or equal to 5',
+        max: 'Must be smaller or equal to 10',
+        exclusive: 'Must be greater than 0',
+      })
+
+      const result2 = form.handleValidation({
+        exclusive: 100,
+      })
+
+      expect(result2.formErrors).toMatchObject({
+        exclusive: 'Must be smaller than 100',
+      })
+    })
+
+    it('shows multipleOf validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          even: {
+            type: 'number',
+            multipleOf: 2,
+          },
+          decimal: {
+            type: 'number',
+            multipleOf: 0.5,
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        even: 3,
+        decimal: 1.75,
+      })
+
+      expect(result.formErrors).toMatchObject({
+        even: 'Must be a multiple of 2',
+        decimal: 'Must be a multiple of 0.5',
+      })
+    })
+  })
+
+  describe('custom error messages', () => {
+    it('allows overriding type error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          age: {
+            'type': 'number',
+            'x-jsf-errorMessage': {
+              type: 'Age must be a number',
+            },
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        age: 'not a number',
+      })
+
+      expect(result.formErrors).toMatchObject({
+        age: 'Age must be a number',
+      })
+    })
+
+    it('allows overriding required field error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          email: {
+            'type': 'string',
+            'x-jsf-errorMessage': {
+              required: 'Please provide your email address',
+            },
+          },
+        },
+        required: ['email'],
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({})
+
+      expect(result.formErrors).toMatchObject({
+        email: 'Please provide your email address',
+      })
+    })
+
+    it('allows overriding validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          password: {
+            'type': 'string',
+            'minLength': 8,
+            'x-jsf-errorMessage': {
+              minLength: 'Password must be at least 8 characters long',
+            },
+          },
+          age: {
+            'type': 'number',
+            'minimum': 18,
+            'x-jsf-errorMessage': {
+              minimum: 'You must be 18 or older',
+            },
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        password: 'short',
+        age: 16,
+      })
+
+      expect(result.formErrors).toMatchObject({
+        password: 'Password must be at least 8 characters long',
+        age: 'You must be 18 or older',
+      })
+    })
+  })
+
+  describe('schema composition errors', () => {
+    it('shows anyOf validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          value: {
+            anyOf: [
+              { type: 'string', maxLength: 5 },
+              { type: 'number', minimum: 0 },
+            ],
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        value: [], // neither a short string nor a positive number
+      })
+
+      expect(result.formErrors).toMatchObject({
+        value: 'The option "[]" is not valid.',
+      })
+    })
+
+    it('shows oneOf validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          value: {
+            oneOf: [
+              { type: 'number', multipleOf: 5 },
+              { type: 'number', multipleOf: 3 },
+            ],
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      // No schema matches - neither multiple of 3 nor 5
+      const result1 = form.handleValidation({
+        value: 7,
+      })
+
+      expect(result1.formErrors).toMatchObject({
+        value: 'The option "7" is not valid.',
+      })
+
+      // Multiple schemas match - multiple of both 3 and 5
+      const result2 = form.handleValidation({
+        value: 15,
+      })
+
+      expect(result2.formErrors).toMatchObject({
+        value: 'The option "15" is not valid.',
+      })
+    })
+
+    it('shows not validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          nonString: {
+            not: { type: 'string' },
+          },
+          nonPositive: {
+            type: 'number',
+            not: { minimum: 0 },
+          },
+          alwaysFails: {
+            not: true,
+          },
+          alwaysPasses: {
+            not: { not: true },
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        nonString: 'this should fail',
+        nonPositive: 5,
+        alwaysFails: 'any value fails',
+        alwaysPasses: 'any value passes',
+      })
+
+      expect(result.formErrors).toMatchObject({
+        nonString: 'The value must not satisfy the provided schema',
+        nonPositive: 'The value must not satisfy the provided schema',
+        alwaysFails: 'The value must not satisfy the provided schema',
+      })
+      expect(result.formErrors).not.toHaveProperty('alwaysPasses')
+    })
+
+    it('shows allOf validation error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          value: {
+            allOf: [
+              { type: 'string' },
+              { minLength: 3 },
+              { maxLength: 5 },
+            ],
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      // Test type validation from first schema
+      const result1 = form.handleValidation({
+        value: 123,
+      })
+
+      expect(result1.formErrors).toMatchObject({
+        value: 'The value must be a string',
+      })
+
+      // Test minLength validation from second schema
+      const result2 = form.handleValidation({
+        value: 'ab',
+      })
+
+      expect(result2.formErrors).toMatchObject({
+        value: 'Please insert at least 3 characters',
+      })
+
+      // Test maxLength validation from third schema
+      const result3 = form.handleValidation({
+        value: 'too long',
+      })
+
+      expect(result3.formErrors).toMatchObject({
+        value: 'Please insert up to 5 characters',
+      })
+
+      // Test valid case that satisfies all conditions
+      const result4 = form.handleValidation({
+        value: 'good',
+      })
+
+      expect(result4.formErrors).toBe(undefined)
+    })
+
+    it('shows nested composition error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          nested: {
+            anyOf: [
+              {
+                allOf: [
+                  { type: 'string' },
+                  { minLength: 3 },
+                ],
+              },
+              { type: 'number' },
+            ],
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      // Should pass because it matches the second anyOf (number)
+      const result1 = form.handleValidation({
+        nested: 123,
+      })
+
+      // Should fail because it matches neither:
+      // 1. First anyOf: fails one allOf condition (too short)
+      // 2. Second anyOf: fails because it is not a number
+      const result2 = form.handleValidation({
+        nested: 'ab',
+      })
+
+      expect(result1.formErrors).toBe(undefined)
+      expect(result2.formErrors).toMatchObject({
+        nested: 'The option "\"ab\"" is not valid.',
+      })
+    })
+  })
+})

--- a/next/test/errors/messages.test.ts
+++ b/next/test/errors/messages.test.ts
@@ -330,6 +330,68 @@ describe('validation error messages', () => {
         age: 'You must be 18 or older',
       })
     })
+
+    it('allows overriding anyOf error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          value: {
+            'anyOf': [
+              { type: 'string', maxLength: 5 },
+              { type: 'number', minimum: 0 },
+            ],
+            'x-jsf-errorMessage': {
+              anyOf: 'Please enter either a short text (max 5 chars) or a positive number',
+            },
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({
+        value: -1, // neither a short string nor a positive number
+      })
+
+      expect(result.formErrors).toMatchObject({
+        value: 'Please enter either a short text (max 5 chars) or a positive number',
+      })
+    })
+
+    it('allows overriding oneOf error messages', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          value: {
+            'oneOf': [
+              { type: 'number', multipleOf: 5 },
+              { type: 'number', multipleOf: 3 },
+            ],
+            'x-jsf-errorMessage': {
+              oneOf: 'Number must be divisible by either 3 or 5, but not both',
+            },
+          },
+        },
+      }
+      const form = createHeadlessForm(schema)
+
+      // Test when no schema matches
+      const result1 = form.handleValidation({
+        value: 7,
+      })
+
+      expect(result1.formErrors).toMatchObject({
+        value: 'Number must be divisible by either 3 or 5, but not both',
+      })
+
+      // Test when multiple schemas match
+      const result2 = form.handleValidation({
+        value: 15,
+      })
+
+      expect(result2.formErrors).toMatchObject({
+        value: 'Number must be divisible by either 3 or 5, but not both',
+      })
+    })
   })
 
   describe('schema composition errors', () => {

--- a/next/test/json-schema-test-suite/failed-json-schema-test-suite.json
+++ b/next/test/json-schema-test-suite/failed-json-schema-test-suite.json
@@ -1,21 +1,37 @@
 {
   "JSON Schema Test Suite": {
     "additionalProperties being false does not allow other properties": [
-      "an additional property is invalid"
+      "no additional properties is valid",
+      "an additional property is invalid",
+      "ignores arrays",
+      "ignores strings",
+      "ignores other non-objects",
+      "patternProperties are not additional properties"
     ],
     "non-ASCII pattern with additionalProperties": [
+      "matching the pattern is valid",
       "not matching the pattern is invalid"
     ],
     "additionalProperties with schema": [
+      "no additional properties is valid",
+      "an additional valid property is valid",
       "an additional invalid property is invalid"
     ],
     "additionalProperties can exist by itself": [
+      "an additional valid property is valid",
       "an additional invalid property is invalid"
+    ],
+    "additionalProperties are allowed by default": [
+      "additional properties are allowed"
     ],
     "additionalProperties does not look in applicators": [
       "properties defined in allOf are not examined"
     ],
+    "additionalProperties with null valued instance properties": [
+      "allows null values"
+    ],
     "additionalProperties with propertyNames": [
+      "Valid against both keywords",
       "Valid against propertyNames, but not additionalProperties"
     ],
     "dependentSchemas with additionalProperties": [
@@ -23,238 +39,874 @@
       "additionalProperties can't see bar",
       "additionalProperties can't see bar even when foo2 is present"
     ],
+    "allOf": [
+      "allOf",
+      "mismatch second",
+      "mismatch first",
+      "wrong type"
+    ],
+    "allOf with base schema": [
+      "valid",
+      "mismatch base schema",
+      "mismatch first allOf",
+      "mismatch second allOf",
+      "mismatch both"
+    ],
+    "allOf simple types": [
+      "valid",
+      "mismatch one"
+    ],
+    "allOf with boolean schemas, all true": [
+      "any value is valid"
+    ],
+    "allOf with boolean schemas, some false": [
+      "any value is invalid"
+    ],
+    "allOf with boolean schemas, all false": [
+      "any value is invalid"
+    ],
+    "allOf with one empty schema": [
+      "any data is valid"
+    ],
+    "allOf with two empty schemas": [
+      "any data is valid"
+    ],
+    "allOf with the first empty schema": [
+      "number is valid",
+      "string is invalid"
+    ],
+    "allOf with the last empty schema": [
+      "number is valid",
+      "string is invalid"
+    ],
+    "nested allOf, to check validation semantics": [
+      "null is valid",
+      "anything non-null is invalid"
+    ],
+    "allOf combined with anyOf, oneOf": [
+      "allOf: false, anyOf: false, oneOf: false",
+      "allOf: false, anyOf: false, oneOf: true",
+      "allOf: false, anyOf: true, oneOf: false",
+      "allOf: false, anyOf: true, oneOf: true",
+      "allOf: true, anyOf: false, oneOf: false",
+      "allOf: true, anyOf: false, oneOf: true",
+      "allOf: true, anyOf: true, oneOf: false",
+      "allOf: true, anyOf: true, oneOf: true"
+    ],
     "Location-independent identifier": [
+      "match",
       "mismatch"
     ],
     "Location-independent identifier with absolute URI": [
+      "match",
       "mismatch"
     ],
     "Location-independent identifier with base URI change in subschema": [
+      "match",
       "mismatch"
     ],
     "same $anchor with different base uri": [
+      "$ref resolves to /$defs/A/allOf/1",
       "$ref does not resolve to /$defs/A/allOf/0"
     ],
-    "contains keyword validation": [
-      "array without items matching schema is invalid",
+    "anyOf": [
+      "first anyOf valid",
+      "second anyOf valid",
+      "both anyOf valid",
+      "neither anyOf valid"
+    ],
+    "anyOf with base schema": [
+      "mismatch base schema",
+      "one anyOf valid",
+      "both anyOf invalid"
+    ],
+    "anyOf with boolean schemas, all true": [
+      "any value is valid"
+    ],
+    "anyOf with boolean schemas, some true": [
+      "any value is valid"
+    ],
+    "anyOf with boolean schemas, all false": [
+      "any value is invalid"
+    ],
+    "anyOf complex types": [
+      "first anyOf valid (complex)",
+      "second anyOf valid (complex)",
+      "both anyOf valid (complex)",
+      "neither anyOf valid (complex)"
+    ],
+    "anyOf with one empty schema": [
+      "string is valid",
+      "number is valid"
+    ],
+    "nested anyOf, to check validation semantics": [
+      "null is valid",
+      "anything non-null is invalid"
+    ],
+    "boolean schema 'true'": [
+      "number is valid",
+      "string is valid",
+      "boolean true is valid",
+      "boolean false is valid",
+      "null is valid",
+      "object is valid",
+      "empty object is valid",
+      "array is valid",
+      "empty array is valid"
+    ],
+    "boolean schema 'false'": [
+      "number is invalid",
+      "string is invalid",
+      "boolean true is invalid",
+      "boolean false is invalid",
+      "null is invalid",
+      "object is invalid",
+      "empty object is invalid",
+      "array is invalid",
       "empty array is invalid"
     ],
+    "const validation": [
+      "same value is valid",
+      "another value is invalid",
+      "another type is invalid"
+    ],
+    "const with object": [
+      "same object is valid",
+      "same object with different property order is valid",
+      "another object is invalid",
+      "another type is invalid"
+    ],
+    "const with array": [
+      "same array is valid",
+      "another array item is invalid",
+      "array with additional items is invalid"
+    ],
+    "const with null": [
+      "null is valid",
+      "not null is invalid"
+    ],
+    "const with false does not match 0": [
+      "false is valid",
+      "integer zero is invalid",
+      "float zero is invalid"
+    ],
+    "const with true does not match 1": [
+      "true is valid",
+      "integer one is invalid",
+      "float one is invalid"
+    ],
+    "const with [false] does not match [0]": [
+      "[false] is valid",
+      "[0] is invalid",
+      "[0.0] is invalid"
+    ],
+    "const with [true] does not match [1]": [
+      "[true] is valid",
+      "[1] is invalid",
+      "[1.0] is invalid"
+    ],
+    "const with {\"a\": false} does not match {\"a\": 0}": [
+      "{\"a\": false} is valid",
+      "{\"a\": 0} is invalid",
+      "{\"a\": 0.0} is invalid"
+    ],
+    "const with {\"a\": true} does not match {\"a\": 1}": [
+      "{\"a\": true} is valid",
+      "{\"a\": 1} is invalid",
+      "{\"a\": 1.0} is invalid"
+    ],
+    "const with 0 does not match other zero-like types": [
+      "false is invalid",
+      "integer zero is valid",
+      "float zero is valid",
+      "empty object is invalid",
+      "empty array is invalid",
+      "empty string is invalid"
+    ],
+    "const with 1 does not match true": [
+      "true is invalid",
+      "integer one is valid",
+      "float one is valid"
+    ],
+    "const with -2.0 matches integer and float types": [
+      "integer -2 is valid",
+      "integer 2 is invalid",
+      "float -2.0 is valid",
+      "float 2.0 is invalid",
+      "float -2.00001 is invalid"
+    ],
+    "float and integers are equal up to 64-bit representation limits": [
+      "integer is valid",
+      "integer minus one is invalid",
+      "float is valid",
+      "float minus one is invalid"
+    ],
+    "nul characters in strings": [
+      "match string with nul",
+      "do not match string lacking nul",
+      "match string with nul",
+      "do not match string lacking nul"
+    ],
+    "contains keyword validation": [
+      "array with item matching schema (5) is valid",
+      "array with item matching schema (6) is valid",
+      "array with two items matching schema (5, 6) is valid",
+      "array without items matching schema is invalid",
+      "empty array is invalid",
+      "not array is valid"
+    ],
     "contains keyword with const keyword": [
+      "array with item 5 is valid",
+      "array with two items 5 is valid",
       "array without item 5 is invalid"
     ],
     "contains keyword with boolean schema true": [
+      "any non-empty array is valid",
       "empty array is invalid"
     ],
     "contains keyword with boolean schema false": [
       "any non-empty array is invalid",
-      "empty array is invalid"
+      "empty array is invalid",
+      "non-arrays are valid"
     ],
     "items + contains": [
       "matches items, does not match contains",
       "does not match items, matches contains",
+      "matches both items and contains",
       "matches neither items nor contains"
     ],
     "contains with false if subschema": [
+      "any non-empty array is valid",
       "empty array is invalid"
     ],
+    "contains with null instance elements": [
+      "allows null items"
+    ],
+    "validation of string-encoded content based on media type": [
+      "a valid JSON document",
+      "an invalid JSON document; validates true",
+      "ignores non-strings"
+    ],
+    "validation of binary string-encoding": [
+      "a valid base64 string",
+      "an invalid base64 string (% is not a valid character); validates true",
+      "ignores non-strings"
+    ],
+    "validation of binary-encoded media type documents": [
+      "a valid base64-encoded JSON document",
+      "a validly-encoded invalid JSON document; validates true",
+      "an invalid base64 string that is valid JSON; validates true",
+      "ignores non-strings"
+    ],
+    "validation of binary-encoded media type documents with schema": [
+      "a valid base64-encoded JSON document",
+      "another valid base64-encoded JSON document",
+      "an invalid base64-encoded JSON document; validates true",
+      "an empty object as a base64-encoded JSON document; validates true",
+      "an empty array as a base64-encoded JSON document",
+      "a validly-encoded invalid JSON document; validates true",
+      "an invalid base64 string that is valid JSON; validates true",
+      "ignores non-strings"
+    ],
+    "invalid type for default": [
+      "valid when property is specified",
+      "still valid when the invalid default is used"
+    ],
+    "invalid string value for default": [
+      "valid when property is specified",
+      "still valid when the invalid default is used"
+    ],
+    "the default keyword does not do anything if the property is missing": [
+      "an explicit property value is checked against maximum (passing)",
+      "an explicit property value is checked against maximum (failing)",
+      "missing properties are not filled in with the default"
+    ],
     "validate definition against metaschema": [
+      "valid definition schema",
       "invalid definition schema"
     ],
     "single dependency": [
+      "neither",
+      "nondependant",
+      "with dependency",
       "missing dependency",
+      "ignores arrays",
+      "ignores strings",
+      "ignores other non-objects",
+      "valid",
+      "no dependency",
       "wrong type",
       "wrong type other",
-      "wrong type both"
+      "wrong type both",
+      "ignores arrays",
+      "ignores strings",
+      "ignores other non-objects"
+    ],
+    "empty dependents": [
+      "empty object",
+      "object with one property",
+      "non-object is valid"
     ],
     "multiple dependents required": [
+      "neither",
+      "nondependants",
+      "with dependencies",
       "missing dependency",
       "missing other dependency",
       "missing both dependencies"
     ],
     "dependencies with escaped characters": [
+      "CRLF",
+      "quoted quotes",
       "CRLF missing dependent",
       "quoted quotes missing dependent",
+      "quoted tab",
       "quoted quote",
       "quoted tab invalid under dependent schema",
       "quoted quote invalid under dependent schema"
     ],
     "boolean subschemas": [
+      "object with property having schema true is valid",
       "object with property having schema false is invalid",
-      "object with both properties is invalid"
+      "object with both properties is invalid",
+      "empty object is valid"
     ],
     "dependent subschema incompatible with root": [
       "matches root",
-      "matches both"
+      "matches dependency",
+      "matches both",
+      "no dependency"
     ],
     "A $dynamicRef to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor": [
-      "An array of strings is valid"
+      "An array of strings is valid",
+      "An array containing non-strings is invalid"
     ],
     "A $dynamicRef to an $anchor in the same schema resource behaves like a normal $ref to an $anchor": [
-      "An array of strings is valid"
+      "An array of strings is valid",
+      "An array containing non-strings is invalid"
     ],
     "A $ref to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor": [
-      "An array of strings is valid"
+      "An array of strings is valid",
+      "An array containing non-strings is invalid"
     ],
     "A $dynamicRef resolves to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated": [
+      "An array of strings is valid",
       "An array containing non-strings is invalid"
     ],
     "A $dynamicRef without anchor in fragment behaves identical to $ref": [
-      "An array of strings is invalid"
+      "An array of strings is invalid",
+      "An array of numbers is valid"
     ],
     "A $dynamicRef with intermediate scopes that don't include a matching $dynamicAnchor does not affect dynamic scope resolution": [
+      "An array of strings is valid",
       "An array containing non-strings is invalid"
     ],
+    "An $anchor with the same name as a $dynamicAnchor is not used for dynamic scope resolution": [
+      "Any array is valid"
+    ],
+    "A $dynamicRef without a matching $dynamicAnchor in the same schema resource behaves like a normal $ref to $anchor": [
+      "Any array is valid"
+    ],
+    "A $dynamicRef with a non-matching $dynamicAnchor in the same schema resource behaves like a normal $ref to $anchor": [
+      "Any array is valid"
+    ],
     "A $dynamicRef that initially resolves to a schema with a matching $dynamicAnchor resolves to the first $dynamicAnchor in the dynamic scope": [
+      "The recursive part is valid against the root",
       "The recursive part is not valid against the root"
     ],
+    "A $dynamicRef that initially resolves to a schema without a matching $dynamicAnchor behaves like a normal $ref to $anchor": [
+      "The recursive part doesn't need to validate against the root"
+    ],
     "multiple dynamic paths to the $dynamicRef keyword": [
+      "number list with number values",
       "number list with string values",
-      "string list with number values"
+      "string list with number values",
+      "string list with string values"
     ],
     "after leaving a dynamic scope, it is not used by a $dynamicRef": [
       "string matches /$defs/thingy, but the $dynamicRef does not stop here",
-      "first_scope is not in dynamic scope for the $dynamicRef"
+      "first_scope is not in dynamic scope for the $dynamicRef",
+      "/then/$defs/thingy is the final stop for the $dynamicRef"
     ],
     "strict-tree schema, guards against misspelled properties": [
-      "instance with misspelled field"
+      "instance with misspelled field",
+      "instance with correct field"
     ],
     "tests for implementation dynamic anchor and reference link": [
       "incorrect parent schema",
-      "incorrect extended schema"
+      "incorrect extended schema",
+      "correct extended schema"
     ],
     "$ref and $dynamicAnchor are independent of order - $defs first": [
       "incorrect parent schema",
-      "incorrect extended schema"
+      "incorrect extended schema",
+      "correct extended schema"
     ],
     "$ref and $dynamicAnchor are independent of order - $ref first": [
       "incorrect parent schema",
-      "incorrect extended schema"
+      "incorrect extended schema",
+      "correct extended schema"
     ],
     "$ref to $dynamicRef finds detached $dynamicAnchor": [
+      "number is valid",
       "non-number is invalid"
     ],
     "$dynamicRef points to a boolean schema": [
+      "follow $dynamicRef to a true schema",
       "follow $dynamicRef to a false schema"
     ],
     "$dynamicRef skips over intermediate resources - direct reference": [
+      "integer property passes",
       "string property fails"
     ],
+    "simple enum validation": [
+      "one of the enum is valid",
+      "something else is invalid"
+    ],
+    "heterogeneous enum validation": [
+      "one of the enum is valid",
+      "something else is invalid",
+      "objects are deep compared",
+      "valid object matches",
+      "extra properties in object is invalid"
+    ],
+    "heterogeneous enum-with-null validation": [
+      "null is valid",
+      "number is valid",
+      "something else is invalid"
+    ],
+    "enums in properties": [
+      "both properties are valid",
+      "wrong foo value",
+      "wrong bar value",
+      "missing optional property is valid",
+      "missing required property is invalid",
+      "missing all properties is invalid"
+    ],
+    "enum with escaped characters": [
+      "member 1 is valid",
+      "member 2 is valid",
+      "another string is invalid"
+    ],
+    "enum with false does not match 0": [
+      "false is valid",
+      "integer zero is invalid",
+      "float zero is invalid"
+    ],
+    "enum with [false] does not match [0]": [
+      "[false] is valid",
+      "[0] is invalid",
+      "[0.0] is invalid"
+    ],
+    "enum with true does not match 1": [
+      "true is valid",
+      "integer one is invalid",
+      "float one is invalid"
+    ],
+    "enum with [true] does not match [1]": [
+      "[true] is valid",
+      "[1] is invalid",
+      "[1.0] is invalid"
+    ],
+    "enum with 0 does not match false": [
+      "false is invalid",
+      "integer zero is valid",
+      "float zero is valid"
+    ],
+    "enum with [0] does not match [false]": [
+      "[false] is invalid",
+      "[0] is valid",
+      "[0.0] is valid"
+    ],
+    "enum with 1 does not match true": [
+      "true is invalid",
+      "integer one is valid",
+      "float one is valid"
+    ],
+    "enum with [1] does not match [true]": [
+      "[true] is invalid",
+      "[1] is valid",
+      "[1.0] is valid"
+    ],
+    "exclusiveMaximum validation": [
+      "below the exclusiveMaximum is valid",
+      "boundary point is invalid",
+      "above the exclusiveMaximum is invalid",
+      "ignores non-numbers"
+    ],
+    "exclusiveMinimum validation": [
+      "above the exclusiveMinimum is valid",
+      "boundary point is invalid",
+      "below the exclusiveMinimum is invalid",
+      "ignores non-numbers"
+    ],
     "email format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid email string is only an annotation by default"
     ],
     "idn-email format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid idn-email string is only an annotation by default"
     ],
     "regex format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid regex string is only an annotation by default"
     ],
     "ipv4 format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid ipv4 string is only an annotation by default"
     ],
     "ipv6 format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid ipv6 string is only an annotation by default"
     ],
+    "idn-hostname format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
+      "invalid idn-hostname string is only an annotation by default"
+    ],
     "hostname format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid hostname string is only an annotation by default"
     ],
     "date format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid date string is only an annotation by default"
     ],
+    "date-time format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
+      "invalid date-time string is only an annotation by default"
+    ],
     "time format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid time string is only an annotation by default"
     ],
     "json-pointer format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid json-pointer string is only an annotation by default"
     ],
     "relative-json-pointer format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid relative-json-pointer string is only an annotation by default"
     ],
     "iri format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid iri string is only an annotation by default"
     ],
+    "iri-reference format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
+      "invalid iri-reference string is only an annotation by default"
+    ],
     "uri format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid uri string is only an annotation by default"
     ],
+    "uri-reference format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
+      "invalid uri-reference string is only an annotation by default"
+    ],
     "uri-template format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid uri-template string is only an annotation by default"
     ],
     "uuid format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid uuid string is only an annotation by default"
     ],
     "duration format": [
+      "all string formats ignore integers",
+      "all string formats ignore floats",
+      "all string formats ignore objects",
+      "all string formats ignore arrays",
+      "all string formats ignore booleans",
+      "all string formats ignore nulls",
       "invalid duration string is only an annotation by default"
     ],
+    "ignore if without then or else": [
+      "valid when valid against lone if",
+      "valid when invalid against lone if"
+    ],
+    "ignore then without if": [
+      "valid when valid against lone then",
+      "valid when invalid against lone then"
+    ],
+    "ignore else without if": [
+      "valid when valid against lone else",
+      "valid when invalid against lone else"
+    ],
+    "if and then without else": [
+      "valid through then",
+      "invalid through then",
+      "valid when if test fails"
+    ],
+    "if and else without then": [
+      "valid when if test passes",
+      "valid through else",
+      "invalid through else"
+    ],
+    "validate against correct branch, then vs else": [
+      "valid through then",
+      "invalid through then",
+      "valid through else",
+      "invalid through else"
+    ],
+    "non-interference across combined schemas": [
+      "valid, but would have been invalid through then",
+      "valid, but would have been invalid through else"
+    ],
+    "if with boolean schema true": [
+      "boolean schema true in if always chooses the then path (valid)",
+      "boolean schema true in if always chooses the then path (invalid)"
+    ],
+    "if with boolean schema false": [
+      "boolean schema false in if always chooses the else path (invalid)",
+      "boolean schema false in if always chooses the else path (valid)"
+    ],
+    "if appears at the end when serialized (keyword processing sequence)": [
+      "yes redirects to then and passes",
+      "other redirects to else and passes",
+      "no redirects to then and fails",
+      "invalid redirects to else and fails"
+    ],
     "evaluating the same schema location against the same data location twice is not a sign of an infinite loop": [
+      "passing case",
       "failing case"
     ],
     "a schema given for items": [
-      "wrong type of items"
+      "valid items",
+      "wrong type of items",
+      "ignores non-arrays",
+      "JavaScript pseudo-array is valid"
+    ],
+    "items with boolean schema (true)": [
+      "any array is valid",
+      "empty array is valid"
     ],
     "items with boolean schema (false)": [
-      "any non-empty array is invalid"
+      "any non-empty array is invalid",
+      "empty array is valid"
     ],
     "items and subitems": [
       "valid items",
+      "too many items",
+      "too many sub-items",
+      "wrong item",
+      "wrong sub-item",
       "fewer items is valid"
     ],
     "nested items": [
-      "valid nested array"
+      "valid nested array",
+      "nested array with invalid type",
+      "not deep enough"
     ],
     "prefixItems with no additional items allowed": [
+      "empty array",
+      "fewer number of items present (1)",
+      "fewer number of items present (2)",
+      "equal number of items present",
       "additional items are not permitted"
     ],
     "items does not look in applicators, valid case": [
-      "prefixItems in allOf does not constrain items, invalid case"
+      "prefixItems in allOf does not constrain items, invalid case",
+      "prefixItems in allOf does not constrain items, valid case"
     ],
     "prefixItems validation adjusts the starting index for items": [
+      "valid items",
       "wrong type of second item"
     ],
     "items with heterogeneous array": [
-      "heterogeneous invalid instance"
+      "heterogeneous invalid instance",
+      "valid instance"
+    ],
+    "items with null instance elements": [
+      "allows null elements"
+    ],
+    "maxContains without contains is ignored": [
+      "one item valid against lone maxContains",
+      "two items still valid against lone maxContains"
     ],
     "maxContains with contains": [
       "empty data",
+      "all elements match, valid maxContains",
       "all elements match, invalid maxContains",
+      "some elements match, valid maxContains",
       "some elements match, invalid maxContains"
     ],
     "maxContains with contains, value with a decimal": [
+      "one element matches, valid maxContains",
       "too many elements match, invalid maxContains"
     ],
     "minContains < maxContains": [
       "actual < minContains < maxContains",
+      "minContains < actual < maxContains",
       "minContains < maxContains < actual"
     ],
     "maxItems validation": [
-      "too long is invalid"
+      "shorter is valid",
+      "exact length is valid",
+      "too long is invalid",
+      "ignores non-arrays"
     ],
     "maxItems validation with a decimal": [
+      "shorter is valid",
+      "too long is invalid"
+    ],
+    "maxLength validation": [
+      "shorter is valid",
+      "exact length is valid",
+      "too long is invalid",
+      "ignores non-strings",
+      "two graphemes is long enough"
+    ],
+    "maxLength validation with a decimal": [
+      "shorter is valid",
       "too long is invalid"
     ],
     "maxProperties validation": [
-      "too long is invalid"
+      "shorter is valid",
+      "exact length is valid",
+      "too long is invalid",
+      "ignores arrays",
+      "ignores strings",
+      "ignores other non-objects"
     ],
     "maxProperties validation with a decimal": [
+      "shorter is valid",
       "too long is invalid"
     ],
     "maxProperties = 0 means the object is empty": [
+      "no properties is valid",
       "one property is invalid"
+    ],
+    "maximum validation": [
+      "below the maximum is valid",
+      "boundary point is valid",
+      "above the maximum is invalid",
+      "ignores non-numbers"
+    ],
+    "maximum validation with unsigned integer": [
+      "below the maximum is invalid",
+      "boundary point integer is valid",
+      "boundary point float is valid",
+      "above the maximum is invalid"
+    ],
+    "minContains without contains is ignored": [
+      "one item valid against lone minContains",
+      "zero items still valid against lone minContains"
     ],
     "minContains=1 with contains": [
       "empty data",
-      "no elements match"
+      "no elements match",
+      "single element matches, valid minContains",
+      "some elements match, valid minContains",
+      "all elements match, valid minContains"
     ],
     "minContains=2 with contains": [
       "empty data",
       "all elements match, invalid minContains",
-      "some elements match, invalid minContains"
+      "some elements match, invalid minContains",
+      "all elements match, valid minContains (exactly as needed)",
+      "all elements match, valid minContains (more than needed)",
+      "some elements match, valid minContains"
     ],
     "minContains=2 with contains with a decimal value": [
-      "one element matches, invalid minContains"
+      "one element matches, invalid minContains",
+      "both elements match, valid minContains"
     ],
     "maxContains = minContains": [
       "empty data",
       "all elements match, invalid minContains",
-      "all elements match, invalid maxContains"
+      "all elements match, invalid maxContains",
+      "all elements match, valid maxContains and minContains"
     ],
     "maxContains < minContains": [
       "empty data",
@@ -262,352 +914,857 @@
       "invalid maxContains",
       "invalid maxContains and minContains"
     ],
+    "minContains = 0": [
+      "empty data",
+      "minContains = 0 makes contains always pass"
+    ],
     "minContains = 0 with maxContains": [
+      "empty data",
+      "not more than maxContains",
       "too many"
     ],
     "minItems validation": [
-      "too short is invalid"
+      "longer is valid",
+      "exact length is valid",
+      "too short is invalid",
+      "ignores non-arrays"
     ],
     "minItems validation with a decimal": [
+      "longer is valid",
+      "too short is invalid"
+    ],
+    "minLength validation": [
+      "longer is valid",
+      "exact length is valid",
+      "too short is invalid",
+      "ignores non-strings",
+      "one grapheme is not long enough"
+    ],
+    "minLength validation with a decimal": [
+      "longer is valid",
       "too short is invalid"
     ],
     "minProperties validation": [
-      "too short is invalid"
+      "longer is valid",
+      "exact length is valid",
+      "too short is invalid",
+      "ignores arrays",
+      "ignores strings",
+      "ignores other non-objects"
     ],
     "minProperties validation with a decimal": [
+      "longer is valid",
       "too short is invalid"
     ],
+    "minimum validation": [
+      "above the minimum is valid",
+      "boundary point is valid",
+      "below the minimum is invalid",
+      "ignores non-numbers"
+    ],
+    "minimum validation with signed integer": [
+      "negative above the minimum is valid",
+      "positive above the minimum is valid",
+      "boundary point is valid",
+      "boundary point with float is valid",
+      "float below the minimum is invalid",
+      "int below the minimum is invalid",
+      "ignores non-numbers"
+    ],
+    "by int": [
+      "int by int",
+      "int by int fail",
+      "ignores non-numbers"
+    ],
+    "by number": [
+      "zero is multiple of anything",
+      "4.5 is multiple of 1.5",
+      "35 is not multiple of 1.5"
+    ],
     "by small number": [
-      "0.0075 is multiple of 0.0001"
+      "0.0075 is multiple of 0.0001",
+      "0.00751 is not multiple of 0.0001"
+    ],
+    "float division = inf": [
+      "always invalid, but naive implementations may raise an overflow error"
     ],
     "small multiple of large integer": [
       "any integer is a multiple of 1e-8"
     ],
+    "not": [
+      "allowed",
+      "disallowed"
+    ],
+    "not multiple types": [
+      "valid",
+      "mismatch",
+      "other mismatch"
+    ],
+    "not more complex schema": [
+      "match",
+      "other match",
+      "mismatch"
+    ],
+    "forbidden property": [
+      "property present",
+      "property absent"
+    ],
+    "forbid everything with empty schema": [
+      "number is invalid",
+      "string is invalid",
+      "boolean true is invalid",
+      "boolean false is invalid",
+      "null is invalid",
+      "object is invalid",
+      "empty object is invalid",
+      "array is invalid",
+      "empty array is invalid"
+    ],
+    "forbid everything with boolean schema true": [
+      "number is invalid",
+      "string is invalid",
+      "boolean true is invalid",
+      "boolean false is invalid",
+      "null is invalid",
+      "object is invalid",
+      "empty object is invalid",
+      "array is invalid",
+      "empty array is invalid"
+    ],
+    "allow everything with boolean schema false": [
+      "number is valid",
+      "string is valid",
+      "boolean true is valid",
+      "boolean false is valid",
+      "null is valid",
+      "object is valid",
+      "empty object is valid",
+      "array is valid",
+      "empty array is valid"
+    ],
+    "double negation": [
+      "any value is valid"
+    ],
     "collect annotations inside a 'not', even if collection is disabled": [
-      "unevaluated property"
+      "unevaluated property",
+      "annotations are still collected inside a 'not'"
+    ],
+    "oneOf": [
+      "first oneOf valid",
+      "second oneOf valid",
+      "both oneOf valid",
+      "neither oneOf valid"
+    ],
+    "oneOf with base schema": [
+      "mismatch base schema",
+      "one oneOf valid",
+      "both oneOf valid"
+    ],
+    "oneOf with boolean schemas, all true": [
+      "any value is invalid"
+    ],
+    "oneOf with boolean schemas, one true": [
+      "any value is valid"
+    ],
+    "oneOf with boolean schemas, more than one true": [
+      "any value is invalid"
+    ],
+    "oneOf with boolean schemas, all false": [
+      "any value is invalid"
+    ],
+    "oneOf complex types": [
+      "first oneOf valid (complex)",
+      "second oneOf valid (complex)",
+      "both oneOf valid (complex)",
+      "neither oneOf valid (complex)"
+    ],
+    "oneOf with empty schema": [
+      "one valid - valid",
+      "both valid - invalid"
+    ],
+    "oneOf with required": [
+      "both invalid - invalid",
+      "first valid - valid",
+      "second valid - valid",
+      "both valid - invalid"
+    ],
+    "oneOf with missing optional property": [
+      "first oneOf valid",
+      "second oneOf valid",
+      "both oneOf valid",
+      "neither oneOf valid"
+    ],
+    "nested oneOf, to check validation semantics": [
+      "null is valid",
+      "anything non-null is invalid"
+    ],
+    "pattern validation": [
+      "a matching pattern is valid",
+      "a non-matching pattern is invalid",
+      "ignores booleans",
+      "ignores integers",
+      "ignores floats",
+      "ignores objects",
+      "ignores arrays",
+      "ignores null"
+    ],
+    "pattern is not anchored": [
+      "matches a substring"
     ],
     "patternProperties validates properties matching a regex": [
+      "a single valid match is valid",
+      "multiple valid matches is valid",
       "a single invalid match is invalid",
-      "multiple invalid matches is invalid"
+      "multiple invalid matches is invalid",
+      "ignores arrays",
+      "ignores strings",
+      "ignores other non-objects"
     ],
     "multiple simultaneous patternProperties are validated": [
+      "a single valid match is valid",
+      "a simultaneous match is valid",
+      "multiple matches is valid",
       "an invalid due to one is invalid",
       "an invalid due to the other is invalid",
       "an invalid due to both is invalid"
     ],
     "regexes are not anchored by default and are case sensitive": [
+      "non recognized members are ignored",
       "recognized members are accounted for",
+      "regexes are case sensitive",
       "regexes are case sensitive, 2"
     ],
     "patternProperties with boolean schemas": [
+      "object with property matching schema true is valid",
       "object with property matching schema false is invalid",
       "object with both properties is invalid",
-      "object with a property matching both true and false is invalid"
+      "object with a property matching both true and false is invalid",
+      "empty object is valid"
+    ],
+    "patternProperties with null valued instance properties": [
+      "allows null values"
     ],
     "a schema given for prefixItems": [
-      "wrong types"
+      "correct types",
+      "wrong types",
+      "incomplete array of items",
+      "array with additional items",
+      "empty array",
+      "JavaScript pseudo-array is valid"
     ],
     "prefixItems with boolean schemas": [
-      "array with two items is invalid"
+      "array with one item is valid",
+      "array with two items is invalid",
+      "empty array is valid"
+    ],
+    "additional items are allowed by default": [
+      "only the first item is validated"
+    ],
+    "prefixItems with null instance elements": [
+      "allows null elements"
+    ],
+    "object properties validation": [
+      "both properties present and valid is valid",
+      "one property invalid is invalid",
+      "both properties invalid is invalid",
+      "doesn't invalidate other properties",
+      "ignores arrays",
+      "ignores other non-objects"
     ],
     "properties, patternProperties, additionalProperties interaction": [
       "property validates property",
+      "property invalidates property",
+      "patternProperty invalidates property",
+      "patternProperty validates nonproperty",
       "patternProperty invalidates nonproperty",
       "additionalProperty ignores property",
+      "additionalProperty validates others",
       "additionalProperty invalidates others"
     ],
+    "properties with boolean schema": [
+      "no property present is valid",
+      "only 'true' property present is valid",
+      "only 'false' property present is invalid",
+      "both properties present is invalid"
+    ],
+    "properties with escaped characters": [
+      "object with all numbers is valid",
+      "object with strings is invalid"
+    ],
+    "properties with null valued instance properties": [
+      "allows null values"
+    ],
     "properties whose names are Javascript object property names": [
-      "none of the properties mentioned"
+      "ignores arrays",
+      "ignores other non-objects",
+      "none of the properties mentioned",
+      "__proto__ not valid",
+      "toString not valid",
+      "constructor not valid",
+      "all present and valid"
     ],
     "propertyNames validation": [
-      "some property names invalid"
+      "all property names valid",
+      "some property names invalid",
+      "object without properties is valid",
+      "ignores arrays",
+      "ignores strings",
+      "ignores other non-objects"
+    ],
+    "propertyNames with boolean schema true": [
+      "object with any properties is valid",
+      "empty object is valid"
     ],
     "propertyNames with boolean schema false": [
-      "object with any properties is invalid"
+      "object with any properties is invalid",
+      "empty object is valid"
     ],
     "root pointer ref": [
+      "match",
+      "recursive match",
       "mismatch",
       "recursive mismatch"
     ],
     "relative pointer ref to object": [
+      "match",
       "mismatch"
     ],
     "relative pointer ref to array": [
+      "match array",
       "mismatch array"
     ],
     "escaped pointer ref": [
       "slash invalid",
       "tilde invalid",
-      "percent invalid"
+      "percent invalid",
+      "slash valid",
+      "tilde valid",
+      "percent valid"
     ],
     "nested refs": [
+      "nested ref valid",
       "nested ref invalid"
     ],
     "ref applies alongside sibling keywords": [
+      "ref valid, maxItems valid",
       "ref valid, maxItems invalid",
       "ref invalid"
     ],
     "remote ref, containing refs itself": [
+      "remote ref valid",
       "remote ref invalid"
     ],
-    "property named $ref, containing an actual $ref": [
+    "property named $ref that is not a reference": [
+      "property named $ref valid",
       "property named $ref invalid"
+    ],
+    "property named $ref, containing an actual $ref": [
+      "property named $ref valid",
+      "property named $ref invalid"
+    ],
+    "$ref to boolean schema true": [
+      "any value is valid"
     ],
     "$ref to boolean schema false": [
       "any value is invalid"
     ],
     "Recursive references between schemas": [
-      "valid tree"
+      "valid tree",
+      "invalid tree"
     ],
     "refs with quote": [
+      "object with numbers is valid",
       "object with strings is invalid"
     ],
     "ref creates new scope when adjacent to keywords": [
       "referenced subschema doesn't see annotations from properties"
     ],
+    "naive replacement of $ref with its destination is not correct": [
+      "do not evaluate the $ref inside the enum, matching any string",
+      "do not evaluate the $ref inside the enum, definition exact match",
+      "match the enum exactly"
+    ],
     "refs with relative uris and defs": [
       "invalid on inner field",
-      "invalid on outer field"
+      "invalid on outer field",
+      "valid on both fields"
     ],
     "relative refs with absolute uris and defs": [
       "invalid on inner field",
-      "invalid on outer field"
+      "invalid on outer field",
+      "valid on both fields"
     ],
     "$id must be resolved against nearest parent, not just immediate parent": [
+      "number is valid",
       "non-number is invalid"
     ],
     "order of evaluation: $id and $ref": [
+      "data is valid against first definition",
       "data is invalid against first definition"
     ],
     "order of evaluation: $id and $anchor and $ref": [
+      "data is valid against first definition",
       "data is invalid against first definition"
     ],
     "simple URN base URI with $ref via the URN": [
+      "valid under the URN IDed schema",
       "invalid under the URN IDed schema"
     ],
     "simple URN base URI with JSON pointer": [
+      "a string is valid",
       "a non-string is invalid"
     ],
     "URN base URI with NSS": [
+      "a string is valid",
       "a non-string is invalid"
     ],
     "URN base URI with r-component": [
+      "a string is valid",
       "a non-string is invalid"
     ],
     "URN base URI with q-component": [
+      "a string is valid",
       "a non-string is invalid"
     ],
     "URN base URI with URN and JSON pointer ref": [
+      "a string is valid",
       "a non-string is invalid"
     ],
     "URN base URI with URN and anchor ref": [
+      "a string is valid",
       "a non-string is invalid"
     ],
     "URN ref with nested pointer ref": [
+      "a string is valid",
       "a non-string is invalid"
     ],
     "ref to if": [
-      "a non-integer is invalid due to the $ref"
+      "a non-integer is invalid due to the $ref",
+      "an integer is valid"
     ],
     "ref to then": [
-      "a non-integer is invalid due to the $ref"
+      "a non-integer is invalid due to the $ref",
+      "an integer is valid"
     ],
     "ref to else": [
-      "a non-integer is invalid due to the $ref"
+      "a non-integer is invalid due to the $ref",
+      "an integer is valid"
     ],
     "ref with absolute-path-reference": [
+      "a string is valid",
       "an integer is invalid"
     ],
     "$id with file URI still resolves pointers - *nix": [
+      "number is valid",
       "non-number is invalid"
     ],
     "$id with file URI still resolves pointers - windows": [
+      "number is valid",
       "non-number is invalid"
     ],
     "empty tokens in $ref json-pointer": [
+      "number is valid",
       "non-number is invalid"
     ],
     "remote ref": [
+      "remote ref valid",
       "remote ref invalid"
     ],
     "fragment within remote ref": [
+      "remote fragment valid",
       "remote fragment invalid"
     ],
     "anchor within remote ref": [
+      "remote anchor valid",
       "remote anchor invalid"
     ],
     "ref within remote ref": [
+      "ref within ref valid",
       "ref within ref invalid"
     ],
     "base URI change": [
+      "base URI change ref valid",
       "base URI change ref invalid"
     ],
     "base URI change - change folder": [
+      "number is valid",
       "string is invalid"
     ],
     "base URI change - change folder in subschema": [
+      "number is valid",
       "string is invalid"
     ],
     "root ref in remote ref": [
+      "string is valid",
+      "null is valid",
       "object is invalid"
     ],
     "remote ref with ref to defs": [
-      "invalid"
+      "invalid",
+      "valid"
     ],
     "Location-independent identifier in remote ref": [
+      "integer is valid",
       "string is invalid"
     ],
     "retrieved nested refs resolve relative to their URI not $id": [
-      "number is invalid"
+      "number is invalid",
+      "string is valid"
     ],
     "remote HTTP ref with different $id": [
-      "number is invalid"
+      "number is invalid",
+      "string is valid"
     ],
     "remote HTTP ref with different URN $id": [
-      "number is invalid"
+      "number is invalid",
+      "string is valid"
     ],
     "remote HTTP ref with nested absolute ref": [
-      "number is invalid"
+      "number is invalid",
+      "string is valid"
     ],
     "$ref to $ref finds detached $anchor": [
+      "number is valid",
       "non-number is invalid"
     ],
     "required validation": [
-      "ignores arrays"
+      "present required property is valid",
+      "non-present required property is invalid",
+      "ignores arrays",
+      "ignores strings",
+      "ignores other non-objects"
+    ],
+    "required default validation": [
+      "not required by default"
+    ],
+    "required with empty array": [
+      "property not required"
+    ],
+    "required with escaped characters": [
+      "object with all properties present is valid",
+      "object with some properties missing is invalid"
     ],
     "required properties whose names are Javascript object property names": [
+      "ignores arrays",
+      "ignores other non-objects",
       "none of the properties mentioned",
       "__proto__ present",
       "toString present",
-      "constructor present"
+      "constructor present",
+      "all present"
+    ],
+    "integer type matches integers": [
+      "an integer is an integer",
+      "a float with zero fractional part is an integer",
+      "a float is not an integer",
+      "a string is not an integer",
+      "a string is still not an integer, even if it looks like one",
+      "an object is not an integer",
+      "an array is not an integer",
+      "a boolean is not an integer",
+      "null is not an integer"
+    ],
+    "number type matches numbers": [
+      "an integer is a number",
+      "a float with zero fractional part is a number (and an integer)",
+      "a float is a number",
+      "a string is not a number",
+      "a string is still not a number, even if it looks like one",
+      "an object is not a number",
+      "an array is not a number",
+      "a boolean is not a number",
+      "null is not a number"
+    ],
+    "string type matches strings": [
+      "1 is not a string",
+      "a float is not a string",
+      "a string is a string",
+      "a string is still a string, even if it looks like a number",
+      "an empty string is still a string",
+      "an object is not a string",
+      "an array is not a string",
+      "a boolean is not a string",
+      "null is not a string"
     ],
     "object type matches objects": [
-      "an array is not an object"
+      "an integer is not an object",
+      "a float is not an object",
+      "a string is not an object",
+      "an object is an object",
+      "an array is not an object",
+      "a boolean is not an object",
+      "null is not an object"
     ],
     "array type matches arrays": [
-      "an array is an array"
+      "an integer is not an array",
+      "a float is not an array",
+      "a string is not an array",
+      "an object is not an array",
+      "an array is an array",
+      "a boolean is not an array",
+      "null is not an array"
+    ],
+    "boolean type matches booleans": [
+      "an integer is not a boolean",
+      "zero is not a boolean",
+      "a float is not a boolean",
+      "a string is not a boolean",
+      "an empty string is not a boolean",
+      "an object is not a boolean",
+      "an array is not a boolean",
+      "true is a boolean",
+      "false is a boolean",
+      "null is not a boolean"
+    ],
+    "null type matches only the null object": [
+      "an integer is not null",
+      "a float is not null",
+      "zero is not null",
+      "a string is not null",
+      "an empty string is not null",
+      "an object is not null",
+      "an array is not null",
+      "true is not null",
+      "false is not null",
+      "null is null"
+    ],
+    "multiple types can be specified in an array": [
+      "an integer is valid",
+      "a string is valid",
+      "a float is invalid",
+      "an object is invalid",
+      "an array is invalid",
+      "a boolean is invalid",
+      "null is invalid"
+    ],
+    "type as array with one item": [
+      "string is valid",
+      "number is invalid"
+    ],
+    "type: array or object": [
+      "array is valid",
+      "object is valid",
+      "number is invalid",
+      "string is invalid",
+      "null is invalid"
+    ],
+    "type: array, object or null": [
+      "array is valid",
+      "object is valid",
+      "null is valid",
+      "number is invalid",
+      "string is invalid"
+    ],
+    "unevaluatedItems true": [
+      "with no unevaluated items",
+      "with unevaluated items"
     ],
     "unevaluatedItems false": [
+      "with no unevaluated items",
       "with unevaluated items"
     ],
     "unevaluatedItems as schema": [
+      "with no unevaluated items",
+      "with valid unevaluated items",
       "with invalid unevaluated items"
     ],
+    "unevaluatedItems with uniform items": [
+      "unevaluatedItems doesn't apply"
+    ],
     "unevaluatedItems with tuple": [
+      "with no unevaluated items",
       "with unevaluated items"
     ],
+    "unevaluatedItems with items and prefixItems": [
+      "unevaluatedItems doesn't apply"
+    ],
     "unevaluatedItems with items": [
+      "valid under items",
       "invalid under items"
     ],
     "unevaluatedItems with nested tuple": [
+      "with no unevaluated items",
       "with unevaluated items"
     ],
     "unevaluatedItems with nested items": [
+      "with only (valid) additional items",
+      "with no additional items",
       "with invalid additional item"
     ],
+    "unevaluatedItems with nested prefixItems and items": [
+      "with no additional items",
+      "with additional items"
+    ],
+    "unevaluatedItems with nested unevaluatedItems": [
+      "with no additional items",
+      "with additional items"
+    ],
     "unevaluatedItems with anyOf": [
+      "when one schema matches and has no unevaluated items",
       "when one schema matches and has unevaluated items",
+      "when two schemas match and has no unevaluated items",
       "when two schemas match and has unevaluated items"
     ],
     "unevaluatedItems with oneOf": [
-      "with no unevaluated items"
+      "with no unevaluated items",
+      "with unevaluated items"
     ],
     "unevaluatedItems with not": [
       "with unevaluated items"
     ],
     "unevaluatedItems with if/then/else": [
+      "when if matches and it has no unevaluated items",
       "when if matches and it has unevaluated items",
+      "when if doesn't match and it has no unevaluated items",
       "when if doesn't match and it has unevaluated items"
     ],
     "unevaluatedItems with boolean schemas": [
+      "with no unevaluated items",
       "with unevaluated items"
     ],
     "unevaluatedItems with $ref": [
+      "with no unevaluated items",
       "with unevaluated items"
     ],
     "unevaluatedItems before $ref": [
+      "with no unevaluated items",
       "with unevaluated items"
     ],
     "unevaluatedItems with $dynamicRef": [
+      "with no unevaluated items",
       "with unevaluated items"
     ],
     "unevaluatedItems can't see inside cousins": [
       "always fails"
     ],
     "item is evaluated in an uncle schema to unevaluatedItems": [
+      "no extra items",
       "uncle keyword evaluation is not significant"
     ],
     "unevaluatedItems depends on adjacent contains": [
+      "second item is evaluated by contains",
       "contains fails, second item is not evaluated",
       "contains passes, second item is not evaluated"
     ],
     "unevaluatedItems depends on multiple nested contains": [
+      "5 not evaluated, passes unevaluatedItems",
       "7 not evaluated, fails unevaluatedItems"
     ],
     "unevaluatedItems and contains interact to control item dependency relationship": [
+      "empty array is valid",
+      "only a's are valid",
+      "a's and b's are valid",
+      "a's, b's and c's are valid",
       "only b's are invalid",
       "only c's are invalid",
       "only b's and c's are invalid",
       "only a's and c's are invalid"
     ],
+    "non-array instances are valid": [
+      "ignores booleans",
+      "ignores integers",
+      "ignores floats",
+      "ignores objects",
+      "ignores strings",
+      "ignores null"
+    ],
+    "unevaluatedItems with null instance elements": [
+      "allows null elements"
+    ],
     "unevaluatedItems can see annotations from if without then and else": [
+      "valid in case if is evaluated",
       "invalid in case if is evaluated"
     ],
+    "unevaluatedProperties true": [
+      "with no unevaluated properties",
+      "with unevaluated properties"
+    ],
     "unevaluatedProperties schema": [
+      "with no unevaluated properties",
+      "with valid unevaluated properties",
       "with invalid unevaluated properties"
     ],
     "unevaluatedProperties false": [
+      "with no unevaluated properties",
       "with unevaluated properties"
     ],
     "unevaluatedProperties with adjacent properties": [
+      "with no unevaluated properties",
       "with unevaluated properties"
     ],
     "unevaluatedProperties with adjacent patternProperties": [
+      "with no unevaluated properties",
       "with unevaluated properties"
     ],
+    "unevaluatedProperties with adjacent additionalProperties": [
+      "with no additional properties",
+      "with additional properties"
+    ],
     "unevaluatedProperties with nested properties": [
+      "with no additional properties",
       "with additional properties"
     ],
     "unevaluatedProperties with nested patternProperties": [
+      "with no additional properties",
       "with additional properties"
     ],
+    "unevaluatedProperties with nested additionalProperties": [
+      "with no additional properties",
+      "with additional properties"
+    ],
+    "unevaluatedProperties with nested unevaluatedProperties": [
+      "with no nested unevaluated properties",
+      "with nested unevaluated properties"
+    ],
     "unevaluatedProperties with anyOf": [
+      "when one matches and has no unevaluated properties",
       "when one matches and has unevaluated properties",
+      "when two match and has no unevaluated properties",
       "when two match and has unevaluated properties"
     ],
     "unevaluatedProperties with oneOf": [
+      "with no unevaluated properties",
       "with unevaluated properties"
     ],
     "unevaluatedProperties with not": [
       "with unevaluated properties"
     ],
     "unevaluatedProperties with if/then/else": [
+      "when if is true and has no unevaluated properties",
       "when if is true and has unevaluated properties",
+      "when if is false and has no unevaluated properties",
       "when if is false and has unevaluated properties"
     ],
     "unevaluatedProperties with if/then/else, then not defined": [
       "when if is true and has no unevaluated properties",
       "when if is true and has unevaluated properties",
+      "when if is false and has no unevaluated properties",
       "when if is false and has unevaluated properties"
     ],
     "unevaluatedProperties with if/then/else, else not defined": [
+      "when if is true and has no unevaluated properties",
       "when if is true and has unevaluated properties",
       "when if is false and has no unevaluated properties",
       "when if is false and has unevaluated properties"
     ],
     "unevaluatedProperties with dependentSchemas": [
+      "with no unevaluated properties",
       "with unevaluated properties"
     ],
     "unevaluatedProperties with boolean schemas": [
+      "with no unevaluated properties",
       "with unevaluated properties"
     ],
     "unevaluatedProperties with $ref": [
+      "with no unevaluated properties",
       "with unevaluated properties"
     ],
     "unevaluatedProperties before $ref": [
+      "with no unevaluated properties",
       "with unevaluated properties"
     ],
     "unevaluatedProperties with $dynamicRef": [
+      "with no unevaluated properties",
       "with unevaluated properties"
     ],
     "unevaluatedProperties can't see inside cousins": [
@@ -616,11 +1773,20 @@
     "unevaluatedProperties can't see inside cousins (reverse order)": [
       "always fails"
     ],
+    "nested unevaluatedProperties, outer false, inner true, properties outside": [
+      "with no nested unevaluated properties",
+      "with nested unevaluated properties"
+    ],
+    "nested unevaluatedProperties, outer false, inner true, properties inside": [
+      "with no nested unevaluated properties",
+      "with nested unevaluated properties"
+    ],
     "nested unevaluatedProperties, outer true, inner false, properties outside": [
       "with no nested unevaluated properties",
       "with nested unevaluated properties"
     ],
     "nested unevaluatedProperties, outer true, inner false, properties inside": [
+      "with no nested unevaluated properties",
       "with nested unevaluated properties"
     ],
     "cousin unevaluatedProperties, true and false, true with properties": [
@@ -628,80 +1794,178 @@
       "with nested unevaluated properties"
     ],
     "cousin unevaluatedProperties, true and false, false with properties": [
+      "with no nested unevaluated properties",
       "with nested unevaluated properties"
     ],
     "property is evaluated in an uncle schema to unevaluatedProperties": [
+      "no extra properties",
       "uncle keyword evaluation is not significant"
     ],
     "in-place applicator siblings, allOf has unevaluated": [
       "base case: both properties present",
+      "in place applicator siblings, bar is missing",
       "in place applicator siblings, foo is missing"
     ],
     "in-place applicator siblings, anyOf has unevaluated": [
       "base case: both properties present",
-      "in place applicator siblings, bar is missing"
+      "in place applicator siblings, bar is missing",
+      "in place applicator siblings, foo is missing"
     ],
     "unevaluatedProperties + single cyclic ref": [
+      "Empty is valid",
+      "Single is valid",
       "Unevaluated on 1st level is invalid",
+      "Nested is valid",
       "Unevaluated on 2nd level is invalid",
+      "Deep nested is valid",
       "Unevaluated on 3rd level is invalid"
     ],
     "unevaluatedProperties + ref inside allOf / oneOf": [
       "Empty is invalid (no x or y)",
       "a and b are invalid (no x or y)",
+      "x and y are invalid",
+      "a and x are valid",
       "a and y are valid",
-      "a and b and y are valid"
+      "a and b and x are valid",
+      "a and b and y are valid",
+      "a and b and x and y are invalid"
     ],
     "dynamic evalation inside nested refs": [
       "Empty is invalid",
       "a is valid",
+      "b is valid",
+      "c is valid",
+      "d is valid",
+      "a + b is invalid",
+      "a + c is invalid",
+      "a + d is invalid",
       "b + c is invalid",
       "b + d is invalid",
       "c + d is invalid",
+      "xx is valid",
+      "xx + foox is valid",
       "xx + foo is invalid",
+      "xx + a is invalid",
       "xx + b is invalid",
       "xx + c is invalid",
-      "xx + d is invalid"
+      "xx + d is invalid",
+      "all is valid",
+      "all + foo is valid",
+      "all + a is invalid"
+    ],
+    "non-object instances are valid": [
+      "ignores booleans",
+      "ignores integers",
+      "ignores floats",
+      "ignores arrays",
+      "ignores strings",
+      "ignores null"
+    ],
+    "unevaluatedProperties with null valued instance properties": [
+      "allows null valued properties"
     ],
     "unevaluatedProperties not affected by propertyNames": [
+      "allows only number properties",
       "string property is invalid"
     ],
     "unevaluatedProperties can see annotations from if without then and else": [
+      "valid in case if is evaluated",
       "invalid in case if is evaluated"
     ],
     "dependentSchemas with unevaluatedProperties": [
       "unevaluatedProperties doesn't consider dependentSchemas",
-      "unevaluatedProperties doesn't see bar when foo2 is absent"
+      "unevaluatedProperties doesn't see bar when foo2 is absent",
+      "unevaluatedProperties sees bar when foo2 is present"
     ],
     "uniqueItems validation": [
+      "unique array of integers is valid",
       "non-unique array of integers is invalid",
       "non-unique array of more than two integers is invalid",
       "numbers are unique if mathematically unequal",
+      "false is not equal to zero",
+      "true is not equal to one",
+      "unique array of strings is valid",
       "non-unique array of strings is invalid",
+      "unique array of objects is valid",
       "non-unique array of objects is invalid",
       "property order of array of objects is ignored",
+      "unique array of nested objects is valid",
       "non-unique array of nested objects is invalid",
+      "unique array of arrays is valid",
       "non-unique array of arrays is invalid",
       "non-unique array of more than two arrays is invalid",
+      "1 and true are unique",
+      "0 and false are unique",
+      "[1] and [true] are unique",
+      "[0] and [false] are unique",
+      "nested [1] and [true] are unique",
+      "nested [0] and [false] are unique",
+      "unique heterogeneous types are valid",
       "non-unique heterogeneous types are invalid",
-      "objects are non-unique despite key order"
+      "different objects are unique",
+      "objects are non-unique despite key order",
+      "{\"a\": false} and {\"a\": 0} are unique",
+      "{\"a\": true} and {\"a\": 1} are unique"
     ],
     "uniqueItems with an array of items": [
+      "[false, true] from items array is valid",
+      "[true, false] from items array is valid",
       "[false, false] from items array is not valid",
       "[true, true] from items array is not valid",
+      "unique array extended from [false, true] is valid",
+      "unique array extended from [true, false] is valid",
       "non-unique array extended from [false, true] is not valid",
       "non-unique array extended from [true, false] is not valid"
     ],
     "uniqueItems with an array of items and additionalItems=false": [
+      "[false, true] from items array is valid",
+      "[true, false] from items array is valid",
       "[false, false] from items array is not valid",
       "[true, true] from items array is not valid",
       "extra items are invalid even if unique"
     ],
+    "uniqueItems=false validation": [
+      "unique array of integers is valid",
+      "non-unique array of integers is valid",
+      "numbers are unique if mathematically unequal",
+      "false is not equal to zero",
+      "true is not equal to one",
+      "unique array of objects is valid",
+      "non-unique array of objects is valid",
+      "unique array of nested objects is valid",
+      "non-unique array of nested objects is valid",
+      "unique array of arrays is valid",
+      "non-unique array of arrays is valid",
+      "1 and true are unique",
+      "0 and false are unique",
+      "unique heterogeneous types are valid",
+      "non-unique heterogeneous types are valid"
+    ],
+    "uniqueItems=false with an array of items": [
+      "[false, true] from items array is valid",
+      "[true, false] from items array is valid",
+      "[false, false] from items array is valid",
+      "[true, true] from items array is valid",
+      "unique array extended from [false, true] is valid",
+      "unique array extended from [true, false] is valid",
+      "non-unique array extended from [false, true] is valid",
+      "non-unique array extended from [true, false] is valid"
+    ],
     "uniqueItems=false with an array of items and additionalItems=false": [
+      "[false, true] from items array is valid",
+      "[true, false] from items array is valid",
+      "[false, false] from items array is valid",
+      "[true, true] from items array is valid",
       "extra items are invalid even if unique"
     ],
     "schema that uses custom metaschema with with no validation vocabulary": [
+      "applicator vocabulary still works",
+      "no validation: valid number",
       "no validation: invalid number, but it still validates"
+    ],
+    "ignore unrecognized optional vocabulary": [
+      "string value",
+      "number value"
     ]
   }
 }

--- a/next/test/validation/composition.test.ts
+++ b/next/test/validation/composition.test.ts
@@ -149,7 +149,6 @@ describe('schema composition validators', () => {
         const errors = validateSchema(value, schema)
         expect(errors).toHaveLength(1)
         expect(errors[0].validation).toBe('anyOf')
-        expect(errors[0].message).toBe(`The option "${value}" is not valid.`)
       })
     })
 
@@ -256,7 +255,6 @@ describe('schema composition validators', () => {
         const errors = validateSchema(value, schema)
         expect(errors).toHaveLength(1)
         expect(errors[0].validation).toBe('oneOf')
-        expect(errors[0].message).toBe(`The option "${value}" is not valid.`)
       })
 
       it('should fail when value matches multiple schemas', () => {
@@ -264,7 +262,6 @@ describe('schema composition validators', () => {
         const errors = validateSchema(value, schema)
         expect(errors).toHaveLength(1)
         expect(errors[0].validation).toBe('oneOf')
-        expect(errors[0].message).toBe(`The option "${value}" is not valid.`)
       })
     })
 
@@ -322,7 +319,6 @@ describe('schema composition validators', () => {
         const errors = validateSchema(value, schema)
         expect(errors).toHaveLength(1)
         expect(errors[0].validation).toBe('oneOf')
-        expect(errors[0].message).toBe(`The option "${value}" is not valid.`)
       })
     })
 
@@ -370,7 +366,6 @@ describe('schema composition validators', () => {
         const errors = validateSchema(value, schema)
         expect(errors).toHaveLength(1)
         expect(errors[0].validation).toBe('not')
-        expect(errors[0].message).toBe('The value must not satisfy the provided schema')
       })
     })
 

--- a/next/test/validation/composition.test.ts
+++ b/next/test/validation/composition.test.ts
@@ -33,7 +33,7 @@ describe('schema composition validators', () => {
         const errors = validateSchema(value, schema)
         expect(errors).toHaveLength(1)
         expect(errors[0].validation).toBe('required')
-        expect(errors[0].path).toEqual(['bar'])
+        expect(errors[0].path).toEqual(['allOf', 0, 'bar'])
       })
 
       it('should fail when missing required property from second schema', () => {
@@ -41,7 +41,7 @@ describe('schema composition validators', () => {
         const errors = validateSchema(value, schema)
         expect(errors).toHaveLength(1)
         expect(errors[0].validation).toBe('required')
-        expect(errors[0].path).toEqual(['foo'])
+        expect(errors[0].path).toEqual(['allOf', 1, 'foo'])
       })
 
       it('should fail when property has wrong type', () => {
@@ -49,7 +49,7 @@ describe('schema composition validators', () => {
         const errors = validateSchema(value, schema)
         expect(errors).toHaveLength(1)
         expect(errors[0].validation).toBe('type')
-        expect(errors[0].path).toEqual(['bar'])
+        expect(errors[0].path).toEqual(['allOf', 0, 'bar'])
       })
     })
 

--- a/next/test/validation/enum.test.ts
+++ b/next/test/validation/enum.test.ts
@@ -15,7 +15,6 @@ describe('enum validation', () => {
       {
         path: [],
         validation: 'enum',
-        message: 'The option 4 is not valid.',
       },
     ])
   })
@@ -35,7 +34,6 @@ describe('enum validation', () => {
       {
         path: [],
         validation: 'enum',
-        message: 'The option {"foo":"baz"} is not valid.',
       },
     ])
     expect(validateSchema(1, schema)).toEqual([])
@@ -54,14 +52,12 @@ describe('enum validation', () => {
       {
         path: [],
         validation: 'enum',
-        message: 'The option "other" is not valid.',
       },
     ])
     expect(validateSchema({ foo: 'baz' }, schema)).toEqual([
       {
         path: [],
         validation: 'enum',
-        message: 'The option {"foo":"baz"} is not valid.',
       },
     ])
   })

--- a/next/test/validation/format.test.ts
+++ b/next/test/validation/format.test.ts
@@ -21,10 +21,7 @@ describe('format validation', () => {
     it('should fail for invalid date-time', () => {
       const errors = validateString('not-a-date-time', schema)
       expect(errors).toHaveLength(1)
-      expect(errors[0]).toMatchObject({
-        validation: 'format',
-        message: 'Must be a valid date-time format',
-      })
+      expect(errors[0]).toMatchObject({ validation: 'format' })
     })
 
     it('should pass for non-string values', () => {
@@ -61,10 +58,7 @@ describe('format validation', () => {
       invalidTimes.forEach((time) => {
         const errors = validateString(time, schema)
         expect(errors).toHaveLength(1)
-        expect(errors[0]).toMatchObject({
-          validation: 'format',
-          message: 'Must be a valid time format',
-        })
+        expect(errors[0]).toMatchObject({ validation: 'format' })
       })
     })
 
@@ -116,10 +110,7 @@ describe('format validation', () => {
       invalidDurations.forEach((duration) => {
         const errors = validateString(duration, schema)
         expect(errors).toHaveLength(1)
-        expect(errors[0]).toMatchObject({
-          validation: 'format',
-          message: 'Must be a valid duration format',
-        })
+        expect(errors[0]).toMatchObject({ validation: 'format' })
       })
     })
 
@@ -148,10 +139,7 @@ describe('format validation', () => {
     it('should fail for invalid email', () => {
       const errors = validateString('not-an-email', schema)
       expect(errors).toHaveLength(1)
-      expect(errors[0]).toMatchObject({
-        validation: 'format',
-        message: 'Please enter a valid email address',
-      })
+      expect(errors[0]).toMatchObject({ validation: 'format' })
     })
 
     it('should fail for invalid email formats', () => {
@@ -185,10 +173,7 @@ describe('format validation', () => {
     it('should fail for invalid hostname', () => {
       const errors = validateString('not_a_hostname!', schema)
       expect(errors).toHaveLength(1)
-      expect(errors[0]).toMatchObject({
-        validation: 'format',
-        message: 'Must be a valid hostname format',
-      })
+      expect(errors[0]).toMatchObject({ validation: 'format' })
     })
   })
 
@@ -206,10 +191,7 @@ describe('format validation', () => {
     it('should fail for invalid IPv4', () => {
       const errors = validateString('256.1.2.3', schema)
       expect(errors).toHaveLength(1)
-      expect(errors[0]).toMatchObject({
-        validation: 'format',
-        message: 'Must be a valid ipv4 format',
-      })
+      expect(errors[0]).toMatchObject({ validation: 'format' })
     })
   })
 
@@ -226,10 +208,7 @@ describe('format validation', () => {
     it('should fail for invalid UUID', () => {
       const errors = validateString('not-a-uuid', schema)
       expect(errors).toHaveLength(1)
-      expect(errors[0]).toMatchObject({
-        validation: 'format',
-        message: 'Must be a valid uuid format',
-      })
+      expect(errors[0]).toMatchObject({ validation: 'format' })
     })
   })
 
@@ -247,10 +226,7 @@ describe('format validation', () => {
     it('should fail for invalid URI', () => {
       const errors = validateString('not-a-uri', schema)
       expect(errors).toHaveLength(1)
-      expect(errors[0]).toMatchObject({
-        validation: 'format',
-        message: 'Must be a valid uri format',
-      })
+      expect(errors[0]).toMatchObject({ validation: 'format' })
     })
   })
 

--- a/next/test/validation/number.test.ts
+++ b/next/test/validation/number.test.ts
@@ -21,7 +21,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'type',
-        message: 'The value must be a number',
       },
     ])
 
@@ -29,7 +28,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'type',
-        message: 'The value must be a number',
       },
     ])
 
@@ -37,7 +35,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'type',
-        message: 'The value must be a number',
       },
     ])
   })
@@ -52,7 +49,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'type',
-        message: 'The value must be a number',
       },
     ])
 
@@ -60,7 +56,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'type',
-        message: 'The value must be a number',
       },
     ])
   })
@@ -71,7 +66,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'minimum',
-        message: 'Must be greater or equal to 10',
       },
     ])
 
@@ -80,7 +74,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'maximum',
-        message: 'Must be smaller or equal to 10',
       },
     ])
 
@@ -89,7 +82,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'maximum',
-        message: 'Must be smaller or equal to 10',
       },
     ])
 
@@ -97,7 +89,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'minimum',
-        message: 'Must be greater or equal to 10',
       },
     ])
   })
@@ -108,7 +99,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'exclusiveMinimum',
-        message: 'Must be greater than 10',
       },
     ])
 
@@ -117,7 +107,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'exclusiveMaximum',
-        message: 'Must be smaller than 10',
       },
     ])
 
@@ -130,7 +119,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'exclusiveMaximum',
-        message: 'Must be smaller than 10',
       },
     ])
     expect(
@@ -139,7 +127,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'exclusiveMinimum',
-        message: 'Must be greater than 10',
       },
     ])
 
@@ -149,12 +136,10 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'exclusiveMaximum',
-        message: 'Must be smaller than 10',
       },
       {
         path: [],
         validation: 'exclusiveMinimum',
-        message: 'Must be greater than 10',
       },
     ])
 
@@ -162,7 +147,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'exclusiveMaximum',
-        message: 'Must be smaller than 3',
       },
     ])
   })
@@ -175,7 +159,6 @@ describe('number validation', () => {
       {
         path: [],
         validation: 'multipleOf',
-        message: 'Must be a multiple of 5',
       },
     ])
   })


### PR DESCRIPTION
This PR centralizes generating error messages.

1. `message` is removed from the `ValidationError` interface.
1. There is a new `addErrorMessages` function that 
1. `path` in the `ValidationError` interface now includes the full path to a subschema when a composition keyword like e.g. `anyOf` is used.
   This is needed to look up a schema & value pair in `addErrorMessages` given a path.