### PR TITLE
chore: change deprecated `presentation` to `x-jsf-presentation` in test helpers

### DIFF
--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -2521,7 +2521,7 @@ describe('createHeadlessForm', () => {
           .addInput({
             username: {
               ...mockTextInputDeprecated,
-              presentation: {
+              'x-jsf-presentation': {
                 inputType: 'text',
                 maskSecret: 2,
                 // should override the root level description

--- a/src/tests/helpers.custom.js
+++ b/src/tests/helpers.custom.js
@@ -11,7 +11,7 @@ export const schemaInputTypeTextarea = {
   properties: {
     comment: {
       title: 'Your comment',
-      presentation: {
+      'x-jsf-presentation': {
         inputType: 'textarea',
       },
       maxLength: 250,
@@ -29,7 +29,7 @@ export const inputTypeCountriesSolo = {
     { title: 'Algeria', const: 'Algeria' },
   ],
   type: 'string',
-  presentation: {
+  'x-jsf-presentation': {
     inputType: 'countries',
   },
 };
@@ -58,7 +58,7 @@ export const schemaInputTypeCountriesMultiple = {
         ],
       },
       type: 'array',
-      presentation: {
+      'x-jsf-presentation': {
         inputType: 'countries',
       },
     },
@@ -90,7 +90,7 @@ export const schemaInputTypeTel = {
       type: 'string',
       pattern: '^(\\+|00)[0-9]{6,}$',
       maxLength: 30,
-      presentation: {
+      'x-jsf-presentation': {
         inputType: 'tel',
       },
       errorMessage: {
@@ -106,7 +106,7 @@ const mockTelInput = {
   title: 'Phone number',
   description: 'Enter your telephone number',
   maxLength: 30,
-  presentation: {
+  'x-jsf-presentation': {
     inputType: 'tel',
   },
   pattern: '^(\\+|00)\\d*$',
@@ -116,7 +116,7 @@ const mockTelInput = {
 export const mockMoneyInput = {
   title: 'Weekly salary',
   description: 'This field has a min and max values. Max has a custom error message.',
-  presentation: {
+  'x-jsf-presentation': {
     inputType: 'money',
     currency: 'EUR',
   },
@@ -150,7 +150,7 @@ export const schemaCustomComponent = {
     salary: {
       title: 'Monthly gross salary',
       description: 'This field gets represented by a custom UI Component.',
-      presentation: {
+      'x-jsf-presentation': {
         inputType: 'money',
         currency: 'EUR',
       },

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -17,7 +17,7 @@ export const mockTextInputDeprecated = {
   title: 'Username',
   description: 'Your username (max 10 characters)',
   maxLength: 10,
-  presentation: {
+  'x-jsf-presentation': {
     inputType: 'text',
     maskSecret: 2,
   },
@@ -1284,7 +1284,7 @@ export const schemaForErrorMessageSpecificity = {
       title: 'Weekday',
       description: "This text field has the traditional error message. 'Required field'",
       type: 'string',
-      presentation: { inputType: 'text' },
+      'x-jsf-presentation': { inputType: 'text' },
     },
     day: {
       title: 'Day',
@@ -1293,21 +1293,21 @@ export const schemaForErrorMessageSpecificity = {
         'The remaining fields are numbers and were customized to say "This cannot be empty." instead of "Required field".',
 
       maximum: 31,
-      presentation: { inputType: 'number' },
+      'x-jsf-presentation': { inputType: 'number' },
     },
     month: {
       title: 'Month',
       type: 'number',
       minimum: 1,
       maximum: 12,
-      presentation: { inputType: 'number' },
+      'x-jsf-presentation': { inputType: 'number' },
     },
     year: {
       title: 'Year',
       description:
         "This number field has a custom error message declared in the json schema, which has a higher specificity than the one declared in createHeadlessForm's configuration.",
       type: 'number',
-      presentation: { inputType: 'number' },
+      'x-jsf-presentation': { inputType: 'number' },
       'x-jsf-errorMessage': {
         required: 'The year is mandatory.',
       },


### PR DESCRIPTION
This changes all test helpers to use `x-jsf-presentation` instead of the deprecated `presentation` so that they can be used with the next version.