### PR TITLE
chore(next): throw error when deprecated modifyConfig option is passed to createHeadlessForm

### DIFF
--- a/next/src/form.ts
+++ b/next/src/form.ts
@@ -242,10 +242,22 @@ function buildFields(params: { schema: JsfObjectSchema, originalSchema: JsfObjec
   return fields
 }
 
+/**
+ * Ensures that no forbidden options are given
+ * @param options - The options to validate
+ * @throws An error if any forbidden options are found
+ */
+function validateOptions(options: CreateHeadlessFormOptions) {
+  if (Object.prototype.hasOwnProperty.call(options, 'modifyConfig')) {
+    throw new Error('modifyConfig has been removed from json-schema-form v1')
+  }
+}
+
 export function createHeadlessForm(
   schema: JsfObjectSchema,
   options: CreateHeadlessFormOptions = {},
 ): FormResult {
+  validateOptions(options)
   const initialValues = options.initialValues || {}
   const strictInputType = options.strictInputType || false
   // Make a new version of the schema with all the computed attrs applied, as well as the final version of each property (taking into account conditional rules)

--- a/next/test/form.test.ts
+++ b/next/test/form.test.ts
@@ -1,8 +1,40 @@
+import type { JsfObjectSchema } from '../src/types'
 import { describe, expect, it } from '@jest/globals'
 import { createHeadlessForm } from '../src'
 
 describe('createHeadlessForm', () => {
   it('should be a function', () => {
     expect(createHeadlessForm).toBeInstanceOf(Function)
+  })
+
+  describe('options validation', () => {
+    const basicSchema: JsfObjectSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    }
+
+    it('should throw error when modifyConfig option is provided', () => {
+      expect(() => {
+        createHeadlessForm(basicSchema, { modifyConfig: {} } as any)
+      }).toThrow('modifyConfig has been removed from json-schema-form v1')
+    })
+
+    it('should not throw error when modifyConfig option is not provided', () => {
+      expect(() => {
+        createHeadlessForm(basicSchema, {})
+      }).not.toThrow()
+    })
+
+    it('should not throw error when other valid options are provided', () => {
+      expect(() => {
+        createHeadlessForm(basicSchema, {
+          initialValues: { name: 'test' },
+          validationOptions: {},
+          strictInputType: true,
+        })
+      }).not.toThrow()
+    })
   })
 })


### PR DESCRIPTION
When migrating code from v0 to v1 this should make it easier to notice when the deprecated `modifyConfig` option is used