### PR TITLE
chore: refactor error message interpolation approach

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -31,7 +31,7 @@
     "dev": "NODE_ENV=development tsup --watch",
     "test": "jest",
     "test:watch": "jest --watchAll",
-    "test:file": "jest --runTestsByPath",
+    "test:file": "jest --runTestsByPath --watch",
     "test:v0-update-baseline": "jest --roots '<rootDir>/../src/tests' --json --outputFile=test/v0-baseline-test-results.json",
     "test:v0-compare-results": "node test/v0_compare_test_results.js",
     "test:v0": "jest --roots '<rootDir>/../src/tests' --json --outputFile=test/v0-test-results.json; pnpm run test:v0-compare-results",

--- a/next/src/errors/index.ts
+++ b/next/src/errors/index.ts
@@ -1,3 +1,5 @@
+import type { JsfSchema, SchemaValue } from '../types'
+
 /**
  * The type of validation error
  * @description
@@ -79,6 +81,14 @@ export interface ValidationError {
    * 'required'
    */
   validation: SchemaValidationErrorType
+  /**
+   * The schema that has a failed validation
+   */
+  schema: JsfSchema
+  /**
+   * The value that triggered the validation error
+   */
+  value: SchemaValue
   /**
    * The custom error message to display
    * @example

--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -6,7 +6,6 @@ import { getErrorMessage } from './errors/messages'
 import { buildFieldObject } from './field/object'
 import { mutateFields } from './mutations'
 import { validateSchema } from './validation/schema'
-import { isObjectValue } from './validation/util'
 
 export { ValidationOptions } from './validation/schema'
 
@@ -128,65 +127,18 @@ interface ValidationErrorWithMessage extends ValidationError {
   message: string
 }
 
-function getSchemaAndValueAtPath(rootSchema: JsfSchema, rootValue: SchemaValue, path: (string | number)[]): { schema: JsfSchema, value: SchemaValue } {
-  let currentSchema = rootSchema
-  let currentValue = rootValue
-
-  for (const segment of path) {
-    if (typeof currentSchema === 'object' && currentSchema !== null) {
-      if (currentSchema.properties && currentSchema.properties[segment]) {
-        currentSchema = currentSchema.properties[segment]
-        if (isObjectValue(currentValue)) {
-          currentValue = currentValue[segment]
-        }
-      }
-      else if (currentSchema.items && typeof currentSchema.items !== 'boolean') {
-        currentSchema = currentSchema.items
-        if (Array.isArray(currentValue)) {
-          currentValue = currentValue[Number(segment)]
-        }
-      }
-      // Skip the 'allOf', 'anyOf', and 'oneOf' segments, the next segment will be the index
-      else if (segment === 'allOf' && currentSchema.allOf) {
-        continue
-      }
-      else if (segment === 'anyOf' && currentSchema.anyOf) {
-        continue
-      }
-      else if (segment === 'oneOf' && currentSchema.oneOf) {
-        continue
-      }
-      // Skip the 'then' and 'else' segments, the next segment will be the field name
-      else if ((segment === 'then' || segment === 'else') && currentSchema[segment]) {
-        currentSchema = currentSchema[segment]
-        continue
-      }
-      // If we have we are in a composition context, get the subschema
-      else if (currentSchema.allOf || currentSchema.anyOf || currentSchema.oneOf) {
-        const index = Number(segment)
-        if (currentSchema.allOf && index >= 0 && index < currentSchema.allOf.length) {
-          currentSchema = currentSchema.allOf[index]
-        }
-        else if (currentSchema.anyOf && index >= 0 && index < currentSchema.anyOf.length) {
-          currentSchema = currentSchema.anyOf[index]
-        }
-        else if (currentSchema.oneOf && index >= 0 && index < currentSchema.oneOf.length) {
-          currentSchema = currentSchema.oneOf[index]
-        }
-      }
-    }
-  }
-
-  return { schema: currentSchema, value: currentValue }
-}
-
-function addErrorMessages(rootValue: SchemaValue, rootSchema: JsfSchema, errors: ValidationError[]): ValidationErrorWithMessage[] {
+/**
+ * Add error messages to validation errors (based on the validation type, schema, and value)
+ * @param errors - The validation errors
+ * @returns The validation errors with error messages added
+ */
+function addErrorMessages(errors: ValidationError[]): ValidationErrorWithMessage[] {
   return errors.map((error) => {
-    const { schema: errorSchema, value: errorValue } = getSchemaAndValueAtPath(rootSchema, rootValue, error.path)
+    const { schema, value, validation, customErrorMessage } = error
 
     return {
       ...error,
-      message: getErrorMessage(errorSchema, errorValue, error.validation, error.customErrorMessage),
+      message: getErrorMessage(schema, value, validation, customErrorMessage),
     }
   })
 }
@@ -265,7 +217,7 @@ function validate(value: SchemaValue, schema: JsfSchema, options: ValidationOpti
   const result: ValidationResult = {}
   const errors = validateSchema(value, schema, options)
 
-  const errorsWithMessages = addErrorMessages(value, schema, errors)
+  const errorsWithMessages = addErrorMessages(errors)
   const processedErrors = applyCustomErrorMessages(errorsWithMessages, schema)
 
   const formErrors = validationErrorsToFormErrors(processedErrors)

--- a/next/src/validation/array.ts
+++ b/next/src/validation/array.ts
@@ -56,11 +56,11 @@ function validateLength(
   const itemsLength = value.length
 
   if (schema.maxItems !== undefined && itemsLength > schema.maxItems) {
-    errors.push({ path, validation: 'maxItems' })
+    errors.push({ path, validation: 'maxItems', schema, value })
   }
 
   if (schema.minItems !== undefined && itemsLength < schema.minItems) {
-    errors.push({ path, validation: 'minItems' })
+    errors.push({ path, validation: 'minItems', schema, value })
   }
 
   return errors
@@ -188,16 +188,16 @@ function validateContains(
 
   if (schema.minContains === undefined && schema.maxContains === undefined) {
     if (contains < 1) {
-      errors.push({ path, validation: 'contains' })
+      errors.push({ path, validation: 'contains', schema, value })
     }
   }
   else {
     if (schema.minContains !== undefined && contains < schema.minContains) {
-      errors.push({ path, validation: 'minContains' })
+      errors.push({ path, validation: 'minContains', schema, value })
     }
 
     if (schema.maxContains !== undefined && contains > schema.maxContains) {
-      errors.push({ path, validation: 'maxContains' })
+      errors.push({ path, validation: 'maxContains', schema, value })
     }
   }
 
@@ -227,7 +227,7 @@ function validateUniqueItems(
   for (let i = 0; i < values.length; i++) {
     for (const prevItem of seen.values()) {
       if (deepEqual(values[i], prevItem)) {
-        return [{ path, validation: 'uniqueItems' }]
+        return [{ path, validation: 'uniqueItems', schema, value: values[i] }]
       }
     }
     seen.set(i, values[i])

--- a/next/src/validation/composition.ts
+++ b/next/src/validation/composition.ts
@@ -86,6 +86,8 @@ export function validateAnyOf(
     {
       path,
       validation: 'anyOf',
+      schema,
+      value,
     },
   ]
 }
@@ -134,6 +136,8 @@ export function validateOneOf(
       {
         path,
         validation: 'oneOf',
+        schema,
+        value,
       },
     ]
   }
@@ -143,6 +147,8 @@ export function validateOneOf(
       {
         path,
         validation: 'oneOf',
+        schema,
+        value,
       },
     ]
   }
@@ -179,9 +185,9 @@ export function validateNot(
   }
 
   if (typeof schema.not === 'boolean') {
-    return schema.not ? [{ path, validation: 'not' }] : []
+    return schema.not ? [{ path, validation: 'not', schema, value }] : []
   }
 
   const notErrors = validateSchema(value, schema.not, options, path, jsonLogicContext)
-  return notErrors.length === 0 ? [{ path, validation: 'not' }] : []
+  return notErrors.length === 0 ? [{ path, validation: 'not', schema, value }] : []
 }

--- a/next/src/validation/const.ts
+++ b/next/src/validation/const.ts
@@ -25,7 +25,7 @@ export function validateConst(
 
   if (!deepEqual(schema.const, value)) {
     return [
-      { path, validation: 'const' },
+      { path, validation: 'const', schema, value },
     ]
   }
 

--- a/next/src/validation/custom/date.ts
+++ b/next/src/validation/custom/date.ts
@@ -78,11 +78,11 @@ export function validateDate(
   const { minDate, maxDate } = schema['x-jsf-presentation']
 
   if (minDate && !validateMinDate(value, minDate)) {
-    errors.push({ path, validation: 'minDate' })
+    errors.push({ path, validation: 'minDate', schema, value })
   }
 
   if (maxDate && !validateMaxDate(value, maxDate)) {
-    errors.push({ path, validation: 'maxDate' })
+    errors.push({ path, validation: 'maxDate', schema, value })
   }
 
   return errors

--- a/next/src/validation/enum.ts
+++ b/next/src/validation/enum.ts
@@ -28,7 +28,7 @@ export function validateEnum(
 
   if (!schema.enum.some(enumValue => deepEqual(enumValue, value))) {
     return [
-      { path, validation: 'enum' },
+      { path, validation: 'enum', schema, value },
     ]
   }
 

--- a/next/src/validation/file.ts
+++ b/next/src/validation/file.ts
@@ -52,7 +52,7 @@ export function validateFile(
   )
 
   if (!isStructureValid) {
-    return [{ path, validation: 'fileStructure' }]
+    return [{ path, validation: 'fileStructure', schema, value }]
   }
 
   // Now we know value is a valid FileLike[] with at least one item.
@@ -65,7 +65,7 @@ export function validateFile(
     const isAnyFileTooLarge = files.some(file => file.size > maxSizeInBytes)
 
     if (isAnyFileTooLarge) {
-      return [{ path, validation: 'maxFileSize' }]
+      return [{ path, validation: 'maxFileSize', schema, value }]
     }
   }
 
@@ -89,7 +89,7 @@ export function validateFile(
 
       // Fail only if *none* of the files have an accepted format.
       if (!isAnyFileFormatAccepted) {
-        return [{ path, validation: 'accept' }]
+        return [{ path, validation: 'accept', schema, value }]
       }
     }
   }

--- a/next/src/validation/format.ts
+++ b/next/src/validation/format.ts
@@ -1,4 +1,5 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
+import type { NonBooleanJsfSchema } from '../types'
 import { Format } from 'json-schema-typed/draft-2020-12'
 
 /**
@@ -168,7 +169,7 @@ const formatValidationFunctions: Record<Format, (value: string) => boolean> = {
 /**
  * Validate a string value against a format
  * @param value - The string value to validate
- * @param format - The format to validate against
+ * @param schema - The schema to validate against
  * @param path - The path to the current field being validated
  * @returns An array of validation errors
  * @description
@@ -181,7 +182,7 @@ const formatValidationFunctions: Record<Format, (value: string) => boolean> = {
  */
 export function validateFormat(
   value: string,
-  format: string,
+  schema: NonBooleanJsfSchema,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   const errors: ValidationError[] = []
@@ -191,9 +192,9 @@ export function validateFormat(
     return errors
   }
 
-  const validateFn = formatValidationFunctions[format as Format]
+  const validateFn = formatValidationFunctions[schema.format as Format]
   if (validateFn && !validateFn(value)) {
-    errors.push({ path, validation: 'format' })
+    errors.push({ path, validation: 'format', schema, value })
   }
 
   return errors

--- a/next/src/validation/json-logic.ts
+++ b/next/src/validation/json-logic.ts
@@ -46,7 +46,7 @@ export function validateJsonLogic(
 
     // If the condition is false, we return a validation error
     if (result === false) {
-      return [{ path, validation: 'json-logic', customErrorMessage: validationData.errorMessage } as ValidationError]
+      return [{ path, validation: 'json-logic', customErrorMessage: validationData.errorMessage, schema, value: formValue } as ValidationError]
     }
 
     return []

--- a/next/src/validation/number.ts
+++ b/next/src/validation/number.ts
@@ -34,27 +34,27 @@ export function validateNumber(
 
   // MultipleOf validation - dividing value by multipleOf must have no remainder
   if (schema.multipleOf !== undefined && value % schema.multipleOf !== 0) {
-    errors.push({ path, validation: 'multipleOf' })
+    errors.push({ path, validation: 'multipleOf', schema, value })
   }
 
   // Maximum validation - value must be less than or equal to maximum
   if (schema.maximum !== undefined && value > schema.maximum) {
-    errors.push({ path, validation: 'maximum' })
+    errors.push({ path, validation: 'maximum', schema, value })
   }
 
   // ExclusiveMaximum validation - value must be less than exclusiveMaximum
   if (schema.exclusiveMaximum !== undefined && value >= schema.exclusiveMaximum) {
-    errors.push({ path, validation: 'exclusiveMaximum' })
+    errors.push({ path, validation: 'exclusiveMaximum', schema, value })
   }
 
   // Minimum validation - value must be greater than or equal to minimum
   if (schema.minimum !== undefined && value < schema.minimum) {
-    errors.push({ path, validation: 'minimum' })
+    errors.push({ path, validation: 'minimum', schema, value })
   }
 
   // ExclusiveMinimum validation - value must be greater than exclusiveMinimum
   if (schema.exclusiveMinimum !== undefined && value <= schema.exclusiveMinimum) {
-    errors.push({ path, validation: 'exclusiveMinimum' })
+    errors.push({ path, validation: 'exclusiveMinimum', schema, value })
   }
 
   return errors

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -107,7 +107,7 @@ function validateType(
   }
 
   // If none of the conditions matched, it's a type error
-  return [{ path, validation: 'type' }]
+  return [{ path, validation: 'type', schema, value }]
 }
 
 /**
@@ -194,7 +194,7 @@ export function validateSchema(
 
   // Handle boolean schemas
   if (typeof schema === 'boolean') {
-    return schema ? [] : [{ path, validation: 'valid' }]
+    return schema ? [] : [{ path, validation: 'valid', schema, value }]
   }
 
   // Check if it is a file input (needed early for null check)
@@ -224,6 +224,8 @@ export function validateSchema(
       errors.push({
         path: [...path, key],
         validation: 'required',
+        schema: schema?.properties?.[key] || schema,
+        value,
       })
     }
   }

--- a/next/src/validation/string.ts
+++ b/next/src/validation/string.ts
@@ -35,24 +35,24 @@ export function validateString(
 
   // Length validation
   if (schema.minLength !== undefined && valueLength < schema.minLength) {
-    errors.push({ path, validation: 'minLength' })
+    errors.push({ path, validation: 'minLength', schema, value })
   }
 
   if (schema.maxLength !== undefined && valueLength > schema.maxLength) {
-    errors.push({ path, validation: 'maxLength' })
+    errors.push({ path, validation: 'maxLength', schema, value })
   }
 
   // Pattern validation
   if (schema.pattern !== undefined) {
     const pattern = new RegExp(schema.pattern)
     if (!pattern.test(value)) {
-      errors.push({ path, validation: 'pattern' })
+      errors.push({ path, validation: 'pattern', schema, value })
     }
   }
 
   // Format validation (annotation by default in 2020-12)
   if (schema.format !== undefined) {
-    const formatErrors = validateFormat(value, schema.format, path)
+    const formatErrors = validateFormat(value, schema, path)
     errors.push(...formatErrors)
   }
 

--- a/next/test/test-utils.ts
+++ b/next/test/test-utils.ts
@@ -1,0 +1,15 @@
+import type { ValidationError } from '../src/errors'
+import { expect } from '@jest/globals'
+
+/**
+ * Helper function for asserting that a `ValidationError` has some expected fields. It automatically populates the `schema` and `value` properties with "any value"
+ * so the tests are less verbose.
+ * @param errorFields expected fields
+ */
+export function errorLike(errorFields: Partial<ValidationError>) {
+  return expect.objectContaining({
+    schema: expect.anything(),
+    value: expect.anything(),
+    ...errorFields,
+  })
+}

--- a/next/test/validation/array.test.ts
+++ b/next/test/validation/array.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
 import { validateSchema } from '../../src/validation/schema'
+import { errorLike } from '../test-utils'
 
 describe('array validation', () => {
   it('validates the array type', () => {
@@ -7,10 +8,10 @@ describe('array validation', () => {
     expect(validateSchema([], schema)).toEqual([])
     expect(validateSchema([1, 2, 3], schema)).toEqual([])
     expect(validateSchema('not an array', schema)).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'type',
-      },
+      }),
     ])
   })
 
@@ -28,10 +29,10 @@ describe('array validation', () => {
 
     it('returns an error for arrays with more than maxItems', () => {
       expect(validateSchema([1, 2, 3, 4], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'maxItems',
-        },
+        }),
       ])
     })
   })
@@ -45,19 +46,19 @@ describe('array validation', () => {
 
     it('returns an error for arrays with less than minItems', () => {
       expect(validateSchema([1], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'minItems',
-        },
+        }),
       ])
     })
 
     it('returns an error for empty arrays', () => {
       expect(validateSchema([], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'minItems',
-        },
+        }),
       ])
     })
   })
@@ -72,28 +73,28 @@ describe('array validation', () => {
 
     it('returns an error for arrays with duplicate items', () => {
       expect(validateSchema([1, 2, 1], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'uniqueItems',
-        },
+        }),
       ])
     })
 
     it('returns an error for arrays with duplicate arrays', () => {
       expect(validateSchema([[1, 2], [1, 2]], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'uniqueItems',
-        },
+        }),
       ])
     })
 
     it('returns an error for arrays with duplicate objects', () => {
       expect(validateSchema([{ a: 1 }, { a: 1 }, { a: 1 }], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'uniqueItems',
-        },
+        }),
       ])
     })
   })
@@ -113,10 +114,10 @@ describe('array validation', () => {
       const schema = { type: 'array', items: { type: 'number' } }
 
       expect(validateSchema([1, 'string', 3], schema)).toEqual([
-        {
+        errorLike({
           path: ['items', 1],
           validation: 'type',
-        },
+        }),
       ])
     })
   })
@@ -140,10 +141,10 @@ describe('array validation', () => {
 
     it('returns an error for arrays with prefixItems that do not match the schema', () => {
       expect(validateSchema(['test', 'not a number'], schema)).toEqual([
-        {
+        errorLike({
           path: ['prefixItems', 1],
           validation: 'type',
-        },
+        }),
       ])
     })
   })
@@ -165,19 +166,19 @@ describe('array validation', () => {
 
     it('returns an error for arrays that do not match the prefixItems constraint', () => {
       expect(validateSchema(['test', 'not a number', true, false], schema)).toEqual([
-        {
+        errorLike({
           path: ['prefixItems', 1],
           validation: 'type',
-        },
+        }),
       ])
     })
 
     it('returns an error for arrays that have additional items after the prefixItems that do not match the items constraint', () => {
       expect(validateSchema(['test', 42, true, false, 'extra'], schema)).toEqual([
-        {
+        errorLike({
           path: ['items', 4],
           validation: 'type',
-        },
+        }),
       ])
     })
   })
@@ -194,17 +195,17 @@ describe('array validation', () => {
 
     it('returns an error for arrays that do not contain any matching items', () => {
       expect(validateSchema([1, 2, 3], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'contains',
-        },
+        }),
       ])
 
       expect(validateSchema([], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'contains',
-        },
+        }),
       ])
     })
   })
@@ -233,10 +234,10 @@ describe('array validation', () => {
 
     it('returns an error for arrays with fewer than minContains items', () => {
       expect(validateSchema([1], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'minContains',
-        },
+        }),
       ])
     })
   })
@@ -254,10 +255,10 @@ describe('array validation', () => {
 
     it('returns an error for arrays with more than maxContains items', () => {
       expect(validateSchema([1, 2, 3], schema)).toEqual([
-        {
+        errorLike({
           path: [],
           validation: 'maxContains',
-        },
+        }),
       ])
     })
   })

--- a/next/test/validation/composition.test.ts
+++ b/next/test/validation/composition.test.ts
@@ -1,6 +1,7 @@
 import type { JsfSchema } from '../../src/types'
 import { describe, expect, it } from '@jest/globals'
 import { validateSchema } from '../../src/validation/schema'
+import { errorLike } from '../test-utils'
 
 describe('schema composition validators', () => {
   describe('validateAllOf', () => {
@@ -384,8 +385,8 @@ describe('schema composition validators', () => {
         const value = { other: 'field' }
         const errors = validateSchema(value, schema)
         expect(errors).toEqual([
-          { validation: 'required', path: ['type'] },
-          { validation: 'not', path: [] },
+          errorLike({ validation: 'required', path: ['type'] }),
+          errorLike({ validation: 'not', path: [] }),
         ])
       })
     })

--- a/next/test/validation/enum.test.ts
+++ b/next/test/validation/enum.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
 import { validateSchema } from '../../src/validation/schema'
+import { errorLike } from '../test-utils'
 
 describe('enum validation', () => {
   it('returns no errors for values that are in the enum', () => {
@@ -12,10 +13,10 @@ describe('enum validation', () => {
   it('returns an error for values that are not in the enum', () => {
     const schema = { enum: [1, 2, 3] }
     expect(validateSchema(4, schema)).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'enum',
-      },
+      }),
     ])
   })
 
@@ -31,10 +32,10 @@ describe('enum validation', () => {
     }
     expect(validateSchema({ foo: 'bar' }, schema)).toEqual([])
     expect(validateSchema({ foo: 'baz' }, schema)).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'enum',
-      },
+      }),
     ])
     expect(validateSchema(1, schema)).toEqual([])
   })
@@ -49,16 +50,16 @@ describe('enum validation', () => {
     expect(validateSchema({ foo: 'bar' }, schema)).toEqual([])
 
     expect(validateSchema('other', schema)).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'enum',
-      },
+      }),
     ])
     expect(validateSchema({ foo: 'baz' }, schema)).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'enum',
-      },
+      }),
     ])
   })
 })

--- a/next/test/validation/json-logic.test.ts
+++ b/next/test/validation/json-logic.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import jsonLogic from 'json-logic-js'
 import * as JsonLogicValidation from '../../src/validation/json-logic'
 import * as SchemaValidation from '../../src/validation/schema'
+import { errorLike } from '../test-utils'
 
 const validateJsonLogic = JsonLogicValidation.validateJsonLogic
 
@@ -81,11 +82,11 @@ describe('validateJsonLogic', () => {
     const result = validateJsonLogic(schema, jsonLogicContext)
 
     expect(result).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'json-logic',
         customErrorMessage: 'Must be over 18',
-      },
+      }),
     ])
 
     expect(jsonLogic.apply).toHaveBeenCalledWith(
@@ -180,11 +181,11 @@ describe('validateJsonLogic', () => {
     const result = validateJsonLogic(schema, jsonLogicContext)
 
     expect(result).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'json-logic',
         customErrorMessage: 'Must be over 18',
-      },
+      }),
     ])
 
     expect(jsonLogic.apply).toHaveBeenCalledTimes(2)
@@ -320,9 +321,6 @@ describe('validateJsonLogic', () => {
     })
 
     it('should validate conditions inside "x-jsf-logic", when present', () => {
-      // jest.spyOn(jsonLogiValidation, 'validateJsonLogic')
-      // jest.spyOn(jsonLogic, 'apply')
-
       const innerSchema: JsfSchema = {
         if: { properties: { foo: { const: 'test' } }, required: ['foo'] },
         then: { properties: { bar: { const: 1 } }, required: ['bar'] },

--- a/next/test/validation/number.test.ts
+++ b/next/test/validation/number.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
 import { validateSchema } from '../../src/validation/schema'
+import { errorLike } from '../test-utils'
 
 describe('number validation', () => {
   it('validates values against number type schemas', () => {
@@ -18,24 +19,24 @@ describe('number validation', () => {
     expect(validateSchema(12.34, { type: ['number'] })).toEqual([])
 
     expect(validateSchema('10', { type: 'number' })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'type',
-      },
+      }),
     ])
 
     expect(validateSchema('42.0', { type: 'number' })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'type',
-      },
+      }),
     ])
 
     expect(validateSchema('test', { type: 'number' })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'type',
-      },
+      }),
     ])
   })
 
@@ -46,68 +47,68 @@ describe('number validation', () => {
     expect(validateSchema(23.0, { type: ['integer'] })).toEqual([])
     expect(validateSchema(10, { type: ['integer'] })).toEqual([])
     expect(validateSchema(0.42, { type: 'integer' })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'type',
-      },
+      }),
     ])
 
     expect(validateSchema(12.34, { type: ['integer'] })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'type',
-      },
+      }),
     ])
   })
 
   it('validates the number against the minimum and maximum properties', () => {
     expect(validateSchema(10, { type: 'number', minimum: 10 })).toEqual([])
     expect(validateSchema(9, { type: 'number', minimum: 10 })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'minimum',
-      },
+      }),
     ])
 
     expect(validateSchema(10, { type: 'number', maximum: 10 })).toEqual([])
     expect(validateSchema(11, { type: 'number', maximum: 10 })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'maximum',
-      },
+      }),
     ])
 
     expect(validateSchema(10, { type: 'number', minimum: 10, maximum: 10 })).toEqual([])
     expect(validateSchema(11, { type: 'number', minimum: 10, maximum: 10 })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'maximum',
-      },
+      }),
     ])
 
     expect(validateSchema(9, { type: 'number', minimum: 10, maximum: 10 })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'minimum',
-      },
+      }),
     ])
   })
 
   it('validates the number against the exclusiveMinimum and exclusiveMaximum properties', () => {
     expect(validateSchema(11, { type: 'number', exclusiveMinimum: 10 })).toEqual([])
     expect(validateSchema(10, { type: 'number', exclusiveMinimum: 10 })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'exclusiveMinimum',
-      },
+      }),
     ])
 
     expect(validateSchema(9, { type: 'number', exclusiveMaximum: 10 })).toEqual([])
     expect(validateSchema(10, { type: 'number', exclusiveMaximum: 10 })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'exclusiveMaximum',
-      },
+      }),
     ])
 
     expect(
@@ -116,38 +117,38 @@ describe('number validation', () => {
     expect(
       validateSchema(11, { type: 'number', exclusiveMinimum: 10, exclusiveMaximum: 10 }),
     ).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'exclusiveMaximum',
-      },
+      }),
     ])
     expect(
       validateSchema(9, { type: 'number', exclusiveMinimum: 10, exclusiveMaximum: 10 }),
     ).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'exclusiveMinimum',
-      },
+      }),
     ])
 
     expect(
       validateSchema(10, { type: 'number', exclusiveMinimum: 10, exclusiveMaximum: 10 }),
     ).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'exclusiveMaximum',
-      },
-      {
+      }),
+      errorLike({
         path: [],
         validation: 'exclusiveMinimum',
-      },
+      }),
     ])
 
     expect(validateSchema(3, { type: 'number', exclusiveMaximum: 3 })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'exclusiveMaximum',
-      },
+      }),
     ])
   })
 
@@ -156,10 +157,10 @@ describe('number validation', () => {
     expect(validateSchema(10, { type: 'number', multipleOf: 5 })).toEqual([])
     expect(validateSchema(15, { type: 'number', multipleOf: 5 })).toEqual([])
     expect(validateSchema(12, { type: 'number', multipleOf: 5 })).toEqual([
-      {
+      errorLike({
         path: [],
         validation: 'multipleOf',
-      },
+      }),
     ])
   })
 })

--- a/next/test/validation/optional.test.ts
+++ b/next/test/validation/optional.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
 import { validateSchema } from '../../src/validation/schema'
+import { errorLike } from '../test-utils'
 
 describe('treatNullAsUndefined', () => {
   it('returns no error when an undefined value is validated against a non-required field', () => {
@@ -27,10 +28,11 @@ describe('treatNullAsUndefined', () => {
       }
 
       expect(validateSchema({ name: null }, schema)).toEqual([
-        {
+        errorLike({
           path: ['name'],
           validation: 'type',
-        },
+          value: null,
+        }),
       ])
     })
   })
@@ -82,10 +84,10 @@ describe('treatNullAsUndefined', () => {
       }
 
       expect(validateSchema({ name: null }, schema, { treatNullAsUndefined: true })).toEqual([
-        {
+        errorLike({
           path: ['name'],
           validation: 'required',
-        },
+        }),
       ])
     })
 
@@ -101,10 +103,10 @@ describe('treatNullAsUndefined', () => {
       }
 
       expect(validateSchema({ name: null }, schema, { treatNullAsUndefined: true })).toEqual([
-        {
+        errorLike({
           path: ['name'],
           validation: 'required',
-        },
+        }),
       ])
     })
   })


### PR DESCRIPTION
Adds `schema` and `value` to `ValidationError`, allowing for the validators to pass extra context to the next step (message interpolation). It also removes the need for traversing the schema an extra time to calculate the correct context for each error message. 

This is why there are a lot of changes: I had to go through each validator and pass these 2 extra properties and update every test that was asserting on the errors returned by the `validateSchema` call.

## Changes
- Added `schema` and `value` fields to `ValidationError` interface to track the schema and value that caused the validation error
- Removed `getSchemaAndValueAtPath` function since schema and value are now directly available in the error object
- Simplified `addErrorMessages` function to use the schema and value directly from the error object
- Updated all validation functions to include schema and value in their error objects
- Added test utility `errorLike` to correct the validation error assertions and avoid big changes on tets.
