### PR TITLE
fix(v1): don't fail validation when oneOf array is empty

### DIFF
--- a/next/src/validation/composition.ts
+++ b/next/src/validation/composition.ts
@@ -96,6 +96,7 @@ export function validateAnyOf(
  * Validate a value against the `oneOf` keyword in a schema.
  * The value must validate successfully against EXACTLY ONE schema in the oneOf array.
  * Returns an error if no schemas validate or if multiple schemas validate.
+ * No error is returned if the oneOf array is empty.
  *
  * @example
  * ```json
@@ -116,6 +117,10 @@ export function validateOneOf(
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   if (!schema.oneOf) {
+    return []
+  }
+
+  if (schema.oneOf.length === 0) {
     return []
   }
 

--- a/next/test/json-schema-test-suite/failed-json-schema-test-suite.json
+++ b/next/test/json-schema-test-suite/failed-json-schema-test-suite.json
@@ -376,10 +376,7 @@
       "non-number is invalid"
     ],
     "required properties whose names are Javascript object property names": [
-      "none of the properties mentioned",
-      "__proto__ present",
-      "toString present",
-      "constructor present"
+      "__proto__ present"
     ],
     "unevaluatedItems false": [
       "with unevaluated items"

--- a/next/test/validation/composition.test.ts
+++ b/next/test/validation/composition.test.ts
@@ -323,6 +323,24 @@ describe('schema composition validators', () => {
       })
     })
 
+    describe('with empty oneOf array', () => {
+      const schema: JsfSchema = {
+        oneOf: [],
+        type: 'number',
+      }
+
+      it('should validate when the value is a number', () => {
+        const errors = validateSchema(123, schema)
+        expect(errors).toHaveLength(0)
+      })
+
+      it('should fail when the value is a string', () => {
+        const errors = validateSchema('foo', schema)
+        expect(errors).toHaveLength(1)
+        expect(errors[0].validation).toBe('type')
+      })
+    })
+
     describe('with required properties', () => {
       const schema: JsfSchema = {
         type: 'object',


### PR DESCRIPTION
As it turns out, `{"oneOf": []}` should match any value. Previously we would just return a validation error in this case, but I think that's not correct. I think [the spec](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3) can be interpreted either way but matching any value seems more practical to me and this is also how v0 handles it.