### PR TITLE
fix: include description when building fieldset Field

### DIFF
--- a/next/src/field/object.ts
+++ b/next/src/field/object.ts
@@ -38,6 +38,10 @@ export function buildFieldObject(schema: JsfObjectSchema, name: string, required
     field.label = schema.title
   }
 
+  if (schema.description !== undefined) {
+    field.description = schema.description
+  }
+
   if (schema['x-jsf-presentation']?.accept) {
     field.accept = schema['x-jsf-presentation']?.accept
   }

--- a/next/test/fields.test.ts
+++ b/next/test/fields.test.ts
@@ -42,6 +42,7 @@ describe('fields', () => {
     const schema = {
       type: 'object',
       title: 'User',
+      description: 'User information',
       properties: {
         name: { type: 'string', title: 'Name' },
         age: { type: 'number', title: 'Age' },
@@ -58,6 +59,7 @@ describe('fields', () => {
       isVisible: true,
       name: 'user',
       label: 'User',
+      description: 'User information',
       required: false,
       jsonType: 'object',
       fields: [


### PR DESCRIPTION
# Adds description field support 

## Changes
- Added support for `description` field in JSON Schema objects
- The description field is now properly parsed and included in the form field metadata
- Updated tests to verify description handling

