### PR TITLE
feat(next): add allowForbiddenValues validation option

### DIFF
--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -21,6 +21,12 @@ export interface ValidationOptions {
    * @default false
    */
   treatNullAsUndefined?: boolean
+
+  /**
+   * If true, providing a value for a schema that is `false`
+   * @default false
+   */
+  allowForbiddenValues?: boolean
 }
 
 /**
@@ -189,7 +195,12 @@ export function validateSchema(
 
   // Handle boolean schemas
   if (typeof schema === 'boolean') {
-    return schema ? [] : [{ path, validation: 'forbidden', schema, value }]
+    // When the boolean schema is false, we will return an error, but only when forbidden values are not explicitly
+    // allowed per the allowForbiddenValues option.
+    if (!schema && !options.allowForbiddenValues) {
+      return [{ path, validation: 'forbidden', schema, value }]
+    }
+    return []
   }
 
   // Check if it is a file input (needed early for null check)

--- a/next/src/validation/schema.ts
+++ b/next/src/validation/schema.ts
@@ -23,7 +23,7 @@ export interface ValidationOptions {
   treatNullAsUndefined?: boolean
 
   /**
-   * If true, providing a value for a schema that is `false`
+   * If true, providing a value for a schema that is `false` won't create an error
    * @default false
    */
   allowForbiddenValues?: boolean

--- a/next/test/validation/boolean_schema.test.ts
+++ b/next/test/validation/boolean_schema.test.ts
@@ -14,4 +14,10 @@ describe('boolean schema validation', () => {
     expect(validateSchema({ name: 'anything' }, schema)).toEqual([])
     expect(validateSchema({}, schema)).toEqual([])
   })
+
+  it('does not return an error if the value is false and allowForbiddenValues is true', () => {
+    const schema = { type: 'object', properties: { name: false } }
+    expect(validateSchema({ name: 'anything' }, schema, { allowForbiddenValues: true })).toEqual([])
+    expect(validateSchema({}, schema, { allowForbiddenValues: true })).toEqual([])
+  })
 })


### PR DESCRIPTION
This adds an option that allow passing values to `false` schemas. This would normally result in a validation error but in v0 we explicitly clear values provided to a false schema: https://github.com/remoteoss/json-schema-form/blob/4efb07e3cd27a2e0a79b704e57e12432c80310f2/src/helpers.js#L451-L461

This option will achieve the same goal, but in a more straight forward way. It will also be disabled by default.