### PR TITLE
feat(next): json-logic error messages interpolations

### DIFF
--- a/next/src/types.ts
+++ b/next/src/types.ts
@@ -75,7 +75,7 @@ export type JsfSchema = JSONSchema & {
   // Extra validations to run. References validations in the `x-jsf-logic` root property.
   'x-jsf-logic-validations'?: string[]
   // Extra attributes to add to the schema. References computedValues in the `x-jsf-logic` root property.
-  'x-jsf-logic-computedAttrs'?: Partial<Record<keyof NonBooleanJsfSchema, string>>
+  'x-jsf-logic-computedAttrs'?: Partial<Record<keyof NonBooleanJsfSchema, string | JsfSchema['x-jsf-errorMessage']>>
 }
 
 /**

--- a/next/src/types.ts
+++ b/next/src/types.ts
@@ -78,6 +78,12 @@ export type JsfSchema = JSONSchema & {
   'x-jsf-logic-computedAttrs'?: Record<keyof JsfSchema, string>
 }
 
+const ok: JsfSchema = {
+  'x-jsf-logic-computedAttrs': {
+    minimum: 'foo',
+  },
+}
+
 /**
  * JSON Schema Form type without booleans.
  * This type is used for convenience in places where a boolean is not allowed.

--- a/next/src/types.ts
+++ b/next/src/types.ts
@@ -75,13 +75,7 @@ export type JsfSchema = JSONSchema & {
   // Extra validations to run. References validations in the `x-jsf-logic` root property.
   'x-jsf-logic-validations'?: string[]
   // Extra attributes to add to the schema. References computedValues in the `x-jsf-logic` root property.
-  'x-jsf-logic-computedAttrs'?: Record<keyof JsfSchema, string>
-}
-
-const ok: JsfSchema = {
-  'x-jsf-logic-computedAttrs': {
-    minimum: 'foo',
-  },
+  'x-jsf-logic-computedAttrs'?: Partial<Record<keyof NonBooleanJsfSchema, string>>
 }
 
 /**

--- a/next/src/validation/json-logic.ts
+++ b/next/src/validation/json-logic.ts
@@ -3,6 +3,7 @@ import type { JsonLogicContext, NonBooleanJsfSchema, ObjectValue, SchemaValue } 
 import type { ValidationOptions } from './schema'
 import jsonLogic from 'json-logic-js'
 import { validateSchema } from './schema'
+import { safeDeepClone } from './util'
 
 /**
  * jsonLogic interprets  undefined and null values differently when running comparisons and that creates inconsistent results.
@@ -79,7 +80,7 @@ export function validateJsonLogicComputedAttributes(
   }
 
   // Create a copy of the schema
-  const schemaCopy: NonBooleanJsfSchema = structuredClone(schema)
+  const schemaCopy: NonBooleanJsfSchema = safeDeepClone(schema)
 
   // Remove the computed attributes from the schema
   delete schemaCopy['x-jsf-logic-computedAttrs']

--- a/next/src/validation/json-logic.ts
+++ b/next/src/validation/json-logic.ts
@@ -79,7 +79,7 @@ export function validateJsonLogicComputedAttributes(
   }
 
   // Create a copy of the schema
-  const schemaCopy: NonBooleanJsfSchema = { ...schema }
+  const schemaCopy: NonBooleanJsfSchema = structuredClone(schema)
 
   // Remove the computed attributes from the schema
   delete schemaCopy['x-jsf-logic-computedAttrs']
@@ -94,7 +94,7 @@ export function validateJsonLogicComputedAttributes(
       return
     }
 
-    const result: any = jsonLogic.apply(computedAttributeRule, replaceUndefinedAndNullValuesWithNaN(formValue))
+    const result: any = jsonLogic.apply(computedAttributeRule, replaceUndefinedAndNullValuesWithNaN(formValue as ObjectValue))
 
     if (typeof result === 'undefined') {
       return
@@ -103,5 +103,6 @@ export function validateJsonLogicComputedAttributes(
     schemaCopy[schemaKey as keyof NonBooleanJsfSchema] = result
   })
 
+  // Validate the modified schema
   return validateSchema(values, schemaCopy, options, path, jsonLogicContext)
 }

--- a/next/src/validation/json-logic.ts
+++ b/next/src/validation/json-logic.ts
@@ -5,8 +5,8 @@ import jsonLogic from 'json-logic-js'
 import { validateSchema } from './schema'
 
 /**
- * This function is needed because undefined and null values behave differently on json-logic.apply function.
- * This ensures consistent results.
+ * jsonLogic interprets  undefined and null values differently when running comparisons and that creates inconsistent results.
+ * This function attempts to fix that (ported from v0).
  *
  * @param {object} values - a set of values from a form
  * @returns {object} values object without any undefined

--- a/next/src/validation/json-logic.ts
+++ b/next/src/validation/json-logic.ts
@@ -1,5 +1,5 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
+import type { JsonLogicContext, NonBooleanJsfSchema, ObjectValue, SchemaValue } from '../types'
 import type { ValidationOptions } from './schema'
 import jsonLogic from 'json-logic-js'
 import { validateSchema } from './schema'
@@ -11,7 +11,7 @@ import { validateSchema } from './schema'
  * @param {object} values - a set of values from a form
  * @returns {object} values object without any undefined
  */
-function replaceUndefinedAndNullValuesWithNaN(values: any = {}) {
+function replaceUndefinedAndNullValuesWithNaN(values: ObjectValue = {}) {
   return Object.entries(values).reduce((prev, [key, value]) => {
     return { ...prev, [key]: value === undefined || value === null ? Number.NaN : value }
   }, {})
@@ -44,7 +44,7 @@ export function validateJsonLogicRules(
       return []
     }
 
-    const result: any = jsonLogic.apply(validationData.rule, replaceUndefinedAndNullValuesWithNaN(formValue))
+    const result: any = jsonLogic.apply(validationData.rule, replaceUndefinedAndNullValuesWithNaN(formValue as ObjectValue))
 
     // If the condition is false, we return a validation error
     if (result === false) {

--- a/next/src/validation/json-logic.ts
+++ b/next/src/validation/json-logic.ts
@@ -20,8 +20,9 @@ function replaceUndefinedAndNullValuesWithNaN(values: any = {}) {
 /**
  * Validates the JSON Logic rules for a given schema.
  *
- * @param {NonBooleanJsfSchema} schema - The JSON Schema to validate.
- * @param {JsonLogicContext | undefined} jsonLogicContext - The JSON Logic context.
+ * @param {NonBooleanJsfSchema} schema - JSON Schema to validate.
+ * @param {JsonLogicContext | undefined} jsonLogicContext - JSON Logic context.
+ * @param {ValidationErrorPath} path - Current validation error path.
  */
 export function validateJsonLogicRules(
   schema: NonBooleanJsfSchema,
@@ -57,8 +58,11 @@ export function validateJsonLogicRules(
 /**
  * Validates the JSON Logic computed attributes for a given schema.
  *
- * @param {NonBooleanJsfSchema} schema - The JSON Schema to validate.
- * @param {JsonLogicContext | undefined} jsonLogicContext - The JSON Logic context.
+ * @param {SchemaValue} values - Current form values.
+ * @param {NonBooleanJsfSchema} schema - JSON Schema to validate.
+ * @param {ValidationOptions} options - Validation options.
+ * @param {JsonLogicContext | undefined} jsonLogicContext - JSON Logic context.
+ * @param {ValidationErrorPath} path - Current validation error path.
  */
 export function validateJsonLogicComputedAttributes(
   values: SchemaValue,

--- a/next/src/validation/json-logic.ts
+++ b/next/src/validation/json-logic.ts
@@ -5,14 +5,13 @@ import jsonLogic from 'json-logic-js'
 import { validateSchema } from './schema'
 
 /**
- * (Ported from v0. TODO: check why we need it and if the name is correct)
- * We removed undefined values in this function as `json-logic` ignores them.
- * Means we will always check against a value for validations.
+ * This function is needed because undefined and null values behave differently on json-logic.apply function.
+ * This ensures consistent results.
  *
  * @param {object} values - a set of values from a form
  * @returns {object} values object without any undefined
  */
-function replaceUndefinedValuesWithNulls(values: any = {}) {
+function replaceUndefinedAndNullValuesWithNaN(values: any = {}) {
   return Object.entries(values).reduce((prev, [key, value]) => {
     return { ...prev, [key]: value === undefined || value === null ? Number.NaN : value }
   }, {})
@@ -44,7 +43,7 @@ export function validateJsonLogicRules(
       return []
     }
 
-    const result: any = jsonLogic.apply(validationData.rule, replaceUndefinedValuesWithNulls(formValue))
+    const result: any = jsonLogic.apply(validationData.rule, replaceUndefinedAndNullValuesWithNaN(formValue))
 
     // If the condition is false, we return a validation error
     if (result === false) {
@@ -91,7 +90,7 @@ export function validateJsonLogicComputedAttributes(
       return
     }
 
-    const result: any = jsonLogic.apply(computedAttributeRule, replaceUndefinedValuesWithNulls(formValue))
+    const result: any = jsonLogic.apply(computedAttributeRule, replaceUndefinedAndNullValuesWithNaN(formValue))
 
     if (typeof result === 'undefined') {
       return

--- a/next/src/validation/json-logic.ts
+++ b/next/src/validation/json-logic.ts
@@ -1,6 +1,8 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { JsonLogicContext, NonBooleanJsfSchema } from '../types'
+import type { JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
+import type { ValidationOptions } from './schema'
 import jsonLogic from 'json-logic-js'
+import { validateSchema } from './schema'
 
 /**
  * (Ported from v0. TODO: check why we need it and if the name is correct)
@@ -17,12 +19,12 @@ function replaceUndefinedValuesWithNulls(values: any = {}) {
 }
 
 /**
- * Validates the JSON Logic for a given schema.
+ * Validates the JSON Logic rules for a given schema.
  *
  * @param {NonBooleanJsfSchema} schema - The JSON Schema to validate.
  * @param {JsonLogicContext | undefined} jsonLogicContext - The JSON Logic context.
  */
-export function validateJsonLogic(
+export function validateJsonLogicRules(
   schema: NonBooleanJsfSchema,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
@@ -51,4 +53,52 @@ export function validateJsonLogic(
 
     return []
   }).flat()
+}
+
+/**
+ * Validates the JSON Logic computed attributes for a given schema.
+ *
+ * @param {NonBooleanJsfSchema} schema - The JSON Schema to validate.
+ * @param {JsonLogicContext | undefined} jsonLogicContext - The JSON Logic context.
+ */
+export function validateJsonLogicComputedAttributes(
+  values: SchemaValue,
+  schema: NonBooleanJsfSchema,
+  options: ValidationOptions = {},
+  jsonLogicContext: JsonLogicContext | undefined,
+  path: ValidationErrorPath = [],
+): ValidationError[] {
+  const computedAttributes = schema['x-jsf-logic-computedAttrs']
+
+  // if the current schema has no computed attributes, we skip the validation
+  if (!computedAttributes || Object.keys(computedAttributes).length === 0) {
+    return []
+  }
+
+  // Create a copy of the schema
+  const schemaCopy: NonBooleanJsfSchema = { ...schema }
+
+  // Remove the computed attributes from the schema
+  delete schemaCopy['x-jsf-logic-computedAttrs']
+
+  // add the new computed attributes to the schema
+  Object.entries(computedAttributes).forEach(([schemaKey, computationName]) => {
+    const computedAttributeRule = jsonLogicContext?.schema?.computedValues?.[computationName]?.rule
+    const formValue = jsonLogicContext?.value
+
+    // if the computation name does not reference any valid rule, we ignore it
+    if (!computedAttributeRule) {
+      return
+    }
+
+    const result: any = jsonLogic.apply(computedAttributeRule, replaceUndefinedValuesWithNulls(formValue))
+
+    if (typeof result === 'undefined') {
+      return
+    }
+
+    schemaCopy[schemaKey as keyof NonBooleanJsfSchema] = result
+  })
+
+  return validateSchema(values, schemaCopy, options, path, jsonLogicContext)
 }

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -7,7 +7,7 @@ import { validateConst } from './const'
 import { validateDate } from './custom/date'
 import { validateEnum } from './enum'
 import { validateFile } from './file'
-import { validateJsonLogic } from './json-logic'
+import { validateJsonLogicComputedAttributes, validateJsonLogicRules } from './json-logic'
 import { validateNumber } from './number'
 import { validateObject } from './object'
 import { validateString } from './string'
@@ -171,9 +171,10 @@ export function validateSchema(
   // If not, it probably means the current schema is the root schema (or that there's no json-logic node in the current schema)
   if (!rootJsonLogicContext && schema['x-jsf-logic']) {
     // - We should set the jsonLogicContext's schema as the schema in the 'x-jsf-logic' property
-    const { validations, computedValues: _, ...rest } = schema['x-jsf-logic']
+    const { validations, computedValues, ...rest } = schema['x-jsf-logic']
     const jsonLogicRules: JsonLogicRules = {
       validations,
+      computedValues,
     }
     jsonLogicContext = {
       schema: jsonLogicRules,
@@ -250,6 +251,7 @@ export function validateSchema(
     // Custom validations
     ...validateDate(value, schema, options, path),
     ...validateJsonLogicSchema(value, jsonLogicRootSchema, options, path, jsonLogicContext),
-    ...validateJsonLogic(schema, jsonLogicContext, path),
+    ...validateJsonLogicRules(schema, jsonLogicContext, path),
+    ...validateJsonLogicComputedAttributes(value, schema, options, jsonLogicContext, path),
   ]
 }

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -251,7 +251,7 @@ export function validateSchema(
     // Custom validations
     ...validateDate(value, schema, options, path),
     ...validateJsonLogicSchema(value, jsonLogicRootSchema, options, path, jsonLogicContext),
-    ...validateJsonLogicRules(schema, jsonLogicContext, path),
     ...validateJsonLogicComputedAttributes(value, schema, options, jsonLogicContext, path),
+    ...validateJsonLogicRules(schema, jsonLogicContext, path),
   ]
 }

--- a/next/src/validation/util.ts
+++ b/next/src/validation/util.ts
@@ -1,4 +1,4 @@
-import type { NonBooleanJsfSchema, ObjectValue, SchemaValue } from '../types'
+import type { ObjectValue, SchemaValue } from '../types'
 
 /**
  * Type guard to check if a given SchemaValue is an ObjectValue

--- a/next/src/validation/util.ts
+++ b/next/src/validation/util.ts
@@ -1,4 +1,4 @@
-import type { ObjectValue, SchemaValue } from '../types'
+import type { NonBooleanJsfSchema, ObjectValue, SchemaValue } from '../types'
 
 /**
  * Type guard to check if a given SchemaValue is an ObjectValue
@@ -67,4 +67,32 @@ export function deepEqual(a: SchemaValue, b: SchemaValue): boolean {
   }
 
   return false
+}
+
+/**
+ * Deep clones an object using structuredClone if available, otherwise falls back to JSON.parse/stringify approach.
+ *
+ * @param obj - The object to clone
+ * @returns deep clone of the original object
+ * @throws If the object contains circular references and structuredClone is not available
+ */
+export function safeDeepClone<T>(obj: T): T {
+  // Check if structuredClone is available
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(obj)
+    }
+    catch (err) {
+      console.warn('structuredClone failed, falling back to JSON method:', err)
+      // Fall through to JSON method
+    }
+  }
+
+  // Fallback to JSON.parse/stringify approach
+  try {
+    return JSON.parse(JSON.stringify(obj))
+  }
+  catch {
+    throw new Error('Deep clone failed: Object may contain circular references or non-serializable values')
+  }
 }

--- a/next/test/validation/json-logic.test.ts
+++ b/next/test/validation/json-logic.test.ts
@@ -5,17 +5,17 @@ import * as JsonLogicValidation from '../../src/validation/json-logic'
 import * as SchemaValidation from '../../src/validation/schema'
 import { errorLike } from '../test-utils'
 
-const validateJsonLogic = JsonLogicValidation.validateJsonLogicRules
+const validateJsonLogicRules = JsonLogicValidation.validateJsonLogicRules
 
 // Mock json-logic-js
 jest.mock('json-logic-js', () => ({
   apply: jest.fn(),
 }))
 
-describe('validateJsonLogic', () => {
+describe('validateJsonLogicRules', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.spyOn(JsonLogicValidation, 'validateJsonLogic')
+    jest.spyOn(JsonLogicValidation, 'validateJsonLogicRules')
   })
 
   it('returns empty array when no validations exist', () => {
@@ -24,7 +24,7 @@ describe('validateJsonLogic', () => {
       properties: {},
     }
 
-    const result = validateJsonLogic(schema, undefined)
+    const result = validateJsonLogicRules(schema, undefined)
     expect(result).toEqual([])
   })
 
@@ -35,7 +35,7 @@ describe('validateJsonLogic', () => {
       'x-jsf-logic-validations': [],
     }
 
-    const result = validateJsonLogic(schema, undefined)
+    const result = validateJsonLogicRules(schema, undefined)
     expect(result).toEqual([])
   })
 
@@ -53,7 +53,7 @@ describe('validateJsonLogic', () => {
       value: {},
     }
 
-    const result = validateJsonLogic(schema, jsonLogicContext)
+    const result = validateJsonLogicRules(schema, jsonLogicContext)
     expect(result).toEqual([])
   })
 
@@ -79,7 +79,7 @@ describe('validateJsonLogic', () => {
     // Mock the jsonLogic.apply to return false (false is the return value for invalid logic)
     (jsonLogic.apply as jest.Mock).mockReturnValue(false)
 
-    const result = validateJsonLogic(schema, jsonLogicContext)
+    const result = validateJsonLogicRules(schema, jsonLogicContext)
 
     expect(result).toEqual([
       errorLike({
@@ -117,7 +117,7 @@ describe('validateJsonLogic', () => {
     // Mock the jsonLogic.apply to return true
     ;(jsonLogic.apply as jest.Mock).mockReturnValue(true)
 
-    const result = validateJsonLogic(schema, jsonLogicContext)
+    const result = validateJsonLogicRules(schema, jsonLogicContext)
     expect(result).toEqual([])
   })
 
@@ -142,7 +142,7 @@ describe('validateJsonLogic', () => {
 
     ;(jsonLogic.apply as jest.Mock).mockReturnValue(true)
 
-    validateJsonLogic(schema, jsonLogicContext)
+    validateJsonLogicRules(schema, jsonLogicContext)
 
     expect(jsonLogic.apply).toHaveBeenCalledWith(
       { '==': [{ var: 'field' }, null] },
@@ -178,7 +178,7 @@ describe('validateJsonLogic', () => {
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(true)
 
-    const result = validateJsonLogic(schema, jsonLogicContext)
+    const result = validateJsonLogicRules(schema, jsonLogicContext)
 
     expect(result).toEqual([
       errorLike({
@@ -194,7 +194,7 @@ describe('validateJsonLogic', () => {
   describe('validateSchema integration with "x-jsf-logic"', () => {
     const validateSchema = SchemaValidation.validateSchema
 
-    it('calls validateJsonLogic with correct context', () => {
+    it('calls validateJsonLogicRules with correct context', () => {
       const schema: JsfSchema = {
         'properties': {
           num_guests: {

--- a/next/test/validation/json-logic.test.ts
+++ b/next/test/validation/json-logic.test.ts
@@ -5,7 +5,7 @@ import * as JsonLogicValidation from '../../src/validation/json-logic'
 import * as SchemaValidation from '../../src/validation/schema'
 import { errorLike } from '../test-utils'
 
-const validateJsonLogic = JsonLogicValidation.validateJsonLogic
+const validateJsonLogic = JsonLogicValidation.validateJsonLogicRules
 
 // Mock json-logic-js
 jest.mock('json-logic-js', () => ({
@@ -233,7 +233,7 @@ describe('validateJsonLogic', () => {
 
       validateSchema({ num_guests: 4, amount_of_snacks_to_bring: 3 }, schema)
 
-      expect(JsonLogicValidation.validateJsonLogic).toHaveBeenCalledWith(schema, {
+      expect(JsonLogicValidation.validateJsonLogicRules).toHaveBeenCalledWith(schema, {
         schema: {
           validations: schema['x-jsf-logic']?.validations,
         },


### PR DESCRIPTION
Depends on https://github.com/remoteoss/json-schema-form/pull/173

### Error Message Handling
- Simplified error message application by using `error.schema` directly instead of traversing schema tree
- Improved error message interpolation with handlebars-style syntax (e.g. `{{computedValue}}`)
- Added validation for computed error messages

### Computed Attributes
- Enhanced `x-jsf-logic-computedAttrs` to support dynamic error messages
- Added type safety by using `Partial<Record<keyof NonBooleanJsfSchema, string | JsfSchema['x-jsf-errorMessage']>>`
- Implemented validation for computed attributes with JSON Logic rules

