### PR TITLE
chore(v1): validation error message fixes

### DIFF
--- a/next/src/errors/messages.ts
+++ b/next/src/errors/messages.ts
@@ -12,6 +12,9 @@ export function getErrorMessage(
     case 'type':
       return getTypeErrorMessage(schema.type)
     case 'required':
+      if (schema['x-jsf-presentation']?.inputType === 'checkbox') {
+        return 'Please acknowledge this field'
+      }
       return 'Required field'
     case 'valid':
       return 'Always fails'

--- a/next/src/errors/messages.ts
+++ b/next/src/errors/messages.ts
@@ -19,7 +19,7 @@ export function getErrorMessage(
     case 'valid':
       return 'Always fails'
     case 'const':
-      return `The only accepted value is ${JSON.stringify(schema.const)}`
+      return `The only accepted value is ${JSON.stringify(schema.const)}.`
     case 'enum':
       return `The option "${valueToString(value)}" is not valid.`
     // Schema composition

--- a/next/test/errors/messages.test.ts
+++ b/next/test/errors/messages.test.ts
@@ -122,8 +122,8 @@ describe('validation error messages', () => {
       })
 
       expect(result.formErrors).toMatchObject({
-        type: 'The only accepted value is "user"',
-        version: 'The only accepted value is 1',
+        type: 'The only accepted value is "user".',
+        version: 'The only accepted value is 1.',
       })
     })
   })

--- a/next/test/errors/messages.test.ts
+++ b/next/test/errors/messages.test.ts
@@ -50,6 +50,29 @@ describe('validation error messages', () => {
       })
     })
 
+    it('shows required field error messages for checkbox fields', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          consent: {
+            'type': 'string',
+            'const': 'yes',
+            'x-jsf-presentation': {
+              inputType: 'checkbox',
+            },
+          },
+        },
+        required: ['consent'],
+      }
+      const form = createHeadlessForm(schema)
+
+      const result = form.handleValidation({})
+
+      expect(result.formErrors).toMatchObject({
+        consent: 'Please acknowledge this field',
+      })
+    })
+
     it('shows enum validation error messages', () => {
       const schema: JsfObjectSchema = {
         type: 'object',


### PR DESCRIPTION
Fixes two minor inconsistencies
* Unchecked, required checkboxes generate a `Please acknowledge this field` error instead of `Required field`
* `const` validation error messages end with a `.`, i.e. `The only accepted value is 1.`