### PR TITLE
fix(next): Field - convert enum to options

### DIFF
--- a/next/src/field/schema.ts
+++ b/next/src/field/schema.ts
@@ -160,7 +160,6 @@ function convertToOptions(nodeOptions: JsfSchema[]): Array<FieldOption> {
  * Get field options from schema
  */
 function getFieldOptions(schema: NonBooleanJsfSchema) {
-  // Handle oneOf or radio input type
   if (schema.oneOf) {
     return convertToOptions(schema.oneOf || [])
   }
@@ -173,6 +172,15 @@ function getFieldOptions(schema: NonBooleanJsfSchema) {
   // Handle anyOf
   if (schema.anyOf) {
     return convertToOptions(schema.anyOf)
+  }
+
+  // Handle enum
+  if (schema.enum) {
+    const enumAsOneOf: JsfSchema['oneOf'] = schema.enum?.map(value => ({
+      title: typeof value === 'string' ? value : JSON.stringify(value),
+      const: value,
+    })) || []
+    return convertToOptions(enumAsOneOf)
   }
 
   return null

--- a/next/test/fields.test.ts
+++ b/next/test/fields.test.ts
@@ -302,7 +302,7 @@ describe('fields', () => {
         {
           type: 'radio',
           inputType: 'radio',
-          jsonType: 'text',
+          jsonType: 'text', // BUG: This is wrong, should be undefined.
           isVisible: true,
           name: 'status',
           required: false,

--- a/next/test/fields.test.ts
+++ b/next/test/fields.test.ts
@@ -283,6 +283,40 @@ describe('fields', () => {
       ])
     })
 
+    it.only('build a radio field with enum', () => {
+      const schema: JsfSchema = {
+        type: 'object',
+        properties: {
+          status: {
+            'enum': ['active', true, false, 1],
+            'x-jsf-presentation': {
+              inputType: 'radio',
+            },
+          },
+        },
+      }
+
+      const fields = buildFieldSchema(schema, 'root', true)!.fields!
+
+      expect(fields).toEqual([
+        {
+          type: 'radio',
+          inputType: 'radio',
+          jsonType: 'text',
+          isVisible: true,
+          name: 'status',
+          required: false,
+          enum: ['active', true, false, 1],
+          options: [
+            { label: 'active', value: 'active' },
+            { label: 'true', value: true },
+            { label: 'false', value: false },
+            { label: '1', value: 1 },
+          ],
+        },
+      ])
+    })
+
     it('skips options without a null const value', () => {
       const schema: JsfSchema = {
         type: 'object',


### PR DESCRIPTION
With this now the following JSON Schema which has a select/radio field gets converted properly with `options`:

```js
{
  type: 'object',
  properties: {
    status: {
      'enum': ['active', true, false, 1],
      'x-jsf-presentation': {
        inputType: 'radio',
      },
    },
  },
}
```

Field Output:

```js
{
  name: 'status',
  enum: ['active', true, false, 1],
  // 🆕 New!
  options: [
    { label: 'active', value: 'active' },
    { label: 'true', value: true },
    { label: 'false', value: false },
    { label: '1', value: 1 },
  ],
},
```