### PR TITLE
chore(next): Type JSONSchema enum as unknown for better type safety

### DIFF
--- a/next/src/types.ts
+++ b/next/src/types.ts
@@ -54,6 +54,7 @@ export interface JsonLogicSchema extends JsonLogicRules, JsonLogicRootSchema {}
 export type JsfSchema = JSONSchema & {
   'properties'?: Record<string, JsfSchema>
   'items'?: JsfSchema
+  'enum'?: unknown[]
   'anyOf'?: JsfSchema[]
   'allOf'?: JsfSchema[]
   'oneOf'?: JsfSchema[]


### PR DESCRIPTION
Follow-up of https://github.com/remoteoss/json-schema-form/pull/181, comment https://github.com/remoteoss/json-schema-form/pull/181#discussion_r2073595996. 

Watch this [loom](https://www.loom.com/share/15db241248f44ea4af0cfcc2b6f1428b) explaining why `enum` should be typed as `unknown[]` instead of `any[]`.

TLDR: Internally we use `enum` to map it to some places that must be `string`. By using `any`, TS doesn't throw an error saying `enum` is not a `string`, which can lead to bugs if we don't pay attention (shown in Loom). 
By typing `enum` as `unknown[]`, TS calls our attention to it.