### PR TITLE
fix(next): update required property on fields when it is changed through conditional schemas

### DIFF
--- a/next/src/mutations.ts
+++ b/next/src/mutations.ts
@@ -154,6 +154,15 @@ function processBranch(fields: Field[], values: SchemaValue, branch: JsfSchema, 
     }
   }
 
+  // Go through the `required` array and mark all fields included in the array as required
+  if (Array.isArray(branch.required)) {
+    fields.forEach((field) => {
+      if (branch.required!.includes(field.name)) {
+        field.required = true
+      }
+    })
+  }
+
   // Apply rules to the branch
   applySchemaRules(fields, values, branch as JsfObjectSchema, options)
 }

--- a/next/test/fields/mutation.test.ts
+++ b/next/test/fields/mutation.test.ts
@@ -350,4 +350,97 @@ describe('field mutation', () => {
       })
     })
   })
+
+  it('correctly updates required on fields', () => {
+    const schema: JsfObjectSchema = {
+      'additionalProperties': false,
+      'allOf': [
+        {
+          else: {
+            properties: {
+              dependent_details: false,
+            },
+          },
+          if: {
+            properties: {
+              has_dependents: {
+                const: 'yes',
+              },
+            },
+            required: [
+              'has_dependents',
+            ],
+          },
+          then: {
+            required: [
+              'dependent_details',
+            ],
+          },
+        },
+      ],
+      'properties': {
+        dependent_details: {
+          'items': {
+            'properties': {
+              first_name: {
+                'maxLength': 255,
+                'title': 'First name',
+                'type': 'string',
+                'x-jsf-presentation': {
+                  inputType: 'text',
+                },
+              },
+            },
+            'required': [
+              'first_name',
+            ],
+            'type': 'object',
+            'x-jsf-order': [
+              'first_name',
+            ],
+          },
+          'title': 'Dependent',
+          'type': 'array',
+          'x-jsf-presentation': {
+            addFieldText: 'Add new section for dependent',
+            inputType: 'group-array',
+          },
+        },
+        has_dependents: {
+          'oneOf': [
+            {
+              const: 'yes',
+              title: 'Yes',
+            },
+            {
+              const: 'no',
+              title: 'No',
+            },
+          ],
+          'title': 'Do you have dependents to claim?',
+          'type': 'string',
+          'x-jsf-presentation': {
+            direction: 'row',
+            inputType: 'radio',
+          },
+        },
+      },
+      'required': [
+        'has_dependents',
+      ],
+      'type': 'object',
+      'x-jsf-order': [
+        'has_dependents',
+        'dependent_details',
+      ],
+    }
+
+    const form = createHeadlessForm(schema)
+
+    expect(form.fields[1].required).toBe(false)
+
+    form.handleValidation({ has_dependents: 'yes' })
+
+    expect(form.fields[1].required).toBe(true)
+  })
 })


### PR DESCRIPTION
This fixes a bug in next where the `required` property on a field was not updated when the field's required status changes through a conditional schema.
I've added a test that illustrates the issue.