### PR TITLE
feat: allow select fields to be made from anyOf

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -506,10 +506,10 @@ function getFieldOptions(node, presentation) {
   }
 
   // it's similar to inputType=radio
-  if (node.oneOf || presentation.inputType === 'radio') {
+  if (node.oneOf || node.anyOf || presentation.inputType === 'radio') {
     // Do not do if(hasType("string")) because a JSON Schema does not need it
     // necessarily to be considered a valid json schema.
-    return convertToOptions(node.oneOf || []);
+    return convertToOptions(node.oneOf || node.anyOf || []);
   }
 
   // it's similar to inputType=select multiple

--- a/src/tests/createHeadlessForm.test.js
+++ b/src/tests/createHeadlessForm.test.js
@@ -571,6 +571,44 @@ describe('createHeadlessForm', () => {
         });
       });
 
+      it('support "select" field type from anyOf', () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            browser: {
+              type: 'string',
+              anyOf: [
+                { title: 'Chrome', const: 'chr' },
+                { title: 'Firefox', const: 'ff' },
+                { title: 'Add new option', pattern: '.*' },
+              ],
+              'x-jsf-presentation': {
+                inputType: 'select',
+              },
+            },
+          },
+        };
+
+        const { fields } = createHeadlessForm(schema);
+        const fieldSelect = fields[0];
+        expect(fieldSelect).toMatchObject({
+          options: [
+            {
+              value: 'chr',
+              label: 'Chrome',
+            },
+            {
+              value: 'ff',
+              label: 'Firefox',
+            },
+            {
+              label: 'Add new option',
+              pattern: '.*',
+            },
+          ],
+        });
+      });
+
       it('supports "select" field type with multiple options @deprecated', () => {
         const result = createHeadlessForm(schemaInputTypeSelectMultipleDeprecated);
         expect(result).toMatchObject({


### PR DESCRIPTION
This will enable the creation of select fields from an `anyOf` instead of just `oneOf`.
`oneOf` is problematic when when one of the options is a pattern like in this example:

``` json
{
  "oneOf": [
    { "title": "Option A", "const": "a" },
    { "title": "Option B", "const": "b" },
    { "title": "Option A", "const": "a" },
    { "pattern": ".*" }
  ]
}
```

When providing the value `"a"` or `"b"` to this schema the validation fails because `"a"` or `"b"` both match the pattern `".*"` as well and `oneOf` requires that exactly one subschema matches. What makes this matter somewhat confusing is that this schema works in v0 and does not have the issue I just described. This however is a bug, `oneOf` should not behave this way.

In v1 we implemented `oneOf` the correct way which means `oneOf` can't be used like in the schema above. Instead `anyOf` can be used like so:

``` json
{
  "anyOf": [
    { "title": "Option A", "const": "a" },
    { "title": "Option B", "const": "b" },
    { "title": "Option A", "const": "a" },
    { "pattern": ".*" }
  ]
}
```

In order to make migrating existing schemas to v1 possible, we need v0 to also support the `anyOf` version which it currently does not do. That's what this PR addresses.