### PR TITLE
feat(next): Add date validation

### DIFF
--- a/next/src/errors/index.ts
+++ b/next/src/errors/index.ts
@@ -21,6 +21,10 @@ export type SchemaValidationErrorType =
    * Number validation keywords
    */
   | 'multipleOf' | 'maximum' | 'exclusiveMaximum' | 'minimum' | 'exclusiveMinimum'
+  /**
+   * Date validation keywords
+   */
+  | 'minDate' | 'maxDate'
 
 export type ValidationErrorPath = Array<string | number>
 

--- a/next/src/errors/messages.ts
+++ b/next/src/errors/messages.ts
@@ -1,6 +1,7 @@
 import type { SchemaValidationErrorType } from '.'
 import type { JsfSchemaType, NonBooleanJsfSchema, SchemaValue } from '../types'
 import { randexp } from 'randexp'
+import { DATE_FORMAT } from '../validation/custom/date'
 
 export function getErrorMessage(
   schema: NonBooleanJsfSchema,
@@ -40,6 +41,12 @@ export function getErrorMessage(
       if (schema.format === 'email') {
         return 'Please enter a valid email address'
       }
+
+      if (schema.format === 'date') {
+        const currentDate = new Date().toISOString().split('T')[0]
+        return `Must be a valid date in ${DATE_FORMAT.toLowerCase()} format. e.g. ${currentDate}`
+      }
+
       return `Must be a valid ${schema.format} format`
     // Number validation
     case 'multipleOf':

--- a/next/src/errors/messages.ts
+++ b/next/src/errors/messages.ts
@@ -52,6 +52,11 @@ export function getErrorMessage(
       return `Must be greater or equal to ${schema.minimum}`
     case 'exclusiveMinimum':
       return `Must be greater than ${schema.exclusiveMinimum}`
+      // Date validation
+    case 'minDate':
+      return `The date must be ${schema['x-jsf-presentation']?.minDate} or after.`
+    case 'maxDate':
+      return `The date must be ${schema['x-jsf-presentation']?.maxDate} or before.`
   }
 }
 

--- a/next/src/validation/custom/date.ts
+++ b/next/src/validation/custom/date.ts
@@ -69,24 +69,21 @@ export function validateDate(
   const isEmptyString = value === ''
   const isUndefined = value === undefined || (value === null && options.treatNullAsUndefined)
   const isEmpty = isEmptyString || isUndefined
+  const errors: ValidationError[] = []
 
   if (!isString || isEmpty || schema['x-jsf-presentation'] === undefined) {
-    return []
+    return errors
   }
 
   const { minDate, maxDate } = schema['x-jsf-presentation']
 
   if (minDate && !validateMinDate(value, minDate)) {
-    return [
-      { path, validation: 'minDate' },
-    ]
+    errors.push({ path, validation: 'minDate' })
   }
 
   if (maxDate && !validateMaxDate(value, maxDate)) {
-    return [
-      { path, validation: 'maxDate' },
-    ]
+    errors.push({ path, validation: 'maxDate' })
   }
 
-  return []
+  return errors
 }

--- a/next/src/validation/custom/date.ts
+++ b/next/src/validation/custom/date.ts
@@ -2,7 +2,7 @@ import type { ValidationError, ValidationErrorPath } from '../../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../../types'
 import type { ValidationOptions } from '../schema'
 
-export const DEFAULT_DATE_FORMAT = 'yyyy-MM-dd'
+export const DATE_FORMAT = 'yyyy-MM-dd'
 type DateComparisonResult = 'LESSER' | 'GREATER' | 'EQUAL'
 
 /**
@@ -34,7 +34,6 @@ function compareDates(d1: string, d2: string): DateComparisonResult {
  */
 function validateMinDate(value: string, minDate: string): boolean {
   const result = compareDates(value, minDate)
-
   return result === 'GREATER' || result === 'EQUAL'
 };
 

--- a/next/src/validation/custom/date.ts
+++ b/next/src/validation/custom/date.ts
@@ -53,6 +53,7 @@ function validateMaxDate(value: string, maxDate: string): boolean {
  * Validate that a date value is valid
  * @param value - The value to validate
  * @param schema - The schema to validate against
+ * @param options - The validation options
  * @param path - The path to the value
  * @returns An array of validation errors
  * @description This function validates that a dat string value matches the maximum

--- a/next/src/validation/custom/date.ts
+++ b/next/src/validation/custom/date.ts
@@ -1,0 +1,92 @@
+import type { ValidationError, ValidationErrorPath } from '../../errors'
+import type { NonBooleanJsfSchema, SchemaValue } from '../../types'
+import type { ValidationOptions } from '../schema'
+
+export const DEFAULT_DATE_FORMAT = 'yyyy-MM-dd'
+type DateComparisonResult = 'LESSER' | 'GREATER' | 'EQUAL'
+
+/**
+ * Compare two dates and returns the ComparisonResult (LESSER, GREATER, EQUAL)
+ * @param d1 - The first date
+ * @param d2 - The second date
+ * @returns 'LESSER' if the first date is less than the second date, 'GREATER' if the first date is greater than the second date, 'EQUAL' if the two dates are equal
+ */
+function compareDates(d1: string, d2: string): DateComparisonResult {
+  const date1 = new Date(d1).getTime()
+  const date2 = new Date(d2).getTime()
+
+  if (date1 < date2) {
+    return 'LESSER'
+  }
+  else if (date1 > date2) {
+    return 'GREATER'
+  }
+  else {
+    return 'EQUAL'
+  }
+};
+
+/**
+ * Validate that a date value is greater than or equal to the minimum date
+ * @param value - The value to validate
+ * @param minDate - The minimum date to validate against
+ * @returns true if the date is greater than or equal to the minimum date, false otherwise
+ */
+function validateMinDate(value: string, minDate: string): boolean {
+  const result = compareDates(value, minDate)
+
+  return result === 'GREATER' || result === 'EQUAL'
+};
+
+/**
+ * Validate that a date value is less than or equal to the maximum date
+ * @param value - The value to validate
+ * @param maxDate - The maximum date to validate against
+ * @returns true if the date is less than or equal to the maximum date, false otherwise
+ */
+function validateMaxDate(value: string, maxDate: string): boolean {
+  const result = compareDates(value, maxDate)
+
+  return result === 'LESSER' || result === 'EQUAL'
+};
+
+/**
+ * Validate that a date value is valid
+ * @param value - The value to validate
+ * @param schema - The schema to validate against
+ * @param path - The path to the value
+ * @returns An array of validation errors
+ * @description This function validates that a dat string value matches the maximum
+ * and minimum date set in the x-jsf-presentation property.
+ */
+export function validateDate(
+  value: SchemaValue,
+  schema: NonBooleanJsfSchema,
+  options: ValidationOptions,
+  path: ValidationErrorPath = [],
+): ValidationError[] {
+  const isString = typeof value === 'string'
+  const isEmptyString = value === ''
+  const isUndefined = value === undefined || (value === null && options.treatNullAsUndefined)
+  const isEmpty = isEmptyString || isUndefined
+
+  if (!isString || isEmpty || schema['x-jsf-presentation'] === undefined) {
+    return []
+  }
+
+  const { minDate, maxDate } = schema['x-jsf-presentation']
+
+  if (minDate && !validateMinDate(value, minDate)) {
+    return [
+      { path, validation: 'minDate' },
+    ]
+  }
+
+  if (maxDate && !validateMaxDate(value, maxDate)) {
+    return [
+      { path, validation: 'maxDate' },
+    ]
+  }
+
+  return []
+}

--- a/next/src/validation/custom/date.ts
+++ b/next/src/validation/custom/date.ts
@@ -56,7 +56,7 @@ function validateMaxDate(value: string, maxDate: string): boolean {
  * @param options - The validation options
  * @param path - The path to the value
  * @returns An array of validation errors
- * @description This function validates that a dat string value matches the maximum
+ * @description This function validates that a date string value matches the maximum
  * and minimum date set in the x-jsf-presentation property.
  */
 export function validateDate(

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -3,6 +3,7 @@ import type { JsfSchema, JsfSchemaType, SchemaValue } from '../types'
 import { validateAllOf, validateAnyOf, validateNot, validateOneOf } from './composition'
 import { validateCondition } from './conditions'
 import { validateConst } from './const'
+import { validateDate } from './custom/date'
 import { validateEnum } from './enum'
 import { validateNumber } from './number'
 import { validateObject } from './object'
@@ -176,6 +177,7 @@ export function validateSchema(
 
   return [
     ...errors,
+    // JSON-schema spec validations
     ...validateConst(value, schema, path),
     ...validateEnum(value, schema, path),
     ...validateObject(value, schema, options, path),
@@ -186,5 +188,7 @@ export function validateSchema(
     ...validateAnyOf(value, schema, options, path),
     ...validateOneOf(value, schema, options, path),
     ...validateCondition(value, schema, options, path),
+    // Custom validations
+    ...validateDate(value, schema, options, path),
   ]
 }


### PR DESCRIPTION
# Date Validation Support

## Changes
- Added date validation support with `minDate` and `maxDate` constraints on the `x-jsf-presentation` property
- Added custom date format validation messages
- Added new error types for date validation
- Added test coverage for date validation scenarios


## Example Usage
```typescript
const schema = {
  type: 'string',
  format: 'date',
  'x-jsf-presentation': {
    minDate: '2022-01-01',
    maxDate: '2022-12-31'
  }
}
```

## Error Messages
- Invalid format: "Must be a valid date in yyyy-mm-dd format. e.g. 2024-03-21"
- Min date violation: "The date must be 2022-01-01 or after."
- Max date violation: "The date must be 2022-12-31 or before."
