### PR TITLE
fix(next): version number

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@remoteoss/json-schema-form",
   "type": "module",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "packageManager": "pnpm@9.15.2",
   "description": "WIP V2 – Headless UI form powered by JSON Schemas",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",


### PR DESCRIPTION
Correcting the version number for `next` as we already have a `beta.2` version released on NPM. 

It was released 3 months ago so it was probably done while we setup the release process. 

This PR corrects the version number in the `package.json` so we can start releasing `beta` versions normally.