### PR TITLE
fix(v1): use correct checkboxValue on checkbox inputs

### DIFF
--- a/next/src/field/schema.ts
+++ b/next/src/field/schema.ts
@@ -20,6 +20,23 @@ function getJsonType(schema: NonBooleanJsfSchema): string {
 }
 
 /**
+ * Add checkbox attributes to a field
+ * @param inputType - The input type of the field
+ * @param field - The field to add the attributes to
+ * @param schema - The schema of the field
+ */
+function addCheckboxAttributes(inputType: string, field: Field, schema: NonBooleanJsfSchema) {
+  // The checkboxValue attribute indicates which is the valid value a checkbox can have (for example "acknowledge", or `true`)
+  // So, we set it to what's specified in the schema (if any)
+  field.checkboxValue = schema.const
+
+  // However, if the schema type is boolean, we should the valid value as `true`
+  if (schema.type === 'boolean') {
+    field.checkboxValue = true
+  }
+}
+
+/**
  * Get the presentation input type for a field from a schema type (ported from v0)
  * @param type - The schema type
  * @param schema - The non boolean schema of the field
@@ -219,12 +236,8 @@ export function buildFieldSchema(
     ...(errorMessage && { errorMessage }),
   }
 
-  if (schema.const) {
-    field.const = schema.const
-
-    if (inputType === 'checkbox') {
-      field.checkboxValue = schema.const
-    }
+  if (inputType === 'checkbox') {
+    addCheckboxAttributes(inputType, field, schema)
   }
 
   if (schema.title) {

--- a/next/src/field/schema.ts
+++ b/next/src/field/schema.ts
@@ -30,7 +30,7 @@ function addCheckboxAttributes(inputType: string, field: Field, schema: NonBoole
   // So, we set it to what's specified in the schema (if any)
   field.checkboxValue = schema.const
 
-  // However, if the schema type is boolean, we should the valid value as `true`
+  // However, if the schema type is boolean, we should set the valid value as `true`
   if (schema.type === 'boolean') {
     field.checkboxValue = true
   }

--- a/next/test/fields.test.ts
+++ b/next/test/fields.test.ts
@@ -1,4 +1,4 @@
-import type { JsfSchema } from '../src/types'
+import type { JsfSchema, NonBooleanJsfSchema } from '../src/types'
 import { describe, expect, it } from '@jest/globals'
 import { buildFieldSchema } from '../src/field/schema'
 
@@ -442,6 +442,55 @@ describe('fields', () => {
       }
       const field = buildFieldSchema(schema, 'test')
       expect(field?.inputType).toBe('checkbox')
+      expect(field?.checkboxValue).toBe(true)
+    })
+
+    it('uses correct checkboxValue checkbox input types with boolean const value', () => {
+      const schema: NonBooleanJsfSchema = {
+        'x-jsf-presentation': {
+          inputType: 'checkbox',
+        },
+        'type': 'boolean',
+      }
+      const field = buildFieldSchema(schema, 'test')
+      expect(field?.inputType).toBe('checkbox')
+      expect(field?.checkboxValue).toBe(true)
+    })
+
+    it('uses correct checkboxValue checkbox input types with string const value', () => {
+      // Setting a schema with a string const value and string type
+      const stringSchema: NonBooleanJsfSchema = {
+        'x-jsf-presentation': {
+          inputType: 'checkbox',
+        },
+        'type': 'string',
+        'const': 'accept',
+      }
+      let fields = buildFieldSchema(stringSchema, 'test')
+      expect(fields?.inputType).toBe('checkbox')
+      expect(fields?.checkboxValue).toBe('accept')
+
+      // Setting a schema with a string const value and boolean type
+      const booleanSchema: NonBooleanJsfSchema = {
+        'x-jsf-presentation': {
+          inputType: 'checkbox',
+        },
+        'type': 'boolean',
+      }
+
+      fields = buildFieldSchema(booleanSchema, 'test')
+      expect(fields?.inputType).toBe('checkbox')
+      expect(fields?.checkboxValue).toBe(true)
+    })
+
+    it('uses checkbox input for boolean type with boolean const value', () => {
+      const schema = {
+        type: 'boolean',
+        const: true,
+      }
+      const field = buildFieldSchema(schema, 'test')
+      expect(field?.inputType).toBe('checkbox')
+      expect(field?.checkboxValue).toBe(true)
     })
 
     // Skipping these tests until we have group-array support

--- a/next/test/validation/boolean_type.test.ts
+++ b/next/test/validation/boolean_type.test.ts
@@ -36,3 +36,4 @@ describe('boolean validation', () => {
 
     expect(result.formErrors).toBeUndefined()
   })
+})

--- a/next/test/validation/boolean_type.test.ts
+++ b/next/test/validation/boolean_type.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@jest/globals'
+import { createHeadlessForm } from '../../src'
+
+describe('boolean validation', () => {
+  it('validates values against boolean type schemas', () => {
+    const result = createHeadlessForm({
+      type: 'object',
+      properties: {
+        show: { type: 'boolean' },
+      },
+    }).handleValidation({ show: 'anything' })
+
+    expect(result).toMatchObject({
+      formErrors: {
+        show: 'The value must be a boolean',
+      },
+    })
+  })
+
+  it('validates values against the actual boolean value', () => {
+    let result = createHeadlessForm({
+      type: 'object',
+      properties: {
+        show: { type: 'boolean' },
+      },
+    }).handleValidation({ show: true })
+
+    expect(result.formErrors).toBeUndefined()
+
+    result = createHeadlessForm({
+      type: 'object',
+      properties: {
+        show: { type: 'boolean' },
+      },
+    }).handleValidation({ show: false })
+
+    expect(result.formErrors).toBeUndefined()
+  })


### PR DESCRIPTION
Our previous implementation had a bug:
- it only populated `checkboxValue` if the schema had a `const` and had `checkbox` as its input type

This is a problem because it's not taking into account the `type` of the schema. In other words, to mimic v0's behavior, one should set the `checkboxValue` to either what's defined in the `const` property OR to boolean, in case the `type` is `boolean`.

Added 2 groups of tests
- one for boolean validation (not boolean schemas, but schemas of type boolean)
- one for the `fields` generation