### PR TITLE
chore: Explain ValidationOptions are a backward-compatibility with v0 mistakes

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -236,14 +236,23 @@ if (formErrors?.address?.street) {
 }
 ```
 
-### 3. **Validation behaviors compatibility with v0**
+## Common Migration Issues
 
-Some validation behaviors *were wrong* in v0, we fixed them in v1.
-If you still need them, you need to enable them in the `validationOptions` option.
+### 1. **ESM Import Errors**
 
-Check the ValidationOptions Type for more details.
+If you get import errors, ensure your project supports ESM:
 
-This was a bug in v0, we fixed it in v1. If you need the same behavior, set this to true.
+```json
+// package.json
+{
+  "type": "module"
+}
+```
+
+### 2. **Validation backward compatibility with v0**
+
+Some validation behaviors *were wrong* in `v0`, we fixed them in v1.
+If you still need them, you need to enable them in the `validationOptions` config.
 
 ```typescript
 const form = createHeadlessForm(schema, {
@@ -252,7 +261,7 @@ const form = createHeadlessForm(schema, {
      * A null value will be treated as undefined.
      * When true, providing a value to a schema that is `false`,
      * the validation will succeed instead of returning a type error.
-     * This was a bug in v0, we fixed it in v1. If you need the same behavior, set this to true.
+     * This was a bug in v0, we fixed it in v1. If you need the same wrong behavior, set this to true.
      * @default false
      * @example
      * ```ts
@@ -265,7 +274,7 @@ const form = createHeadlessForm(schema, {
      * A value against a schema "false" will be allowed.
      * When true, providing a value to a non-required field that is not of type 'null' or ['null']
      * the validation will succeed instead of returning a type error.
-     * This was a bug in v0, we fixed it in v1. If you need the same behavior, set this to true.
+     * This was a bug in v0, we fixed it in v1. If you need the same wrong behavior, set this to true.
      * @default false
      * @example
      * ```ts
@@ -276,19 +285,6 @@ const form = createHeadlessForm(schema, {
     allowForbiddenValues: true,
   }
 })
-```
-
-## Common Migration Issues
-
-### 1. **ESM Import Errors**
-
-If you get import errors, ensure your project supports ESM:
-
-```json
-// package.json
-{
-  "type": "module"
-}
 ```
 
 ## Testing Your Migration

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -18,7 +18,7 @@ export interface ValidationOptions {
    * A null value will be treated as undefined.
    * When true, providing a value to a schema that is `false`,
    * the validation will succeed instead of returning a type error.
-   * This was a bug in v0, we fixed it in v1. If you need the same behavior, set this to true.
+   * This was a bug in v0, we fixed it in v1. If you need the same wrong behavior, set this to true.
    * @default false
    * @example
    * ```ts
@@ -31,7 +31,7 @@ export interface ValidationOptions {
    * A value against a schema "false" will be allowed.
    * When true, providing a value to a non-required field that is not of type 'null' or ['null']
    * the validation will succeed instead of returning a type error.
-   * This was a bug in v0, we fixed it in v1. If you need the same behavior, set this to true.
+   * This was a bug in v0, we fixed it in v1. If you need the same wrong behavior, set this to true.
    * @default false
    * @example
    * ```ts


### PR DESCRIPTION
It was not well explained what v1 `ValidationOptions` are for, and why they were created. Now it is more clear.