### PR TITLE
fix(next): only skip dropdown options with an explicit null const value

### DIFF
--- a/next/src/field/schema.ts
+++ b/next/src/field/schema.ts
@@ -32,7 +32,7 @@ function getJsonType(schema: NonBooleanJsfSchema): string {
 function convertToOptions(nodeOptions: JsfSchema[]): Array<FieldOption> {
   return nodeOptions
     .filter((option): option is NonBooleanJsfSchema =>
-      'const' in option && option.const !== undefined && option.const !== null,
+      option !== null && typeof option === 'object' && option.const !== null,
     )
     .map((schemaOption) => {
       const title = schemaOption.title

--- a/next/test/fields.test.ts
+++ b/next/test/fields.test.ts
@@ -246,7 +246,7 @@ describe('fields', () => {
       ])
     })
 
-    it('skips options without a const value', () => {
+    it('skips options without a null const value', () => {
       const schema = {
         type: 'object',
         properties: {
@@ -278,6 +278,7 @@ describe('fields', () => {
           options: [
             { label: 'Active', value: 'active' },
             { label: 'Inactive', value: 'inactive' },
+            { label: 'Undefined', value: undefined },
           ],
         },
       ])


### PR DESCRIPTION
The filtering of options implemented in !158 which skips options that have either no const value or a null const value breaks schemas such as the following:

```json
{
  "properties": {
    "phone_number": {
      "title": "Phone number",
      "description": "Enter your telephone number",
      "type": "string",
      "x-jsf-presentation": {
        "inputType": "tel"
      },
      "oneOf": [
        {
          "title": "Portugal",
          "pattern": "^(\\+351)[0-9]{9,}$",
          "x-jsf-presentation": {
            "meta": {
              "countryCode": "351"
            }
          }
        },
        {
          "title": "United Kingdom (UK)",
          "pattern": "^(\\+44)[0-9]{1,}$",
          "x-jsf-presentation": {
            "meta": {
              "countryCode": "44"
            }
          }
        },
        {
          "title": "Bolivia",
          "pattern": "^(\\+591)[0-9]{9,}$",
          "x-jsf-presentation": {
            "meta": {
              "countryCode": "591"
            }
          }
        },
        {
          "title": "Canada",
          "pattern": "^(\\+1)(206|224)[0-9]{1,}$",
          "x-jsf-presentation": {
            "meta": {
              "countryCode": "1"
            }
          }
        },
        {
          "title": "United States",
          "pattern": "^(\\+1)[0-9]{1,}$",
          "x-jsf-presentation": {
            "meta": {
              "countryCode": "1"
            }
          }
        }
      ]
    }
  }
}
```