### PR TITLE
feat(next): custom validations with json logic inner conditionals

### DIFF
--- a/next/src/mutations.ts
+++ b/next/src/mutations.ts
@@ -6,7 +6,7 @@ import { validateSchema } from './validation/schema'
 import { isObjectValue } from './validation/util'
 
 /**
- * Updates field visibility based on JSON schema conditional rules
+ * Updates field properties based on JSON schema conditional rules
  * @param fields - The fields to update
  * @param values - The current form values
  * @param schema - The JSON schema definition
@@ -72,14 +72,11 @@ function evaluateConditional(
 }
 
 /**
- * Applies JSON Schema conditional rules to determine field visibility
+ * Applies JSON Schema conditional rules to determine updated field properties
  * @param fields - The fields to apply rules to
  * @param values - The current form values
  * @param schema - The JSON schema containing the rules
  * @param options - Validation options
- *
- * Fields start visible by default, and they're set to hidden if their schema is
- * set to false (a falsy schema means the schema fails whenever a value is sent for that field)
  *
  */
 function applySchemaRules(
@@ -121,7 +118,7 @@ function applySchemaRules(
 }
 
 /**
- * Processes a branch of a conditional rule, updating the visibility of fields based on the branch's schema
+ * Processes a branch of a conditional rule, updating the properties of fields based on the branch's schema
  * @param fields - The fields to process
  * @param values - The current form values
  * @param branch - The branch (schema representing and then/else) to process
@@ -129,8 +126,9 @@ function applySchemaRules(
  */
 function processBranch(fields: Field[], values: SchemaValue, branch: JsfSchema, options: ValidationOptions = {}) {
   if (branch.properties) {
-    // Cycle through each property in the schema and search for any (possibly nested)
-    // fields that have a false boolean schema. If found, set the field's visibility to false
+    // Cycle through each property in the schema and search for any property that needs
+    // to be updated in the fields collection.
+    // Note: False schemas mean the field should be hidden in the form (isVisible = false)
     for (const fieldName in branch.properties) {
       const fieldSchema = branch.properties[fieldName]
       const field = fields.find(e => e.name === fieldName)

--- a/next/src/types.ts
+++ b/next/src/types.ts
@@ -29,12 +29,13 @@ export type JsfPresentation = {
   [key: string]: unknown
 }
 
-export interface JsonLogicBag {
-  schema: JsonLogicSchema
+export interface JsonLogicContext {
+  schema: JsonLogicRules
   value: SchemaValue
 }
 
-export interface JsonLogicSchema {
+// x-jsf-logic schema can have validations/computedValues as well as conditional rules present in any JSON Schema
+export interface JsonLogicRules {
   validations?: Record<string, {
     errorMessage?: string
     rule: RulesLogic
@@ -43,6 +44,9 @@ export interface JsonLogicSchema {
     rule: RulesLogic
   }>
 }
+export interface JsonLogicRootSchema extends Pick<NonBooleanJsfSchema, 'if' | 'then' | 'else' | 'allOf' | 'anyOf' | 'oneOf' | 'not'> {}
+
+export interface JsonLogicSchema extends JsonLogicRules, JsonLogicRootSchema {}
 
 /**
  * JSON Schema Form extending JSON Schema with additional JSON Schema Form properties.

--- a/next/src/validation/array.ts
+++ b/next/src/validation/array.ts
@@ -1,5 +1,5 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { JsfSchema, JsonLogicBag, NonBooleanJsfSchema, SchemaValue } from '../types'
+import type { JsfSchema, JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema, type ValidationOptions } from './schema'
 import { deepEqual } from './util'
 
@@ -8,7 +8,7 @@ import { deepEqual } from './util'
  * @param value - The value to validate
  * @param schema - The schema to validate against
  * @param options - The validation options
- * @param jsonLogicBag - The JSON logic bag
+ * @param jsonLogicContext - The JSON logic context
  * @param path - The path to the current field being validated
  * @returns An array of validation errors
  * @description
@@ -19,7 +19,7 @@ export function validateArray(
   value: SchemaValue,
   schema: JsfSchema,
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
   if (!Array.isArray(value)) {
@@ -29,9 +29,9 @@ export function validateArray(
   return [
     ...validateLength(schema, value, path),
     ...validateUniqueItems(schema, value, path),
-    ...validateContains(value, schema, options, jsonLogicBag, path),
-    ...validatePrefixItems(schema, value, options, jsonLogicBag, path),
-    ...validateItems(schema, value, options, jsonLogicBag, path),
+    ...validateContains(value, schema, options, jsonLogicContext, path),
+    ...validatePrefixItems(schema, value, options, jsonLogicContext, path),
+    ...validateItems(schema, value, options, jsonLogicContext, path),
   ]
 }
 
@@ -71,7 +71,7 @@ function validateLength(
  * @param schema - The schema to validate against
  * @param values - The array value to validate
  * @param options - The validation options
- * @param jsonLogicBag - The JSON logic bag
+ * @param jsonLogicContext - The JSON logic context
  * @param path - The path to the current field being validated
  * @returns An array of validation errors
  * @description
@@ -83,7 +83,7 @@ function validateItems(
   schema: NonBooleanJsfSchema,
   values: SchemaValue[],
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
   if (schema.items === undefined) {
@@ -100,7 +100,7 @@ function validateItems(
         schema.items,
         options,
         [...path, 'items', i + startIndex],
-        jsonLogicBag,
+        jsonLogicContext,
       ),
     )
   }
@@ -113,7 +113,7 @@ function validateItems(
  * @param schema - The schema to validate against
  * @param values - The array value to validate
  * @param options - The validation options
- * @param jsonLogicBag - The JSON logic bag
+ * @param jsonLogicContext - The JSON logic context
  * @param path - The path to the current field being validated
  * @returns An array of validation errors
  * @description
@@ -124,7 +124,7 @@ function validatePrefixItems(
   schema: NonBooleanJsfSchema,
   values: SchemaValue[],
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
   if (!Array.isArray(schema.prefixItems)) {
@@ -140,7 +140,7 @@ function validatePrefixItems(
           schema.prefixItems[i] as JsfSchema,
           options,
           [...path, 'prefixItems', i],
-          jsonLogicBag,
+          jsonLogicContext,
         ),
       )
     }
@@ -154,7 +154,7 @@ function validatePrefixItems(
  * @param value - The array value to validate
  * @param schema - The schema to validate against
  * @param options - The validation options
- * @param jsonLogicBag - The JSON logic bag
+ * @param jsonLogicContext - The JSON logic context
  * @param path - The path to the current field being validated
  * @returns An array of validation errors
  * @description
@@ -165,7 +165,7 @@ function validateContains(
   value: SchemaValue[],
   schema: NonBooleanJsfSchema,
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
   if (!('contains' in schema)) {
@@ -182,7 +182,7 @@ function validateContains(
         schema.contains as JsfSchema,
         options,
         [...path, 'contains'],
-        jsonLogicBag,
+        jsonLogicContext,
       ).length === 0,
   ).length
 

--- a/next/src/validation/composition.ts
+++ b/next/src/validation/composition.ts
@@ -7,7 +7,7 @@
 
 import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { ValidationOptions } from '../form'
-import type { JsfSchema, JsonLogicBag, SchemaValue } from '../types'
+import type { JsfSchema, JsonLogicContext, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 
 /**
@@ -30,7 +30,7 @@ export function validateAllOf(
   value: SchemaValue,
   schema: JsfSchema,
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (!schema.allOf) {
@@ -39,7 +39,7 @@ export function validateAllOf(
 
   for (let i = 0; i < schema.allOf.length; i++) {
     const subSchema = schema.allOf[i]
-    const errors = validateSchema(value, subSchema, options, [...path, 'allOf', i], jsonLogicBag)
+    const errors = validateSchema(value, subSchema, options, [...path, 'allOf', i], jsonLogicContext)
     if (errors.length > 0) {
       return errors
     }
@@ -68,7 +68,7 @@ export function validateAnyOf(
   value: SchemaValue,
   schema: JsfSchema,
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (!schema.anyOf) {
@@ -76,7 +76,7 @@ export function validateAnyOf(
   }
 
   for (const subSchema of schema.anyOf) {
-    const errors = validateSchema(value, subSchema, options, path, jsonLogicBag)
+    const errors = validateSchema(value, subSchema, options, path, jsonLogicContext)
     if (errors.length === 0) {
       return []
     }
@@ -110,7 +110,7 @@ export function validateOneOf(
   value: SchemaValue,
   schema: JsfSchema,
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (!schema.oneOf) {
@@ -120,7 +120,7 @@ export function validateOneOf(
   let validCount = 0
 
   for (let i = 0; i < schema.oneOf.length; i++) {
-    const errors = validateSchema(value, schema.oneOf[i], options, path, jsonLogicBag)
+    const errors = validateSchema(value, schema.oneOf[i], options, path, jsonLogicContext)
     if (errors.length === 0) {
       validCount++
       if (validCount > 1) {
@@ -171,7 +171,7 @@ export function validateNot(
   value: SchemaValue,
   schema: JsfSchema,
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (schema.not === undefined) {
@@ -182,6 +182,6 @@ export function validateNot(
     return schema.not ? [{ path, validation: 'not' }] : []
   }
 
-  const notErrors = validateSchema(value, schema.not, options, path, jsonLogicBag)
+  const notErrors = validateSchema(value, schema.not, options, path, jsonLogicContext)
   return notErrors.length === 0 ? [{ path, validation: 'not' }] : []
 }

--- a/next/src/validation/conditions.ts
+++ b/next/src/validation/conditions.ts
@@ -1,27 +1,27 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { ValidationOptions } from '../form'
-import type { JsonLogicBag, NonBooleanJsfSchema, SchemaValue } from '../types'
+import type { JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 
 export function validateCondition(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (schema.if === undefined) {
     return []
   }
 
-  const conditionIsTrue = validateSchema(value, schema.if, options, path, jsonLogicBag).length === 0
+  const conditionIsTrue = validateSchema(value, schema.if, options, path, jsonLogicContext).length === 0
 
   if (conditionIsTrue && schema.then !== undefined) {
-    return validateSchema(value, schema.then, options, [...path, 'then'], jsonLogicBag)
+    return validateSchema(value, schema.then, options, [...path, 'then'], jsonLogicContext)
   }
 
   if (!conditionIsTrue && schema.else !== undefined) {
-    return validateSchema(value, schema.else, options, [...path, 'else'], jsonLogicBag)
+    return validateSchema(value, schema.else, options, [...path, 'else'], jsonLogicContext)
   }
 
   return []

--- a/next/src/validation/json-logic.ts
+++ b/next/src/validation/json-logic.ts
@@ -1,5 +1,5 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { JsonLogicBag, NonBooleanJsfSchema } from '../types'
+import type { JsonLogicContext, NonBooleanJsfSchema } from '../types'
 import jsonLogic from 'json-logic-js'
 
 /**
@@ -20,11 +20,11 @@ function replaceUndefinedValuesWithNulls(values: any = {}) {
  * Validates the JSON Logic for a given schema.
  *
  * @param {NonBooleanJsfSchema} schema - The JSON Schema to validate.
- * @param {JsonLogicBag | undefined} jsonLogicBag - The JSON Logic bag.
+ * @param {JsonLogicContext | undefined} jsonLogicContext - The JSON Logic context.
  */
 export function validateJsonLogic(
   schema: NonBooleanJsfSchema,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   const validations = schema['x-jsf-logic-validations']
@@ -35,8 +35,8 @@ export function validateJsonLogic(
   }
 
   return validations.map((validation: string) => {
-    const validationData = jsonLogicBag?.schema?.validations?.[validation]
-    const formValue = jsonLogicBag?.value
+    const validationData = jsonLogicContext?.schema?.validations?.[validation]
+    const formValue = jsonLogicContext?.value
 
     if (!validationData) {
       return []

--- a/next/src/validation/object.ts
+++ b/next/src/validation/object.ts
@@ -9,7 +9,7 @@ import { isObjectValue } from './util'
  * @param value - The value to validate
  * @param schema - The schema to validate against
  * @param options - The validation options
- * @param jsonLogicBag - The JSON Logic bag
+ * @param jsonLogicContext - The JSON Logic context
  * @param path - The path to the current field being validated
  * @returns An array of validation errors
  * @description

--- a/next/src/validation/object.ts
+++ b/next/src/validation/object.ts
@@ -1,6 +1,6 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { ValidationOptions } from '../form'
-import type { JsonLogicBag, NonBooleanJsfSchema, SchemaValue } from '../types'
+import type { JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 import { isObjectValue } from './util'
 
@@ -20,13 +20,13 @@ export function validateObject(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
   options: ValidationOptions,
-  jsonLogicBag: JsonLogicBag | undefined,
+  jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (typeof schema === 'object' && schema.properties && isObjectValue(value)) {
     const errors = []
     for (const [key, propertySchema] of Object.entries(schema.properties)) {
-      errors.push(...validateSchema(value[key], propertySchema, options, [...path, key], jsonLogicBag))
+      errors.push(...validateSchema(value[key], propertySchema, options, [...path, key], jsonLogicContext))
     }
     return errors
   }

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -179,7 +179,7 @@ export function validateSchema(
       value,
     }
     // - We need to validate any schema that's in the 'x-jsf-logic' property, like if/then/else/allOf/etc.
-    // This is done below in the recursive validateSchema call.
+    // This is done below in the validateJsonLogicSchema call.
     jsonLogicRootSchema = rest
   }
 

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -161,8 +161,8 @@ export function validateSchema(
       schema: JsonLogicBagSchema,
       value,
     }
-    // - We need to validate the actual schema that's in the 'x-jsf-logic' property
-    // (done below in the recursive validateSchema call)
+    // - We need to validate any schema that's in the 'x-jsf-logic' property, like if/then/else/allOf/etc.
+    // This is done below in the recursive validateSchema call.
     jsonLogicRootSchema = rest
   }
 

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -111,6 +111,23 @@ function validateType(
 }
 
 /**
+ * Validate a value against a json-logic schema (inner conditions inside a 'x-jsf-logic' property)
+ * @param value - The value to validate
+ * @param schema - The schema to validate against
+ * @param options - The validation options
+ * @param path - The path to the current field being validated
+ * @param jsonLogicContext - The json-logic context
+ * @returns An array of validation errors
+ */
+function validateJsonLogicSchema(value: SchemaValue, schema: JsfSchema | undefined, options: ValidationOptions = {}, path: ValidationErrorPath = [], jsonLogicContext?: JsonLogicContext): ValidationError[] {
+  if (!schema) {
+    return []
+  }
+
+  return validateSchema(value, schema, options, path, jsonLogicContext)
+}
+
+/**
  * Validate a value against a schema
  * @param value - The value to validate
  * @param schema - The schema to validate against
@@ -229,7 +246,8 @@ export function validateSchema(
     ...validateCondition(value, schema, options, jsonLogicContext, path),
     // Custom validations
     ...validateDate(value, schema, options, path),
-    ...(jsonLogicRootSchema ? validateSchema(value, jsonLogicRootSchema, options, path, jsonLogicContext) : []),
+    ...validateJsonLogicSchema(value, jsonLogicRootSchema, options, path, jsonLogicContext),
+    // If we have a jsonLogicContext, we should validate the json-logic
     ...validateJsonLogic(schema, jsonLogicContext, path),
   ]
 }

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -170,12 +170,12 @@ export function validateSchema(
   // If not, it probably means the current schema is the root schema (or that there's no json-logic node in the current schema)
   if (!rootJsonLogicContext && schema['x-jsf-logic']) {
     // - We should set the jsonLogicContext's schema as the schema in the 'x-jsf-logic' property
-    const { validations, computedValues, ...rest } = schema['x-jsf-logic']
-    const JsonLogicBagSchema: JsonLogicRules = {
+    const { validations, computedValues: _, ...rest } = schema['x-jsf-logic']
+    const jsonLogicRules: JsonLogicRules = {
       validations,
     }
     jsonLogicContext = {
-      schema: JsonLogicBagSchema,
+      schema: jsonLogicRules,
       value,
     }
     // - We need to validate any schema that's in the 'x-jsf-logic' property, like if/then/else/allOf/etc.
@@ -247,7 +247,6 @@ export function validateSchema(
     // Custom validations
     ...validateDate(value, schema, options, path),
     ...validateJsonLogicSchema(value, jsonLogicRootSchema, options, path, jsonLogicContext),
-    // If we have a jsonLogicContext, we should validate the json-logic
     ...validateJsonLogic(schema, jsonLogicContext, path),
   ]
 }

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -112,6 +112,7 @@ function validateType(
 
 /**
  * Validate a value against a json-logic schema (inner conditions inside a 'x-jsf-logic' property)
+ * Note: for this validator, the schema might be absent, so we return early in that case.
  * @param value - The value to validate
  * @param schema - The schema to validate against
  * @param options - The validation options

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -150,7 +150,7 @@ export function validateSchema(
   let jsonLogicRootSchema: JsonLogicRootSchema | undefined
 
   // If we have a root jsonLogicContext, we shoud use that.
-  // If not, it probably means the current schema is the root schema (or that there's not json-logic node in the current schema)
+  // If not, it probably means the current schema is the root schema (or that there's no json-logic node in the current schema)
   if (!rootJsonLogicContext && schema['x-jsf-logic']) {
     // - We should set the jsonLogicContext's schema as the schema in the 'x-jsf-logic' property
     const { validations, computedValues, ...rest } = schema['x-jsf-logic']

--- a/next/test/validation/json-logic.test.ts
+++ b/next/test/validation/json-logic.test.ts
@@ -240,7 +240,7 @@ describe('validateJsonLogic', () => {
       }, [])
     })
 
-    it('should call json logic apply fn when "x-jsf-logic-validations" is present', () => {
+    it('should call json logic\'s apply function fn when "x-jsf-logic-validations" are present for a field', () => {
       const schema: JsfSchema = {
         'properties': {
           num_guests: {
@@ -291,7 +291,7 @@ describe('validateJsonLogic', () => {
       expect(jsonLogic.apply).toHaveBeenCalledTimes(2)
     })
 
-    it('should not call json logic apply fn when "x-jsf-logic-validations" is not present or when it references an invalid rule', () => {
+    it('should not call json logic\'s apply function when "x-jsf-logic-validations" are not present or when they reference an invalid rule', () => {
       const schema: JsfSchema = {
         'properties': {
           num_guests: {
@@ -319,58 +319,7 @@ describe('validateJsonLogic', () => {
       expect(jsonLogic.apply).not.toHaveBeenCalled()
     })
 
-    it('should call validateJsonLogic when "x-jsf-logic-validations" is present', () => {
-      const schema: JsfSchema = {
-        'properties': {
-          num_guests: {
-            title: 'Number of guests to invite',
-            type: 'number',
-          },
-          amount_of_snacks_to_bring: {
-            'title': 'Number of snacks to bring',
-            'type': 'number',
-            'x-jsf-logic-validations': [
-              'more_snacks_than_guests',
-            ],
-          },
-        },
-        'required': [
-          'num_guests',
-        ],
-        'x-jsf-logic': {
-          validations: {
-            more_snacks_than_guests: {
-              errorMessage: 'Consider bringing extra snacks so theres something for everyone.',
-              rule: {
-                '>=': [
-                  {
-                    var: 3,
-                  },
-                  {
-                    var: 2,
-                  },
-                ],
-              },
-            },
-          },
-        },
-      };
-
-      // Mock the jsonLogic.apply to return false (false is the return value for invalid logic)
-      (jsonLogic.apply as jest.Mock).mockReturnValue(false)
-
-      let errors = validateSchema({ num_guests: 4, amount_of_snacks_to_bring: 3 }, schema)
-      expect(errors).toHaveLength(1)
-      expect(errors[0].validation).toBe('json-logic');
-
-      (jsonLogic.apply as jest.Mock).mockReturnValue(true)
-      errors = validateSchema({ num_guests: 4, amount_of_snacks_to_bring: 10 }, schema)
-      expect(errors).toHaveLength(0)
-
-      expect(jsonLogic.apply).toHaveBeenCalledTimes(2)
-    })
-
-    it('should validate conditions inside "x-jsf-logic"', () => {
+    it('should validate conditions inside "x-jsf-logic", when present', () => {
       // jest.spyOn(jsonLogiValidation, 'validateJsonLogic')
       // jest.spyOn(jsonLogic, 'apply')
 

--- a/next/test/validation/json-logic.test.ts
+++ b/next/test/validation/json-logic.test.ts
@@ -240,7 +240,7 @@ describe('validateJsonLogic', () => {
       }, [])
     })
 
-    it('should call json logic\'s apply function fn when "x-jsf-logic-validations" are present for a field', () => {
+    it('should call json logic\'s apply function when "x-jsf-logic-validations" are present for a field', () => {
       const schema: JsfSchema = {
         'properties': {
           num_guests: {

--- a/next/test/validation/json-logic.test.ts
+++ b/next/test/validation/json-logic.test.ts
@@ -1,4 +1,4 @@
-import type { JsonLogicBag, NonBooleanJsfSchema } from '../../src/types'
+import type { JsonLogicContext, NonBooleanJsfSchema } from '../../src/types'
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import jsonLogic from 'json-logic-js'
 import { validateJsonLogic } from '../../src/validation/json-logic'
@@ -41,14 +41,14 @@ describe('validateJsonLogic', () => {
       'x-jsf-logic-validations': ['someValidation'],
     }
 
-    const jsonLogicBag: JsonLogicBag = {
+    const jsonLogicContext: JsonLogicContext = {
       schema: {
         validations: {},
       },
       value: {},
     }
 
-    const result = validateJsonLogic(schema, jsonLogicBag)
+    const result = validateJsonLogic(schema, jsonLogicContext)
     expect(result).toEqual([])
   })
 
@@ -59,7 +59,7 @@ describe('validateJsonLogic', () => {
       'x-jsf-logic-validations': ['ageCheck'],
     }
 
-    const jsonLogicBag: JsonLogicBag = {
+    const jsonLogicContext: JsonLogicContext = {
       schema: {
         validations: {
           ageCheck: {
@@ -74,7 +74,7 @@ describe('validateJsonLogic', () => {
     // Mock the jsonLogic.apply to return false (false is the return value for invalid logic)
     (jsonLogic.apply as jest.Mock).mockReturnValue(false)
 
-    const result = validateJsonLogic(schema, jsonLogicBag)
+    const result = validateJsonLogic(schema, jsonLogicContext)
 
     expect(result).toEqual([
       {
@@ -97,7 +97,7 @@ describe('validateJsonLogic', () => {
       'x-jsf-logic-validations': ['ageCheck'],
     }
 
-    const jsonLogicBag: JsonLogicBag = {
+    const jsonLogicContext: JsonLogicContext = {
       schema: {
         validations: {
           ageCheck: {
@@ -112,7 +112,7 @@ describe('validateJsonLogic', () => {
     // Mock the jsonLogic.apply to return true
     ;(jsonLogic.apply as jest.Mock).mockReturnValue(true)
 
-    const result = validateJsonLogic(schema, jsonLogicBag)
+    const result = validateJsonLogic(schema, jsonLogicContext)
     expect(result).toEqual([])
   })
 
@@ -123,7 +123,7 @@ describe('validateJsonLogic', () => {
       'x-jsf-logic-validations': ['check'],
     }
 
-    const jsonLogicBag: JsonLogicBag = {
+    const jsonLogicContext: JsonLogicContext = {
       schema: {
         validations: {
           check: {
@@ -137,7 +137,7 @@ describe('validateJsonLogic', () => {
 
     ;(jsonLogic.apply as jest.Mock).mockReturnValue(true)
 
-    validateJsonLogic(schema, jsonLogicBag)
+    validateJsonLogic(schema, jsonLogicContext)
 
     expect(jsonLogic.apply).toHaveBeenCalledWith(
       { '==': [{ var: 'field' }, null] },
@@ -152,7 +152,7 @@ describe('validateJsonLogic', () => {
       'x-jsf-logic-validations': ['check1', 'check2'],
     }
 
-    const jsonLogicBag: JsonLogicBag = {
+    const jsonLogicContext: JsonLogicContext = {
       schema: {
         validations: {
           check1: {
@@ -173,7 +173,7 @@ describe('validateJsonLogic', () => {
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(true)
 
-    const result = validateJsonLogic(schema, jsonLogicBag)
+    const result = validateJsonLogic(schema, jsonLogicContext)
 
     expect(result).toEqual([
       {

--- a/next/test/validation/json-logic.test.ts
+++ b/next/test/validation/json-logic.test.ts
@@ -1,7 +1,10 @@
-import type { JsonLogicContext, NonBooleanJsfSchema } from '../../src/types'
+import type { JsfSchema, JsonLogicContext, NonBooleanJsfSchema } from '../../src/types'
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import jsonLogic from 'json-logic-js'
-import { validateJsonLogic } from '../../src/validation/json-logic'
+import * as JsonLogicValidation from '../../src/validation/json-logic'
+import * as SchemaValidation from '../../src/validation/schema'
+
+const validateJsonLogic = JsonLogicValidation.validateJsonLogic
 
 // Mock json-logic-js
 jest.mock('json-logic-js', () => ({
@@ -11,6 +14,7 @@ jest.mock('json-logic-js', () => ({
 describe('validateJsonLogic', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.spyOn(JsonLogicValidation, 'validateJsonLogic')
   })
 
   it('returns empty array when no validations exist', () => {
@@ -166,10 +170,10 @@ describe('validateJsonLogic', () => {
         },
       },
       value: { age: 16 },
-    }
+    };
 
     // First validation fails, second passes
-    ;(jsonLogic.apply as jest.Mock)
+    (jsonLogic.apply as jest.Mock)
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(true)
 
@@ -184,5 +188,215 @@ describe('validateJsonLogic', () => {
     ])
 
     expect(jsonLogic.apply).toHaveBeenCalledTimes(2)
+  })
+
+  describe('validateSchema integration with "x-jsf-logic"', () => {
+    const validateSchema = SchemaValidation.validateSchema
+
+    it('calls validateJsonLogic with correct context', () => {
+      const schema: JsfSchema = {
+        'properties': {
+          num_guests: {
+            title: 'Number of guests to invite',
+            type: 'number',
+          },
+          amount_of_snacks_to_bring: {
+            'title': 'Number of snacks to bring',
+            'type': 'number',
+            'x-jsf-logic-validations': [
+              'more_snacks_than_guests',
+            ],
+          },
+        },
+        'required': [
+          'num_guests',
+        ],
+        'x-jsf-logic': {
+          validations: {
+            more_snacks_than_guests: {
+              errorMessage: 'Consider bringing extra snacks so theres something for everyone.',
+              rule: {
+                '>=': [
+                  {
+                    var: 3,
+                  },
+                  {
+                    var: 2,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }
+
+      validateSchema({ num_guests: 4, amount_of_snacks_to_bring: 3 }, schema)
+
+      expect(JsonLogicValidation.validateJsonLogic).toHaveBeenCalledWith(schema, {
+        schema: {
+          validations: schema['x-jsf-logic']?.validations,
+        },
+        value: { num_guests: 4, amount_of_snacks_to_bring: 3 },
+      }, [])
+    })
+
+    it('should call json logic apply fn when "x-jsf-logic-validations" is present', () => {
+      const schema: JsfSchema = {
+        'properties': {
+          num_guests: {
+            title: 'Number of guests to invite',
+            type: 'number',
+          },
+          amount_of_snacks_to_bring: {
+            'title': 'Number of snacks to bring',
+            'type': 'number',
+            'x-jsf-logic-validations': [
+              'more_snacks_than_guests',
+            ],
+          },
+        },
+        'required': [
+          'num_guests',
+        ],
+        'x-jsf-logic': {
+          validations: {
+            more_snacks_than_guests: {
+              errorMessage: 'Consider bringing extra snacks so theres something for everyone.',
+              rule: {
+                '>=': [
+                  {
+                    var: 3,
+                  },
+                  {
+                    var: 2,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+
+      // Mock the jsonLogic.apply to return false (false is the return value for invalid logic)
+      (jsonLogic.apply as jest.Mock).mockReturnValue(false)
+
+      let errors = validateSchema({ num_guests: 4, amount_of_snacks_to_bring: 3 }, schema)
+      expect(errors).toHaveLength(1)
+      expect(errors[0].validation).toBe('json-logic');
+
+      (jsonLogic.apply as jest.Mock).mockReturnValue(true)
+      errors = validateSchema({ num_guests: 4, amount_of_snacks_to_bring: 10 }, schema)
+      expect(errors).toHaveLength(0)
+
+      expect(jsonLogic.apply).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not call json logic apply fn when "x-jsf-logic-validations" is not present or when it references an invalid rule', () => {
+      const schema: JsfSchema = {
+        'properties': {
+          num_guests: {
+            title: 'Number of guests to invite',
+            type: 'number',
+          },
+          amount_of_snacks_to_bring: {
+            'title': 'Number of snacks to bring',
+            'type': 'number',
+            'x-jsf-logic-validations': [
+              'invalid-rule',
+            ],
+          },
+        },
+        'required': [
+          'num_guests',
+        ],
+        'x-jsf-logic': {
+          validations: { },
+        },
+      }
+
+      const errors = validateSchema({ num_guests: 4, amount_of_snacks_to_bring: 3 }, schema)
+      expect(errors).toHaveLength(0)
+      expect(jsonLogic.apply).not.toHaveBeenCalled()
+    })
+
+    it('should call validateJsonLogic when "x-jsf-logic-validations" is present', () => {
+      const schema: JsfSchema = {
+        'properties': {
+          num_guests: {
+            title: 'Number of guests to invite',
+            type: 'number',
+          },
+          amount_of_snacks_to_bring: {
+            'title': 'Number of snacks to bring',
+            'type': 'number',
+            'x-jsf-logic-validations': [
+              'more_snacks_than_guests',
+            ],
+          },
+        },
+        'required': [
+          'num_guests',
+        ],
+        'x-jsf-logic': {
+          validations: {
+            more_snacks_than_guests: {
+              errorMessage: 'Consider bringing extra snacks so theres something for everyone.',
+              rule: {
+                '>=': [
+                  {
+                    var: 3,
+                  },
+                  {
+                    var: 2,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+
+      // Mock the jsonLogic.apply to return false (false is the return value for invalid logic)
+      (jsonLogic.apply as jest.Mock).mockReturnValue(false)
+
+      let errors = validateSchema({ num_guests: 4, amount_of_snacks_to_bring: 3 }, schema)
+      expect(errors).toHaveLength(1)
+      expect(errors[0].validation).toBe('json-logic');
+
+      (jsonLogic.apply as jest.Mock).mockReturnValue(true)
+      errors = validateSchema({ num_guests: 4, amount_of_snacks_to_bring: 10 }, schema)
+      expect(errors).toHaveLength(0)
+
+      expect(jsonLogic.apply).toHaveBeenCalledTimes(2)
+    })
+
+    it('should validate conditions inside "x-jsf-logic"', () => {
+      // jest.spyOn(jsonLogiValidation, 'validateJsonLogic')
+      // jest.spyOn(jsonLogic, 'apply')
+
+      const innerSchema: JsfSchema = {
+        if: { properties: { foo: { const: 'test' } }, required: ['foo'] },
+        then: { properties: { bar: { const: 1 } }, required: ['bar'] },
+      }
+
+      const schema: JsfSchema = {
+        'properties': {
+          foo: { type: 'string' },
+          bar: { type: 'number' },
+        },
+        'x-jsf-logic': innerSchema,
+      }
+
+      // if/then/allOf/etc should be applied even if inside the x-jsf-logic schema node
+      let errors = validateSchema({ foo: 'test', bar: 0 }, schema)
+      expect(errors).toHaveLength(1)
+      expect(errors[0].validation).toBe('const')
+
+      errors = validateSchema({ foo: 'test', bar: 1 }, schema)
+      expect(errors).toHaveLength(0)
+
+      // json-logic validation should not have been called as there are no json-logic rules present in the schema
+      expect(jsonLogic.apply).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
This PR adds support for running schema validations on a `x-jsf-logic` node.

(Most of the solution is on the changes in `src/validation/schema.ts` file. The rest of the changes are due to type renaming and adding new tests.

1. **Renaming / new types**:
- Renamed `JsonLogicBag` to `JsonLogicContext`
- Renamed `JsonLogicSchema` to `JsonLogicRules`
- Added new type `JsonLogicRootSchema` for schema validation rules
- Added new type `JsonLogicSchema` that combines `JsonLogicRules` and `JsonLogicRootSchema`

2. **Schema Validation Changes**:
- Enhanced `validateSchema` to handle both JSON Logic validations and schema validations from `x-jsf-logic`
- Split validation of `x-jsf-logic` into two parts:
  - JSON Logic rules (validations/computedValues)
  - Schema validation rules (if/then/else/allOf/etc)

3. **Test Updates**:
- Updated tests to reflect new type names
- Added tests for validating conditions inside `x-jsf-logic`

