### PR TITLE
fix(next): set field jsonType to the schema's type

### DIFF
--- a/next/src/field/schema.ts
+++ b/next/src/field/schema.ts
@@ -3,23 +3,6 @@ import type { Field, FieldOption, FieldType } from './type'
 import { buildFieldObject } from './object'
 
 /**
- * Get the JSON type for a field
- * @param schema - The non boolean schema of the field
- * @returns The JSON type for the field, based schema type. Default to 'text'
- */
-function getJsonType(schema: NonBooleanJsfSchema): string {
-  if (Array.isArray(schema.type)) {
-    return 'select'
-  }
-
-  if (schema.type !== undefined) {
-    return schema.type as string
-  }
-
-  return 'text'
-}
-
-/**
  * Add checkbox attributes to a field
  * @param inputType - The input type of the field
  * @param field - The field to add the attributes to
@@ -230,7 +213,7 @@ export function buildFieldSchema(
     type: inputType,
     name,
     inputType,
-    jsonType: getJsonType(schema),
+    jsonType: schema.type,
     required,
     isVisible: true,
     ...(errorMessage && { errorMessage }),

--- a/next/src/field/type.ts
+++ b/next/src/field/type.ts
@@ -1,3 +1,5 @@
+import type { JsfSchemaType } from '../types'
+
 /**
  * WIP type for UI field output that allows for all `x-jsf-presentation` properties to be splatted
  * TODO/QUESTION: what are the required fields for a field? what are the things we want to deprecate, if any?
@@ -11,7 +13,7 @@ export interface Field {
   type: FieldType
   inputType: FieldType
   required: boolean
-  jsonType: string
+  jsonType: JsfSchemaType
   isVisible: boolean
   accept?: string
   errorMessage?: Record<string, string>

--- a/next/test/fields.test.ts
+++ b/next/test/fields.test.ts
@@ -520,4 +520,17 @@ describe('fields', () => {
       })
     })
   })
+
+  describe('jsonType', () => {
+    it('should be the type of the schema', () => {
+      expect(buildFieldSchema({ type: 'string' }, 'test')?.jsonType).toBe('string')
+      expect(buildFieldSchema({ type: 'number' }, 'test')?.jsonType).toBe('number')
+      expect(buildFieldSchema({ type: 'boolean' }, 'test')?.jsonType).toBe('boolean')
+      expect(buildFieldSchema({ type: 'object' }, 'test')?.jsonType).toBe('object')
+    })
+
+    it('should be undefined when the schema has no type', () => {
+      expect(buildFieldSchema({}, 'test')?.jsonType).toBeUndefined()
+    })
+  })
 })

--- a/next/test/fields.test.ts
+++ b/next/test/fields.test.ts
@@ -1,5 +1,6 @@
 import type { JsfSchema, NonBooleanJsfSchema } from '../src/types'
 import { describe, expect, it } from '@jest/globals'
+import { TypeName } from 'json-schema-typed'
 import { buildFieldSchema } from '../src/field/schema'
 
 describe('fields', () => {
@@ -523,10 +524,19 @@ describe('fields', () => {
 
   describe('jsonType', () => {
     it('should be the type of the schema', () => {
-      expect(buildFieldSchema({ type: 'string' }, 'test')?.jsonType).toBe('string')
-      expect(buildFieldSchema({ type: 'number' }, 'test')?.jsonType).toBe('number')
-      expect(buildFieldSchema({ type: 'boolean' }, 'test')?.jsonType).toBe('boolean')
-      expect(buildFieldSchema({ type: 'object' }, 'test')?.jsonType).toBe('object')
+      const schemaTypes = Object.values(TypeName)
+      for (const type of schemaTypes) {
+        // TODO: remove once array is supported
+        if (type === 'array') {
+          continue
+        }
+        expect(buildFieldSchema({ type }, 'test')?.jsonType).toBe(type)
+      }
+    })
+
+    it('should work for array types as well', () => {
+      expect(buildFieldSchema({ type: ['string', 'number'] }, 'test')?.jsonType).toEqual(['string', 'number'])
+      expect(buildFieldSchema({ type: [] }, 'test')?.jsonType).toEqual([])
     })
 
     it('should be undefined when the schema has no type', () => {

--- a/next/test/fields.test.ts
+++ b/next/test/fields.test.ts
@@ -303,7 +303,7 @@ describe('fields', () => {
         {
           type: 'radio',
           inputType: 'radio',
-          jsonType: 'text', // BUG: This is wrong, should be undefined.
+          jsonType: undefined,
           isVisible: true,
           name: 'status',
           required: false,


### PR DESCRIPTION
Sets the `jsonType` property on fields correctly. It should just be what the actual schema's type is.