### PR TITLE
feat: simplify custom error messages calculation and allow for interp…

### DIFF
--- a/next/src/types.ts
+++ b/next/src/types.ts
@@ -75,7 +75,7 @@ export type JsfSchema = JSONSchema & {
   // Extra validations to run. References validations in the `x-jsf-logic` root property.
   'x-jsf-logic-validations'?: string[]
   // Extra attributes to add to the schema. References computedValues in the `x-jsf-logic` root property.
-  'x-jsf-logic-computedAttrs'?: Partial<Record<keyof NonBooleanJsfSchema, string>>
+  'x-jsf-logic-computedAttrs'?: Partial<Record<keyof NonBooleanJsfSchema, string | JsfSchema['x-jsf-errorMessage']>>
 }
 
 /**

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -251,7 +251,7 @@ export function validateSchema(
     // Custom validations
     ...validateDate(value, schema, options, path),
     ...validateJsonLogicSchema(value, jsonLogicRootSchema, options, path, jsonLogicContext),
-    ...validateJsonLogicRules(schema, jsonLogicContext, path),
     ...validateJsonLogicComputedAttributes(value, schema, options, jsonLogicContext, path),
+    ...validateJsonLogicRules(schema, jsonLogicContext, path),
   ]
 }


### PR DESCRIPTION
## What

This PR adds the ability for computed error messages (`x-jsf-errorMessage` inside `x-jsf-computedAttrs`) to reference  
computed values of `x-jsf-logic`. For example:

```json
{
    "properties": {
      "some_property": {
        ...
        "x-jsf-logic-computedAttrs": {
          "minimum": "some_computation",
          "x-jsf-errorMessage": {
            "minimum": "Must be at least {{some_computation}} units"
          }
        }
      }
    },
    "required": [
      "some_property"
    ],
    "x-jsf-logic": {
      "computedValues": {
        "some_computation": {
          "rule": {
            "*": [
              {
                "var": "some_property"
              },
              0.5
            ]
          }
        }
      }
    }
  }
```

## How

This is mainly done with 2 changes:
- When applying the custom error message, we don't traverse the schema searching for the node that holds the `x-jsf-errorMessage` values. This has 2 problems:
  - 1. it traverses the tree again (this traversal already happened in the validation phase)
  - 2. it lacks the json logic context to apply the interpolated values
  - Instead, we now use the `schema` that comes attached to the `ValidationError`. This schema already brings any interpolations executed and makes the code much simpler
 - When applying the json logic computed attributes, we check if the attribute we're computing is `x-jsf-errorMessage` and, in that case, we run an `interpolate` function that replaced any handlebar symbols with the respective computed value from the json logic.