### PR TITLE
fix: rename validationOptions to legacyOptions

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -40,7 +40,7 @@ v1 removes several heavy dependencies:
 +   Field,
 +   FieldType,
 +   FormErrors,
-+   ValidationOptions,
++   V0Support,
 +   ValidationResult
 + } from '@remoteoss/json-schema-form'
 ```
@@ -56,7 +56,7 @@ v1 removes several heavy dependencies:
 
 + createHeadlessForm(schema, {
 +   initialValues: { ... },
-+   validationOptions: { ... },
++   v0Support: { ... },
 +   strictInputType: boolean
 + })
 ```
@@ -252,11 +252,11 @@ If you get import errors, ensure your project supports ESM:
 ### 2. **Validation backward compatibility with v0**
 
 Some validation behaviors *were wrong* in `v0`, we fixed them in v1.
-If you still need them, you need to enable them in the `validationOptions` config.
+If you still need them, you need to enable them in the `v0Support` config.
 
 ```typescript
 const form = createHeadlessForm(schema, {
-  validationOptions: {
+  v0Support: {
     /**
      * A null value will be treated as undefined.
      * When true, providing a value to a schema that is `false`,

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -40,7 +40,7 @@ v1 removes several heavy dependencies:
 +   Field,
 +   FieldType,
 +   FormErrors,
-+   V0Support,
++   LegacyOptions,
 +   ValidationResult
 + } from '@remoteoss/json-schema-form'
 ```
@@ -56,7 +56,7 @@ v1 removes several heavy dependencies:
 
 + createHeadlessForm(schema, {
 +   initialValues: { ... },
-+   v0Support: { ... },
++   legacyOptions: { ... },
 +   strictInputType: boolean
 + })
 ```
@@ -252,11 +252,11 @@ If you get import errors, ensure your project supports ESM:
 ### 2. **Validation backward compatibility with v0**
 
 Some validation behaviors *were wrong* in `v0`, we fixed them in v1.
-If you still need them, you need to enable them in the `v0Support` config.
+If you still need them, you need to enable them in the `legacyOptions` config.
 
 ```typescript
 const form = createHeadlessForm(schema, {
-  v0Support: {
+  legacyOptions: {
     /**
      * A null value will be treated as undefined.
      * When true, providing a value to a schema that is `false`,

--- a/src/form.ts
+++ b/src/form.ts
@@ -1,13 +1,13 @@
 import type { ValidationError, ValidationErrorPath } from './errors'
 import type { Field } from './field/type'
 import type { JsfObjectSchema, JsfSchema, SchemaValue } from './types'
-import type { ValidationOptions } from './validation/schema'
+import type { V0Support } from './validation/schema'
 import { getErrorMessage } from './errors/messages'
 import { buildFieldSchema } from './field/schema'
 import { calculateFinalSchema, updateFieldProperties } from './mutations'
 import { validateSchema } from './validation/schema'
 
-export { ValidationOptions } from './validation/schema'
+export { V0Support } from './validation/schema'
 
 interface FormResult {
   fields: Field[]
@@ -198,7 +198,7 @@ function applyCustomErrorMessages(errors: ValidationErrorWithMessage[], schema: 
  * @param schema - The schema to validate against
  * @returns The validation result
  */
-function validate(value: SchemaValue, schema: JsfSchema, options: ValidationOptions = {}): ValidationResult {
+function validate(value: SchemaValue, schema: JsfSchema, options: V0Support = {}): ValidationResult {
   const result: ValidationResult = {}
   const errors = validateSchema(value, schema, options)
 
@@ -220,9 +220,9 @@ export interface CreateHeadlessFormOptions {
    */
   initialValues?: SchemaValue
   /**
-   * The validation options to use for the form
+   * Backward compatibility config with v0
    */
-  validationOptions?: ValidationOptions
+  v0Support?: V0Support
   /**
    * When enabled, ['x-jsf-presentation'].inputType is required for all properties.
    * @default false
@@ -264,7 +264,7 @@ export function createHeadlessForm(
   const updatedSchema = calculateFinalSchema({
     schema,
     values: initialValues,
-    options: options.validationOptions,
+    options: options.v0Support,
   })
 
   const fields = buildFields({ schema: updatedSchema, originalSchema: schema, strictInputType })
@@ -276,10 +276,10 @@ export function createHeadlessForm(
     const updatedSchema = calculateFinalSchema({
       schema,
       values: value,
-      options: options.validationOptions,
+      options: options.v0Support,
     })
 
-    const result = validate(value, updatedSchema, options.validationOptions)
+    const result = validate(value, updatedSchema, options.v0Support)
 
     // Fields properties might have changed, so we need to reset the fields by updating them in place
     updateFieldProperties(fields, updatedSchema, schema)

--- a/src/form.ts
+++ b/src/form.ts
@@ -1,13 +1,13 @@
 import type { ValidationError, ValidationErrorPath } from './errors'
 import type { Field } from './field/type'
 import type { JsfObjectSchema, JsfSchema, SchemaValue } from './types'
-import type { V0Support } from './validation/schema'
+import type { LegacyOptions } from './validation/schema'
 import { getErrorMessage } from './errors/messages'
 import { buildFieldSchema } from './field/schema'
 import { calculateFinalSchema, updateFieldProperties } from './mutations'
 import { validateSchema } from './validation/schema'
 
-export { V0Support } from './validation/schema'
+export { LegacyOptions } from './validation/schema'
 
 interface FormResult {
   fields: Field[]
@@ -198,7 +198,7 @@ function applyCustomErrorMessages(errors: ValidationErrorWithMessage[], schema: 
  * @param schema - The schema to validate against
  * @returns The validation result
  */
-function validate(value: SchemaValue, schema: JsfSchema, options: V0Support = {}): ValidationResult {
+function validate(value: SchemaValue, schema: JsfSchema, options: LegacyOptions = {}): ValidationResult {
   const result: ValidationResult = {}
   const errors = validateSchema(value, schema, options)
 
@@ -222,7 +222,7 @@ export interface CreateHeadlessFormOptions {
   /**
    * Backward compatibility config with v0
    */
-  v0Support?: V0Support
+  legacyOptions?: LegacyOptions
   /**
    * When enabled, ['x-jsf-presentation'].inputType is required for all properties.
    * @default false
@@ -264,7 +264,7 @@ export function createHeadlessForm(
   const updatedSchema = calculateFinalSchema({
     schema,
     values: initialValues,
-    options: options.v0Support,
+    options: options.legacyOptions,
   })
 
   const fields = buildFields({ schema: updatedSchema, originalSchema: schema, strictInputType })
@@ -276,10 +276,10 @@ export function createHeadlessForm(
     const updatedSchema = calculateFinalSchema({
       schema,
       values: value,
-      options: options.v0Support,
+      options: options.legacyOptions,
     })
 
-    const result = validate(value, updatedSchema, options.v0Support)
+    const result = validate(value, updatedSchema, options.legacyOptions)
 
     // Fields properties might have changed, so we need to reset the fields by updating them in place
     updateFieldProperties(fields, updatedSchema, schema)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export {
   createHeadlessForm,
   type CreateHeadlessFormOptions,
   type FormErrors,
-  type ValidationOptions,
+  type V0Support,
   type ValidationResult,
 } from './form'
 export { modifySchema as modify } from './modify-schema'

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export {
   createHeadlessForm,
   type CreateHeadlessFormOptions,
   type FormErrors,
-  type V0Support,
+  type LegacyOptions,
   type ValidationResult,
 } from './form'
 export { modifySchema as modify } from './modify-schema'

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -1,6 +1,6 @@
 import type { Field } from './field/type'
 import type { JsfObjectSchema, JsfSchema, JsonLogicContext, NonBooleanJsfSchema, ObjectValue, SchemaValue } from './types'
-import type { ValidationOptions } from './validation/schema'
+import type { V0Support } from './validation/schema'
 import { buildFieldSchema } from './field/schema'
 import { deepMergeSchemas } from './utils'
 import { applyComputedAttrsToSchema, getJsonLogicContextFromSchema } from './validation/json-logic'
@@ -23,7 +23,7 @@ export function calculateFinalSchema({
 }: {
   schema: JsfObjectSchema
   values: SchemaValue
-  options?: ValidationOptions
+  options?: V0Support
 }): JsfObjectSchema {
   const jsonLogicContext = schema['x-jsf-logic'] ? getJsonLogicContextFromSchema(schema['x-jsf-logic'], values) : undefined
   const schemaCopy = safeDeepClone(schema)
@@ -49,7 +49,7 @@ function evaluateConditional(
   values: ObjectValue,
   schema: JsfObjectSchema,
   rule: NonBooleanJsfSchema,
-  options: ValidationOptions = {},
+  options: V0Support = {},
 ) {
   const conditionIsTrue = validateSchema(values, rule.if!, options).length === 0
 
@@ -81,7 +81,7 @@ function evaluateConditional(
 function applySchemaRules(
   schema: JsfObjectSchema,
   values: SchemaValue = {},
-  options: ValidationOptions = {},
+  options: V0Support = {},
   jsonLogicContext: JsonLogicContext | undefined,
 ) {
   if (!isObjectValue(values)) {
@@ -142,7 +142,7 @@ function applySchemaRules(
  * @param options - Validation options
  * @param jsonLogicContext - JSON Logic context
  */
-function processBranch(schema: JsfObjectSchema, values: SchemaValue, branch: JsfSchema, options: ValidationOptions = {}, jsonLogicContext: JsonLogicContext | undefined) {
+function processBranch(schema: JsfObjectSchema, values: SchemaValue, branch: JsfSchema, options: V0Support = {}, jsonLogicContext: JsonLogicContext | undefined) {
   const branchSchema = branch as JsfObjectSchema
 
   applySchemaRules(branchSchema, values, options, jsonLogicContext)

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -1,6 +1,6 @@
 import type { Field } from './field/type'
 import type { JsfObjectSchema, JsfSchema, JsonLogicContext, NonBooleanJsfSchema, ObjectValue, SchemaValue } from './types'
-import type { V0Support } from './validation/schema'
+import type { LegacyOptions } from './validation/schema'
 import { buildFieldSchema } from './field/schema'
 import { deepMergeSchemas } from './utils'
 import { applyComputedAttrsToSchema, getJsonLogicContextFromSchema } from './validation/json-logic'
@@ -23,7 +23,7 @@ export function calculateFinalSchema({
 }: {
   schema: JsfObjectSchema
   values: SchemaValue
-  options?: V0Support
+  options?: LegacyOptions
 }): JsfObjectSchema {
   const jsonLogicContext = schema['x-jsf-logic'] ? getJsonLogicContextFromSchema(schema['x-jsf-logic'], values) : undefined
   const schemaCopy = safeDeepClone(schema)
@@ -49,7 +49,7 @@ function evaluateConditional(
   values: ObjectValue,
   schema: JsfObjectSchema,
   rule: NonBooleanJsfSchema,
-  options: V0Support = {},
+  options: LegacyOptions = {},
 ) {
   const conditionIsTrue = validateSchema(values, rule.if!, options).length === 0
 
@@ -81,7 +81,7 @@ function evaluateConditional(
 function applySchemaRules(
   schema: JsfObjectSchema,
   values: SchemaValue = {},
-  options: V0Support = {},
+  options: LegacyOptions = {},
   jsonLogicContext: JsonLogicContext | undefined,
 ) {
   if (!isObjectValue(values)) {
@@ -142,7 +142,7 @@ function applySchemaRules(
  * @param options - Validation options
  * @param jsonLogicContext - JSON Logic context
  */
-function processBranch(schema: JsfObjectSchema, values: SchemaValue, branch: JsfSchema, options: V0Support = {}, jsonLogicContext: JsonLogicContext | undefined) {
+function processBranch(schema: JsfObjectSchema, values: SchemaValue, branch: JsfSchema, options: LegacyOptions = {}, jsonLogicContext: JsonLogicContext | undefined) {
   const branchSchema = branch as JsfObjectSchema
 
   applySchemaRules(branchSchema, values, options, jsonLogicContext)

--- a/src/validation/array.ts
+++ b/src/validation/array.ts
@@ -1,6 +1,6 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { JsfSchema, JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
-import { validateSchema, type V0Support } from './schema'
+import { type V0Support, validateSchema } from './schema'
 import { deepEqual } from './util'
 
 /**

--- a/src/validation/array.ts
+++ b/src/validation/array.ts
@@ -1,6 +1,6 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { JsfSchema, JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
-import { validateSchema, type ValidationOptions } from './schema'
+import { validateSchema, type V0Support } from './schema'
 import { deepEqual } from './util'
 
 /**
@@ -18,7 +18,7 @@ import { deepEqual } from './util'
 export function validateArray(
   value: SchemaValue,
   schema: JsfSchema,
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
@@ -82,7 +82,7 @@ function validateLength(
 function validateItems(
   schema: NonBooleanJsfSchema,
   values: SchemaValue[],
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
@@ -123,7 +123,7 @@ function validateItems(
 function validatePrefixItems(
   schema: NonBooleanJsfSchema,
   values: SchemaValue[],
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
@@ -164,7 +164,7 @@ function validatePrefixItems(
 function validateContains(
   value: SchemaValue[],
   schema: NonBooleanJsfSchema,
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {

--- a/src/validation/array.ts
+++ b/src/validation/array.ts
@@ -1,6 +1,6 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { JsfSchema, JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
-import { type V0Support, validateSchema } from './schema'
+import { type LegacyOptions, validateSchema } from './schema'
 import { deepEqual } from './util'
 
 /**
@@ -18,7 +18,7 @@ import { deepEqual } from './util'
 export function validateArray(
   value: SchemaValue,
   schema: JsfSchema,
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
@@ -82,7 +82,7 @@ function validateLength(
 function validateItems(
   schema: NonBooleanJsfSchema,
   values: SchemaValue[],
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
@@ -123,7 +123,7 @@ function validateItems(
 function validatePrefixItems(
   schema: NonBooleanJsfSchema,
   values: SchemaValue[],
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {
@@ -164,7 +164,7 @@ function validatePrefixItems(
 function validateContains(
   value: SchemaValue[],
   schema: NonBooleanJsfSchema,
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath,
 ): ValidationError[] {

--- a/src/validation/composition.ts
+++ b/src/validation/composition.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { V0Support } from '../form'
+import type { LegacyOptions } from '../form'
 import type { JsfSchema, JsonLogicContext, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 
@@ -29,7 +29,7 @@ import { validateSchema } from './schema'
 export function validateAllOf(
   value: SchemaValue,
   schema: JsfSchema,
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
@@ -67,7 +67,7 @@ export function validateAllOf(
 export function validateAnyOf(
   value: SchemaValue,
   schema: JsfSchema,
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
@@ -112,7 +112,7 @@ export function validateAnyOf(
 export function validateOneOf(
   value: SchemaValue,
   schema: JsfSchema,
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
@@ -181,7 +181,7 @@ export function validateOneOf(
 export function validateNot(
   value: SchemaValue,
   schema: JsfSchema,
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {

--- a/src/validation/composition.ts
+++ b/src/validation/composition.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { ValidationOptions } from '../form'
+import type { V0Support } from '../form'
 import type { JsfSchema, JsonLogicContext, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 
@@ -29,7 +29,7 @@ import { validateSchema } from './schema'
 export function validateAllOf(
   value: SchemaValue,
   schema: JsfSchema,
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
@@ -67,7 +67,7 @@ export function validateAllOf(
 export function validateAnyOf(
   value: SchemaValue,
   schema: JsfSchema,
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
@@ -112,7 +112,7 @@ export function validateAnyOf(
 export function validateOneOf(
   value: SchemaValue,
   schema: JsfSchema,
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
@@ -181,7 +181,7 @@ export function validateOneOf(
 export function validateNot(
   value: SchemaValue,
   schema: JsfSchema,
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {

--- a/src/validation/conditions.ts
+++ b/src/validation/conditions.ts
@@ -1,12 +1,12 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { V0Support } from '../form'
+import type { LegacyOptions } from '../form'
 import type { JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 
 export function validateCondition(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {

--- a/src/validation/conditions.ts
+++ b/src/validation/conditions.ts
@@ -1,12 +1,12 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { ValidationOptions } from '../form'
+import type { V0Support } from '../form'
 import type { JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 
 export function validateCondition(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {

--- a/src/validation/custom/date.ts
+++ b/src/validation/custom/date.ts
@@ -1,6 +1,6 @@
 import type { ValidationError, ValidationErrorPath } from '../../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../../types'
-import type { ValidationOptions } from '../schema'
+import type { V0Support } from '../schema'
 
 export const DATE_FORMAT = 'yyyy-MM-dd'
 type DateComparisonResult = 'LESSER' | 'GREATER' | 'EQUAL'
@@ -62,7 +62,7 @@ function validateMaxDate(value: string, maxDate: string): boolean {
 export function validateDate(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  options: ValidationOptions,
+  options: V0Support,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   const isString = typeof value === 'string'

--- a/src/validation/custom/date.ts
+++ b/src/validation/custom/date.ts
@@ -1,6 +1,6 @@
 import type { ValidationError, ValidationErrorPath } from '../../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../../types'
-import type { V0Support } from '../schema'
+import type { LegacyOptions } from '../schema'
 
 export const DATE_FORMAT = 'yyyy-MM-dd'
 type DateComparisonResult = 'LESSER' | 'GREATER' | 'EQUAL'
@@ -62,7 +62,7 @@ function validateMaxDate(value: string, maxDate: string): boolean {
 export function validateDate(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  options: V0Support,
+  options: LegacyOptions,
   path: ValidationErrorPath = [],
 ): ValidationError[] {
   const isString = typeof value === 'string'

--- a/src/validation/object.ts
+++ b/src/validation/object.ts
@@ -1,5 +1,5 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { ValidationOptions } from '../form'
+import type { V0Support } from '../form'
 import type { JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 import { isObjectValue } from './util'
@@ -19,7 +19,7 @@ import { isObjectValue } from './util'
 export function validateObject(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  options: ValidationOptions,
+  options: V0Support,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {

--- a/src/validation/object.ts
+++ b/src/validation/object.ts
@@ -1,5 +1,5 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { V0Support } from '../form'
+import type { LegacyOptions } from '../form'
 import type { JsonLogicContext, NonBooleanJsfSchema, SchemaValue } from '../types'
 import { validateSchema } from './schema'
 import { isObjectValue } from './util'
@@ -19,7 +19,7 @@ import { isObjectValue } from './util'
 export function validateObject(
   value: SchemaValue,
   schema: NonBooleanJsfSchema,
-  options: V0Support,
+  options: LegacyOptions,
   jsonLogicContext: JsonLogicContext | undefined,
   path: ValidationErrorPath = [],
 ): ValidationError[] {

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -13,7 +13,7 @@ import { validateObject } from './object'
 import { validateString } from './string'
 import { isObjectValue } from './util'
 
-export interface ValidationOptions {
+export interface V0Support {
   /**
    * A null value will be treated as undefined.
    * When true, providing a value to a schema that is `false`,
@@ -139,7 +139,7 @@ function validateType(
  * @param jsonLogicContext - The json-logic context
  * @returns An array of validation errors
  */
-function validateJsonLogicSchema(value: SchemaValue, schema: JsfSchema | undefined, options: ValidationOptions = {}, path: ValidationErrorPath = [], jsonLogicContext?: JsonLogicContext): ValidationError[] {
+function validateJsonLogicSchema(value: SchemaValue, schema: JsfSchema | undefined, options: V0Support = {}, path: ValidationErrorPath = [], jsonLogicContext?: JsonLogicContext): ValidationError[] {
   if (!schema) {
     return []
   }
@@ -179,7 +179,7 @@ function validateJsonLogicSchema(value: SchemaValue, schema: JsfSchema | undefin
 export function validateSchema(
   value: SchemaValue,
   schema: JsfSchema,
-  options: ValidationOptions = {},
+  options: V0Support = {},
   path: ValidationErrorPath = [],
   rootJsonLogicContext?: JsonLogicContext,
 ): ValidationError[] {

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -13,7 +13,7 @@ import { validateObject } from './object'
 import { validateString } from './string'
 import { isObjectValue } from './util'
 
-export interface V0Support {
+export interface LegacyOptions {
   /**
    * A null value will be treated as undefined.
    * When true, providing a value to a schema that is `false`,
@@ -139,7 +139,7 @@ function validateType(
  * @param jsonLogicContext - The json-logic context
  * @returns An array of validation errors
  */
-function validateJsonLogicSchema(value: SchemaValue, schema: JsfSchema | undefined, options: V0Support = {}, path: ValidationErrorPath = [], jsonLogicContext?: JsonLogicContext): ValidationError[] {
+function validateJsonLogicSchema(value: SchemaValue, schema: JsfSchema | undefined, options: LegacyOptions = {}, path: ValidationErrorPath = [], jsonLogicContext?: JsonLogicContext): ValidationError[] {
   if (!schema) {
     return []
   }
@@ -179,7 +179,7 @@ function validateJsonLogicSchema(value: SchemaValue, schema: JsfSchema | undefin
 export function validateSchema(
   value: SchemaValue,
   schema: JsfSchema,
-  options: V0Support = {},
+  options: LegacyOptions = {},
   path: ValidationErrorPath = [],
   rootJsonLogicContext?: JsonLogicContext,
 ): ValidationError[] {

--- a/test/errors/messages.test.ts
+++ b/test/errors/messages.test.ts
@@ -467,7 +467,7 @@ describe('validation error messages', () => {
 
         expect(result.formErrors).toBeUndefined()
 
-        form = createHeadlessForm(schema, { validationOptions: { treatNullAsUndefined: true } })
+        form = createHeadlessForm(schema, { v0Support: { treatNullAsUndefined: true } })
 
         result = form.handleValidation({
           dateWithoutConstraints: null,

--- a/test/errors/messages.test.ts
+++ b/test/errors/messages.test.ts
@@ -467,7 +467,7 @@ describe('validation error messages', () => {
 
         expect(result.formErrors).toBeUndefined()
 
-        form = createHeadlessForm(schema, { v0Support: { treatNullAsUndefined: true } })
+        form = createHeadlessForm(schema, { legacyOptions: { treatNullAsUndefined: true } })
 
         result = form.handleValidation({
           dateWithoutConstraints: null,

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -31,7 +31,7 @@ describe('createHeadlessForm', () => {
       expect(() => {
         createHeadlessForm(basicSchema, {
           initialValues: { name: 'test' },
-          validationOptions: {},
+          v0Support: {},
           strictInputType: true,
         })
       }).not.toThrow()

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -31,7 +31,7 @@ describe('createHeadlessForm', () => {
       expect(() => {
         createHeadlessForm(basicSchema, {
           initialValues: { name: 'test' },
-          v0Support: {},
+          legacyOptions: {},
           strictInputType: true,
         })
       }).not.toThrow()


### PR DESCRIPTION
Follow-up of https://github.com/remoteoss/json-schema-form/pull/211, comment:

> note: Now looking back I'd have called this v0Support instead of ValidationOptions. This is where we'd also pass any config to still support deprecated features.
> 
> Another one that comes to my mind is [dropping type attr in favor of of inputType](https://linear.app/remote/issue/DEVXP-2862/deprecate-type-attr-on-field). If we have done that already, then it would look like this:
> ```js
> const form = createHeadlessForm(schema, {
>   v0Support: {
>       includeTypeAttr: true,
>   }
> }
> ```