### PR TITLE
fix(next): DEVXP-2802: add some simple unit tests that highlight the wrong visibility behavior

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "dev": "tsup --watch",
     "test": "jest",
     "test:watch": "jest --watchAll",
     "test:file": "jest --runTestsByPath",

--- a/next/package.json
+++ b/next/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch",
+    "dev": "NODE_ENV=development tsup --watch",
     "test": "jest",
     "test:watch": "jest --watchAll",
     "test:file": "jest --runTestsByPath",

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -262,7 +262,6 @@ function applyCustomErrorMessages(errors: ValidationErrorWithMessage[], schema: 
  * @returns The validation result
  */
 function validate(value: SchemaValue, schema: JsfSchema, options: ValidationOptions = {}): ValidationResult {
-  debugger
   const result: ValidationResult = {}
   const errors = validateSchema(value, schema, options)
 

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -294,7 +294,8 @@ export function createHeadlessForm(
 ): FormResult {
   const initialValues = options.initialValues || {}
   const fields = buildFields({ schema })
-  // Making sure visibility is set correctly upon form creation
+
+  // Making sure visibility is set correctly upon form creation, for initial values
   updateFieldVisibility(fields, initialValues, schema)
 
   // TODO: check if we need this isError variable exposed
@@ -302,8 +303,10 @@ export function createHeadlessForm(
 
   const handleValidation = (value: SchemaValue) => {
     const result = validate(value, schema, options.validationOptions)
+
     // Updating field visibility based on the new value
     updateFieldVisibility(fields, value, schema, options.validationOptions)
+
     return result
   }
 

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -294,11 +294,15 @@ export function createHeadlessForm(
 ): FormResult {
   const initialValues = options.initialValues || {}
   const fields = buildFields({ schema })
+  // Making sure visibility is set correctly upon form creation
   updateFieldVisibility(fields, initialValues, schema)
+
+  // TODO: check if we need this isError variable exposed
   const isError = false
 
   const handleValidation = (value: SchemaValue) => {
     const result = validate(value, schema, options.validationOptions)
+    // Updating field visibility based on the new value
     updateFieldVisibility(fields, value, schema, options.validationOptions)
     return result
   }

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -294,13 +294,12 @@ export function createHeadlessForm(
 ): FormResult {
   const initialValues = options.initialValues || {}
   const fields = buildFields({ schema })
-  const validationResult = validate(initialValues, schema, options.validationOptions)
-  updateFieldVisibility(fields, validationResult)
+  updateFieldVisibility(fields, initialValues, schema)
   const isError = false
 
   const handleValidation = (value: SchemaValue) => {
     const result = validate(value, schema, options.validationOptions)
-    updateFieldVisibility(fields, result)
+    updateFieldVisibility(fields, value, schema, options.validationOptions)
     return result
   }
 

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -262,6 +262,7 @@ function applyCustomErrorMessages(errors: ValidationErrorWithMessage[], schema: 
  * @returns The validation result
  */
 function validate(value: SchemaValue, schema: JsfSchema, options: ValidationOptions = {}): ValidationResult {
+  debugger
   const result: ValidationResult = {}
   const errors = validateSchema(value, schema, options)
 
@@ -294,12 +295,13 @@ export function createHeadlessForm(
 ): FormResult {
   const initialValues = options.initialValues || {}
   const fields = buildFields({ schema })
-  updateFieldVisibility(fields, initialValues, schema)
+  const validationResult = validate(initialValues, schema, options.validationOptions)
+  updateFieldVisibility(fields, validationResult)
   const isError = false
 
   const handleValidation = (value: SchemaValue) => {
     const result = validate(value, schema, options.validationOptions)
-    updateFieldVisibility(fields, value, schema, options.validationOptions)
+    updateFieldVisibility(fields, result)
     return result
   }
 

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -137,13 +137,19 @@ export function validateSchema(
   const valueIsUndefined = value === undefined || (value === null && options.treatNullAsUndefined)
   const errors: ValidationError[] = []
 
-  if (typeof schema === 'boolean') {
-    return (schema || valueIsUndefined) ? [] : [{ path, validation: 'valid' }]
-  }
-
   // If value is undefined but not required, no further validation needed
   if (valueIsUndefined) {
     return []
+  }
+
+  if (typeof schema === 'boolean') {
+    // It means the property does not exist in the payload
+    if (!schema && typeof value !== 'undefined') {
+      return [{ path, validation: 'valid' }]
+    }
+    else {
+      return []
+    }
   }
 
   const typeValidationErrors = validateType(value, schema, path)

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -137,13 +137,13 @@ export function validateSchema(
   const valueIsUndefined = value === undefined || (value === null && options.treatNullAsUndefined)
   const errors: ValidationError[] = []
 
+  if (typeof schema === 'boolean') {
+    return (schema || valueIsUndefined) ? [] : [{ path, validation: 'valid' }]
+  }
+
   // If value is undefined but not required, no further validation needed
   if (valueIsUndefined) {
     return []
-  }
-
-  if (typeof schema === 'boolean') {
-    return schema ? [] : [{ path, validation: 'valid' }]
   }
 
   const typeValidationErrors = validateType(value, schema, path)

--- a/next/src/visibility.ts
+++ b/next/src/visibility.ts
@@ -1,9 +1,5 @@
 import type { Field } from './field/type'
 import type { FormErrors, ValidationResult } from './form'
-import type { JsfObjectSchema, JsfSchema, NonBooleanJsfSchema, SchemaValue } from './types'
-import type { ValidationOptions } from './validation/schema'
-import { validateSchema } from './validation/schema'
-import { isObjectValue } from './validation/util'
 
 function resetVisibility(fields: Field[]) {
   for (const field of fields) {

--- a/next/src/visibility.ts
+++ b/next/src/visibility.ts
@@ -1,5 +1,119 @@
 import type { Field } from './field/type'
-import type { FormErrors, ValidationResult } from './form'
+import type { JsfObjectSchema, JsfSchema, NonBooleanJsfSchema, SchemaValue } from './types'
+import type { ValidationOptions } from './validation/schema'
+import { validateSchema } from './validation/schema'
+import { isObjectValue } from './validation/util'
+
+/**
+ * Updates field visibility based on JSON schema conditional rules
+ * @param fields - The fields to update
+ * @param values - The current form values
+ * @param schema - The JSON schema definition
+ * @param options - Validation options
+ */
+export function updateFieldVisibility(
+  fields: Field[],
+  values: SchemaValue,
+  schema: JsfObjectSchema,
+  options: ValidationOptions = {},
+) {
+  if (!isObjectValue(values)) {
+    return
+  }
+
+  // Apply rules to current level of fields
+  applySchemaRules(fields, values, schema, options)
+
+  // Process nested object fields that have conditional logic
+  for (const fieldName in schema.properties) {
+    const fieldSchema = schema.properties[fieldName]
+
+    // Only process object schemas with conditional logic (allOf)
+    if (typeof fieldSchema !== 'object' || fieldSchema === null
+      || Array.isArray(fieldSchema) || !fieldSchema.allOf) {
+      continue
+    }
+
+    const objectField = fields.find(field => field.name === fieldSchema.title || field.name === fieldName)
+    if (!objectField || !objectField.fields || objectField.fields.length === 0) {
+      continue
+    }
+
+    const fieldValues = isObjectValue(values[fieldName])
+      ? values[fieldName]
+      : isObjectValue(values[objectField.name]) ? values[objectField.name] : {}
+
+    // Apply rules to nested fields
+    applySchemaRules(objectField.fields, fieldValues, fieldSchema as JsfObjectSchema, options)
+  }
+}
+
+/**
+ * Applies JSON Schema conditional rules to determine field visibility
+ * @param fields - The fields to apply rules to
+ * @param values - The current form values
+ * @param schema - The JSON schema containing the rules
+ * @param options - Validation options
+ *
+ * Fields start with visibility based on their required status.
+ * Conditional rules in the schema's allOf property can then:
+ * - Make fields visible by including them in a required array
+ * - Make fields hidden by setting them to false in properties
+ */
+function applySchemaRules(
+  fields: Field[],
+  values: SchemaValue,
+  schema: JsfObjectSchema,
+  options: ValidationOptions = {},
+) {
+  if (!schema.allOf || !Array.isArray(schema.allOf) || !isObjectValue(values)) {
+    return
+  }
+
+  const conditionalRules = schema.allOf
+    .filter(rule => typeof rule === 'object' && rule !== null && 'if' in rule)
+    .map((rule) => {
+      const ruleObj = rule as NonBooleanJsfSchema
+
+      const ifErrors = validateSchema(values, ruleObj.if!, options)
+      const matches = ifErrors.length === 0
+
+      // Prevent fields from being shown when required fields have type errors
+      let hasTypeErrors = false
+      if (matches
+        && typeof ruleObj.if === 'object'
+        && ruleObj.if !== null
+        && Array.isArray(ruleObj.if.required)) {
+        const requiredFields = ruleObj.if.required
+        hasTypeErrors = requiredFields.some((fieldName) => {
+          if (!schema.properties || !schema.properties[fieldName]) {
+            return false
+          }
+          const fieldSchema = schema.properties[fieldName]
+          const fieldValue = values[fieldName]
+          const fieldErrors = validateSchema(fieldValue, fieldSchema, options)
+          return fieldErrors.some(error => error.validation === 'type')
+        })
+      }
+
+      return { rule: ruleObj, matches: matches && !hasTypeErrors }
+    })
+
+  // for (const field of fields) {
+  //   // Default visibility is based on required status
+  //   let isVisible = field.isVisible ?? true
+
+  resetVisibility(fields)
+
+  for (const { rule, matches } of conditionalRules) {
+    if (matches && rule.then) {
+      processBranch(fields, rule.then)
+    }
+    else if (!matches && rule.else) {
+      processBranch(fields, rule.else)
+    }
+  }
+}
 
 function resetVisibility(fields: Field[]) {
   for (const field of fields) {
@@ -10,41 +124,23 @@ function resetVisibility(fields: Field[]) {
   }
 }
 
-function affectFieldVisibilityOfFields(fields: Field[], formErrors: FormErrors) {
-  for (const fieldName in formErrors) {
-    const error = formErrors[fieldName]
-    if (typeof error === 'string') {
-      if (error === 'Always fails') {
-        const field = fields.find(field => field.name === fieldName)
-        if (field) {
+function processBranch(fields: Field[], branch: JsfSchema) {
+  if (branch.properties) {
+    // cycle through each branch property
+    for (const fieldName in branch.properties) {
+      const fieldSchema = branch.properties[fieldName]
+      const field = fields.find(e => e.name === fieldName)
+      if (field) {
+        if (field?.fields) {
+          processBranch(field.fields, fieldSchema)
+        }
+        else if (fieldSchema === false) {
           field.isVisible = false
+        }
+        else {
+          field.isVisible = true
         }
       }
     }
-    else if (typeof error === 'object') {
-      const fieldset = fields.find(field => field.name === fieldName)
-      if (fieldset?.fields) {
-        affectFieldVisibilityOfFields(fieldset.fields, error)
-      }
-    }
   }
-}
-
-/**
- * Updates field visibility based on JSON schema conditional rules
- * @param fields - The fields to update
- * @param validationResult - The current form errors
- */
-export function updateFieldVisibility(
-  fields: Field[],
-  validationResult: ValidationResult,
-) {
-  resetVisibility(fields)
-  const { formErrors } = validationResult
-
-  if (!formErrors) {
-    return
-  }
-
-  affectFieldVisibilityOfFields(fields, formErrors)
 }

--- a/next/src/visibility.ts
+++ b/next/src/visibility.ts
@@ -1,163 +1,54 @@
 import type { Field } from './field/type'
+import type { FormErrors, ValidationResult } from './form'
 import type { JsfObjectSchema, JsfSchema, NonBooleanJsfSchema, SchemaValue } from './types'
 import type { ValidationOptions } from './validation/schema'
 import { validateSchema } from './validation/schema'
 import { isObjectValue } from './validation/util'
 
+function resetVisibility(fields: Field[]) {
+  for (const field of fields) {
+    field.isVisible = true
+    if (field.fields) {
+      resetVisibility(field.fields)
+    }
+  }
+}
+
+function affectFieldVisibilityOfFields(fields: Field[], formErrors: FormErrors) {
+  for (const fieldName in formErrors) {
+    const error = formErrors[fieldName]
+    if (typeof error === 'string') {
+      if (error === 'Always fails') {
+        const field = fields.find(field => field.name === fieldName)
+        if (field) {
+          field.isVisible = false
+        }
+      }
+    }
+    else if (typeof error === 'object') {
+      const fieldset = fields.find(field => field.name === fieldName)
+      if (fieldset?.fields) {
+        affectFieldVisibilityOfFields(fieldset.fields, error)
+      }
+    }
+  }
+}
+
 /**
  * Updates field visibility based on JSON schema conditional rules
  * @param fields - The fields to update
- * @param values - The current form values
- * @param schema - The JSON schema definition
- * @param options - Validation options
+ * @param validationResult - The current form errors
  */
 export function updateFieldVisibility(
   fields: Field[],
-  values: SchemaValue,
-  schema: JsfObjectSchema,
-  options: ValidationOptions = {},
+  validationResult: ValidationResult,
 ) {
-  if (!isObjectValue(values)) {
+  resetVisibility(fields)
+  const { formErrors } = validationResult
+
+  if (!formErrors) {
     return
   }
 
-  // Apply rules to current level of fields
-  applySchemaRules(fields, values, schema, options)
-
-  // Process nested object fields that have conditional logic
-  for (const fieldName in schema.properties) {
-    const fieldSchema = schema.properties[fieldName]
-
-    // Only process object schemas with conditional logic (allOf)
-    if (typeof fieldSchema !== 'object' || fieldSchema === null
-      || Array.isArray(fieldSchema) || !fieldSchema.allOf) {
-      continue
-    }
-
-    const objectField = fields.find(field => field.name === fieldSchema.title || field.name === fieldName)
-    if (!objectField || !objectField.fields || objectField.fields.length === 0) {
-      continue
-    }
-
-    const fieldValues = isObjectValue(values[fieldName])
-      ? values[fieldName]
-      : isObjectValue(values[objectField.name]) ? values[objectField.name] : {}
-
-    // Apply rules to nested fields
-    applySchemaRules(objectField.fields, fieldValues, fieldSchema as JsfObjectSchema, options)
-
-    // Only process nested fields if parent is visible
-    if (objectField.isVisible) {
-      updateFieldVisibility(
-        objectField.fields,
-        fieldValues,
-        fieldSchema as JsfObjectSchema,
-        options,
-      )
-    }
-  }
-}
-
-/**
- * Applies JSON Schema conditional rules to determine field visibility
- * @param fields - The fields to apply rules to
- * @param values - The current form values
- * @param schema - The JSON schema containing the rules
- * @param options - Validation options
- *
- * Fields start with visibility based on their required status.
- * Conditional rules in the schema's allOf property can then:
- * - Make fields visible by including them in a required array
- * - Make fields hidden by setting them to false in properties
- */
-function applySchemaRules(
-  fields: Field[],
-  values: SchemaValue,
-  schema: JsfObjectSchema,
-  options: ValidationOptions = {},
-) {
-  if (!schema.allOf || !Array.isArray(schema.allOf) || !isObjectValue(values)) {
-    return
-  }
-
-  const conditionalRules = schema.allOf
-    .filter(rule => typeof rule === 'object' && rule !== null && 'if' in rule)
-    .map((rule) => {
-      const ruleObj = rule as NonBooleanJsfSchema
-
-      const ifErrors = validateSchema(values, ruleObj.if!, options)
-      const matches = ifErrors.length === 0
-
-      // Prevent fields from being shown when required fields have type errors
-      let hasTypeErrors = false
-      if (matches
-        && typeof ruleObj.if === 'object'
-        && ruleObj.if !== null
-        && Array.isArray(ruleObj.if.required)) {
-        const requiredFields = ruleObj.if.required
-        hasTypeErrors = requiredFields.some((fieldName) => {
-          if (!schema.properties || !schema.properties[fieldName]) {
-            return false
-          }
-          const fieldSchema = schema.properties[fieldName]
-          const fieldValue = values[fieldName]
-          const fieldErrors = validateSchema(fieldValue, fieldSchema, options)
-          return fieldErrors.some(error => error.validation === 'type')
-        })
-      }
-
-      return { rule: ruleObj, matches: matches && !hasTypeErrors }
-    })
-
-  for (const field of fields) {
-    // Default visibility is based on required status
-    let isVisible = field.required
-
-    for (const { rule, matches } of conditionalRules) {
-      if (matches && rule.then) {
-        isVisible = isFieldVisible(field.name, rule.then, isVisible)
-      }
-      else if (!matches && rule.else) {
-        isVisible = isFieldVisible(field.name, rule.else, isVisible)
-      }
-    }
-
-    field.isVisible = isVisible
-  }
-}
-
-/**
- * Determines whether a field should be visible based on a schema branch
- * @param fieldName - The name of the field
- * @param branch - The schema clause (either 'then' or 'else')
- * @param currentVisibility - The current visibility state
- * @returns The updated visibility state
- *
- * Visibility logic:
- * - If the field is in the required array → make visible
- * - If the field is explicitly false in properties → make hidden
- * - Otherwise, preserve current visibility
- */
-function isFieldVisible(
-  fieldName: string,
-  branch: JsfSchema,
-  currentVisibility: boolean,
-): boolean {
-  let isVisible = currentVisibility
-
-  if (typeof branch === 'object' && branch !== null) {
-    if (Array.isArray(branch.required)) {
-      if (branch.required.includes(fieldName)) {
-        isVisible = true
-      }
-    }
-
-    if (branch.properties !== undefined) {
-      if (fieldName in branch.properties && branch.properties[fieldName] === false) {
-        isVisible = false
-      }
-    }
-  }
-
-  return isVisible
+  affectFieldVisibilityOfFields(fields, formErrors)
 }

--- a/next/test/visibility.test.ts
+++ b/next/test/visibility.test.ts
@@ -4,7 +4,7 @@ import { createHeadlessForm } from '../src'
 
 describe('Field visibility', () => {
   describe('if inside allOf', () => {
-    describe('if no "then" branch is provided', () => {
+    describe('if a "then" branch is not provided', () => {
       const schema: JsfObjectSchema = {
         type: 'object',
         properties: {

--- a/next/test/visibility.test.ts
+++ b/next/test/visibility.test.ts
@@ -151,56 +151,6 @@ describe('Field visibility', () => {
   })
 
   // This does not work with v0 but I think it should work with v1
-  describe('if on object schema level', () => {
-    const schema: JsfObjectSchema = {
-      type: 'object',
-      properties: {
-        name: {
-          type: 'string',
-        },
-        password: {
-          type: 'string',
-        },
-      },
-      if: {
-        properties: {
-          name: {
-            const: 'admin',
-          },
-        },
-        required: ['name'],
-      },
-      else: {
-        properties: {
-          password: false,
-        },
-      },
-    }
-
-    it('should hide the password field by default', () => {
-      const form = createHeadlessForm(schema, { initialValues: { name: '', password: null } })
-      // No name provided
-      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
-
-      // Different name provided
-      form.handleValidation({
-        name: 'some name',
-        password: null,
-      })
-      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
-    })
-
-    it('should show the password field if the name is admin', () => {
-      const form = createHeadlessForm(schema)
-      form.handleValidation({
-        name: 'admin',
-        password: null,
-      })
-      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
-    })
-  })
-
-  // This does not work with v0 but I think it should work with v1
   describe('if on a fieldset schema level', () => {
     const schema: JsfObjectSchema = {
       type: 'object',

--- a/next/test/visibility.test.ts
+++ b/next/test/visibility.test.ts
@@ -4,53 +4,149 @@ import { createHeadlessForm } from '../src'
 
 describe('Field visibility', () => {
   describe('if inside allOf', () => {
-    const schema: JsfObjectSchema = {
-      type: 'object',
-      properties: {
-        name: {
-          type: 'string',
+    describe('if no "then" branch is provided', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          password: {
+            type: 'string',
+          },
         },
-        password: {
-          type: 'string',
-        },
-      },
-      allOf: [
-        {
-          if: {
-            properties: {
-              name: {
-                const: 'admin',
+        allOf: [
+          {
+            if: {
+              properties: {
+                name: {
+                  const: 'admin',
+                },
+              },
+              required: ['name'],
+            },
+            else: {
+              properties: {
+                password: false,
               },
             },
-            required: ['name'],
           },
-          else: {
-            properties: {
-              password: false,
-            },
+        ],
+      }
+
+      it('should hide the password field by default', () => {
+        const form = createHeadlessForm(schema, { initialValues: { name: 'asd', password: null } })
+        expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
+
+        // Different name provided
+        form.handleValidation({
+          name: 'some name',
+          password: null,
+        })
+        expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
+      })
+
+      it('should show the password field if the name is admin', () => {
+        const form = createHeadlessForm(schema)
+        form.handleValidation({
+          name: 'admin',
+        })
+        expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
+      })
+    })
+    describe('if an "else" branch is not provided', () => {
+      const userName = 'user that does not need password field visible'
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          password: {
+            type: 'string',
           },
         },
-      ],
-    }
+        allOf: [
+          {
+            if: {
+              properties: {
+                name: {
+                  const: userName,
+                },
+              },
+              required: ['name'],
+            },
+            then: {
+              properties: {
+                password: false,
+              },
+            },
+          },
+        ],
+      }
 
-    it('should hide the password field by default', () => {
-      const form = createHeadlessForm(schema)
-      // No name provided
-      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
+      it('should show the password field by default', () => {
+        const form = createHeadlessForm(schema)
+        // No name provided
+        expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
 
-      // Different name provided
-      form.handleValidation({
-        name: 'some name',
+        // Different name provided
+        form.handleValidation({
+          name: 'some name',
+        })
+        expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
       })
-      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
+
+      it('should hide the password field if the name is "user that does not need password field visible"', () => {
+        const form = createHeadlessForm(schema, { initialValues: { name: userName, password: null } })
+        expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
+      })
     })
+    describe('if no "else" or "then" branch are provided', () => {
+      const userName = 'admin'
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          password: {
+            type: 'string',
+          },
+        },
+        allOf: [
+          {
+            if: {
+              properties: {
+                name: {
+                  const: userName,
+                },
+              },
+              required: ['name'],
+            },
+          },
+        ],
+      }
 
-    it('should show the password field if the name is admin', () => {
-      const form = createHeadlessForm(schema)
-      form.handleValidation({
-        name: 'admin',
+      it('should show the password field by default', () => {
+        const form = createHeadlessForm(schema)
+        // No name provided
+        expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
+
+        // Different name provided
+        form.handleValidation({
+          name: 'some name',
+        })
+        expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
       })
-      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
+
+      it('should show the password field if the name is "admin"', () => {
+        const form = createHeadlessForm(schema)
+        form.handleValidation({
+          name: userName,
+        })
+        expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
+      })
     })
   })
 
@@ -82,13 +178,14 @@ describe('Field visibility', () => {
     }
 
     it('should hide the password field by default', () => {
-      const form = createHeadlessForm(schema)
+      const form = createHeadlessForm(schema, { initialValues: { name: '', password: null } })
       // No name provided
       expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
 
       // Different name provided
       form.handleValidation({
         name: 'some name',
+        password: null,
       })
       expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
     })
@@ -97,8 +194,74 @@ describe('Field visibility', () => {
       const form = createHeadlessForm(schema)
       form.handleValidation({
         name: 'admin',
+        password: null,
       })
       expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
+    })
+  })
+
+  // This does not work with v0 but I think it should work with v1
+  describe('if on a fieldset schema level', () => {
+    const schema: JsfObjectSchema = {
+      type: 'object',
+      properties: {
+        form: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+            password: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      if: {
+        properties: {
+          form: {
+            properties: {
+              name: {
+                const: 'admin',
+              },
+            },
+            required: ['name'],
+          },
+        },
+        required: ['form'],
+      },
+      else: {
+        properties: {
+          form: {
+            properties: {
+              password: false,
+            },
+          },
+        },
+      },
+    }
+
+    it('should hide the password field by default', () => {
+      const form = createHeadlessForm(schema, { initialValues: { form: { name: '', password: null } } })
+      // No name provided
+      expect(form.fields.find(field => field.name === 'form')?.fields?.find(field => field.name === 'password')?.isVisible).toBe(false)
+
+      // Different name provided
+      form.handleValidation({
+        form: {
+          name: 'some name',
+          password: null,
+        },
+      })
+      expect(form.fields.find(field => field.name === 'form')?.fields?.find(field => field.name === 'password')?.isVisible).toBe(false)
+    })
+
+    it('should show the password field if the name is admin', () => {
+      const form = createHeadlessForm(schema, { initialValues: { form: { name: 'admin', password: null } } })
+      form.handleValidation({
+        name: 'admin',
+      })
+      expect(form.fields.find(field => field.name === 'form')?.fields?.find(field => field.name === 'password')?.isVisible).toBe(true)
     })
   })
 })

--- a/next/test/visibility.test.ts
+++ b/next/test/visibility.test.ts
@@ -1,4 +1,4 @@
-import type { JsfObjectSchema, ObjectValue, SchemaValue } from '../src/types'
+import type { JsfObjectSchema } from '../src/types'
 import { describe, expect, it } from '@jest/globals'
 import { createHeadlessForm } from '../src'
 

--- a/next/test/visibility.test.ts
+++ b/next/test/visibility.test.ts
@@ -3,269 +3,102 @@ import { describe, expect, it } from '@jest/globals'
 import { createHeadlessForm } from '../src'
 
 describe('Field visibility', () => {
-  describe('updateFieldVisibility behavior', () => {
-    it('should keep all fields visible by default without conditional rules', () => {
-      const schema: JsfObjectSchema = {
-        type: 'object',
-        properties: {
-          requiredField: { type: 'string' },
-          optionalField: { type: 'string' },
+  describe('if inside allOf', () => {
+    const schema: JsfObjectSchema = {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
         },
-        required: ['requiredField'],
-      }
-
-      const form = createHeadlessForm(schema)
-
-      const requiredField = form.fields.find(field => field.name === 'requiredField')
-      const optionalField = form.fields.find(field => field.name === 'optionalField')
-
-      expect(requiredField?.isVisible).toBe(true)
-      expect(optionalField?.isVisible).toBe(true)
-    })
-
-    it('should make fields visible when included in required array of conditional rule', () => {
-      const schema: JsfObjectSchema = {
-        type: 'object',
-        properties: {
-          showDetails: { type: 'boolean' },
-          details: { type: 'string' },
+        password: {
+          type: 'string',
         },
-        allOf: [
-          {
-            if: {
-              properties: {
-                showDetails: { const: true },
-              },
-              required: ['showDetails'],
-            },
-            then: {
-              required: ['details'],
-            },
-          },
-        ],
-      }
-
-      const form = createHeadlessForm(schema)
-
-      const detailsField = form.fields.find(field => field.name === 'details')
-      expect(detailsField?.isVisible).toBe(false)
-
-      const value1: ObjectValue = { showDetails: true as unknown as SchemaValue }
-      form.handleValidation(value1)
-      expect(detailsField?.isVisible).toBe(true)
-
-      const value2: ObjectValue = { showDetails: false as unknown as SchemaValue }
-      form.handleValidation(value2)
-      expect(detailsField?.isVisible).toBe(false)
-    })
-
-    it('should hide fields explicitly set to false in properties', () => {
-      const schema: JsfObjectSchema = {
-        type: 'object',
-        properties: {
-          toggle: { type: 'boolean' },
-          alwaysVisible: { type: 'string' },
-        },
-        required: ['alwaysVisible'],
-        allOf: [
-          {
-            if: {
-              properties: {
-                toggle: { const: true },
-              },
-              required: ['toggle'],
-            },
-            then: {
-              properties: {
-                alwaysVisible: false,
-              },
-            },
-          },
-        ],
-      }
-
-      const form = createHeadlessForm(schema)
-
-      const targetField = form.fields.find(field => field.name === 'alwaysVisible')
-      expect(targetField?.isVisible).toBe(true)
-
-      const value: ObjectValue = { toggle: true as unknown as SchemaValue }
-      form.handleValidation(value)
-      expect(targetField?.isVisible).toBe(false)
-    })
-
-    it('should handle nested field visibility', () => {
-      const schema: JsfObjectSchema = {
-        type: 'object',
-        properties: {
-          user: {
-            type: 'object',
+      },
+      allOf: [
+        {
+          if: {
             properties: {
-              type: { type: 'string', enum: ['personal', 'business'] },
-              personalName: { type: 'string' },
-              businessName: { type: 'string' },
+              name: {
+                const: 'admin',
+              },
             },
-            required: ['type'],
-            allOf: [
-              {
-                if: {
-                  properties: {
-                    type: { const: 'personal' },
-                  },
-                  required: ['type'],
-                },
-                then: {
-                  required: ['personalName'],
-                },
-              },
-              {
-                if: {
-                  properties: {
-                    type: { const: 'business' },
-                  },
-                  required: ['type'],
-                },
-                then: {
-                  required: ['businessName'],
-                },
-              },
-            ],
+            required: ['name'],
+          },
+          else: {
+            properties: {
+              password: false,
+            },
           },
         },
-      }
+      ],
+    }
 
-      // We need to initialize with user object explicitly for nested fields
-      const form = createHeadlessForm(schema, { initialValues: { user: {} } })
+    it('should hide the password field by default', () => {
+      const form = createHeadlessForm(schema)
+      // No name provided
+      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
 
-      const userField = form.fields.find(field => field.name === 'user')
-      expect(userField?.fields).toBeTruthy()
-
-      if (userField?.fields) {
-        const typeField = userField.fields.find(f => f.name === 'type')
-        const personalNameField = userField.fields.find(f => f.name === 'personalName')
-        const businessNameField = userField.fields.find(f => f.name === 'businessName')
-
-        expect(typeField?.isVisible).toBe(true)
-        expect(personalNameField?.isVisible).toBe(false)
-        expect(businessNameField?.isVisible).toBe(false)
-
-        const personalValue: ObjectValue = { user: { type: 'personal' } as ObjectValue }
-        form.handleValidation(personalValue)
-        expect(personalNameField?.isVisible).toBe(true)
-        expect(businessNameField?.isVisible).toBe(false)
-
-        const businessValue: ObjectValue = { user: { type: 'business' } as ObjectValue }
-        form.handleValidation(businessValue)
-        expect(personalNameField?.isVisible).toBe(false)
-        expect(businessNameField?.isVisible).toBe(true)
-      }
+      // Different name provided
+      form.handleValidation({
+        name: 'some name',
+      })
+      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
     })
 
-    it('should consider type errors in conditional fields', () => {
-      const schema: JsfObjectSchema = {
-        type: 'object',
-        properties: {
-          count: { type: 'number' },
-          details: { type: 'string' },
-        },
-        allOf: [
-          {
-            if: {
-              properties: {
-                count: { minimum: 1 },
-              },
-              required: ['count'],
-            },
-            then: {
-              required: ['details'],
-            },
-          },
-        ],
-      }
-
+    it('should show the password field if the name is admin', () => {
       const form = createHeadlessForm(schema)
+      form.handleValidation({
+        name: 'admin',
+      })
+      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
+    })
+  })
 
-      const detailsField = form.fields.find(field => field.name === 'details')
-      expect(detailsField?.isVisible).toBe(false)
+  // This does not work with v0 but I think it should work with v1
+  describe('if on object schema level', () => {
+    const schema: JsfObjectSchema = {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        password: {
+          type: 'string',
+        },
+      },
+      if: {
+        properties: {
+          name: {
+            const: 'admin',
+          },
+        },
+        required: ['name'],
+      },
+      else: {
+        properties: {
+          password: false,
+        },
+      },
+    }
 
-      const invalidValue: ObjectValue = { count: 'not-a-number' }
-      form.handleValidation(invalidValue)
-      expect(detailsField?.isVisible).toBe(false)
+    it('should hide the password field by default', () => {
+      const form = createHeadlessForm(schema)
+      // No name provided
+      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
 
-      const validValue: ObjectValue = { count: 2 }
-      form.handleValidation(validValue)
-      expect(detailsField?.isVisible).toBe(true)
+      // Different name provided
+      form.handleValidation({
+        name: 'some name',
+      })
+      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(false)
     })
 
-    it('should handle multiple conditional rules affecting the same field', () => {
-      const schema: JsfObjectSchema = {
-        type: 'object',
-        properties: {
-          isAdult: { type: 'boolean' },
-          hasJob: { type: 'boolean' },
-          salary: { type: 'string' },
-        },
-        allOf: [
-          {
-            if: {
-              properties: {
-                isAdult: { const: true },
-              },
-              required: ['isAdult'],
-            },
-            then: {
-              required: ['hasJob'],
-            },
-          },
-          {
-            if: {
-              properties: {
-                hasJob: { const: true },
-              },
-              required: ['hasJob'],
-            },
-            then: {
-              required: ['salary'],
-            },
-          },
-        ],
-      }
-
+    it('should show the password field if the name is admin', () => {
       const form = createHeadlessForm(schema)
-
-      const hasJobField = form.fields.find(f => f.name === 'hasJob')
-      const salaryField = form.fields.find(f => f.name === 'salary')
-
-      expect(hasJobField?.isVisible).toBe(false)
-      expect(salaryField?.isVisible).toBe(false)
-
-      const value1: ObjectValue = { isAdult: true as unknown as SchemaValue }
-      form.handleValidation(value1)
-      expect(hasJobField?.isVisible).toBe(true)
-      expect(salaryField?.isVisible).toBe(false)
-
-      const value2: ObjectValue = {
-        isAdult: true as unknown as SchemaValue,
-        hasJob: true as unknown as SchemaValue,
-      }
-      form.handleValidation(value2)
-      expect(hasJobField?.isVisible).toBe(true)
-      expect(salaryField?.isVisible).toBe(true)
-
-      const value3: ObjectValue = {
-        isAdult: true as unknown as SchemaValue,
-        hasJob: false as unknown as SchemaValue,
-      }
-      form.handleValidation(value3)
-      expect(hasJobField?.isVisible).toBe(true)
-      expect(salaryField?.isVisible).toBe(false)
-
-      const value4: ObjectValue = {
-        isAdult: false as unknown as SchemaValue,
-      }
-      form.handleValidation(value4)
-      expect(hasJobField?.isVisible).toBe(false)
-      expect(salaryField?.isVisible).toBe(false)
+      form.handleValidation({
+        name: 'admin',
+      })
+      expect(form.fields.find(field => field.name === 'password')?.isVisible).toBe(true)
     })
   })
 })

--- a/next/test/visibility.test.ts
+++ b/next/test/visibility.test.ts
@@ -258,9 +258,9 @@ describe('Field visibility', () => {
 
     it('should show the password field if the name is admin', () => {
       const form = createHeadlessForm(schema, { initialValues: { form: { name: 'admin', password: null } } })
-      form.handleValidation({
+      form.handleValidation({ form: {
         name: 'admin',
-      })
+      } })
       expect(form.fields.find(field => field.name === 'form')?.fields?.find(field => field.name === 'password')?.isVisible).toBe(true)
     })
   })

--- a/next/tsup.config.js
+++ b/next/tsup.config.js
@@ -1,3 +1,7 @@
+import process from 'node:process'
+
+const isDevelopment = process.env.NODE_ENV === 'development'
+
 /** @type {import('tsup').Options} */
 const config = {
   clean: true,
@@ -5,7 +9,7 @@ const config = {
   entry: ['src/index.ts'],
   format: ['esm'],
   sourcemap: true,
-  minify: true,
+  minify: !isDevelopment,
   target: 'es2020',
   outDir: 'dist',
   outExtension() {


### PR DESCRIPTION
## Description

This MR aims to fix some of the problems our _visibility_ calculation had, which happened when evaluating conditional (inside an `if/then/else` statement) visibility of fields inside a `fieldset`:

- tests were added to `visibility.test.ts` to highlight the main behavior we should implement
- a fix was added, and the main logic is:
  - fields are visible by default
  - a field is not visible if a schema for that field is has a `false` boolean value

Some quality of life improvements:
- a `dev` script that runs `tsup` in watch mode
- this script also sets an env variable that disables minification in the final build. This makes setting breakpoints in the consumer app way easier 🤓 