### PR TITLE
fix: properly handle function as custom field properties

### DIFF
--- a/src/field/schema.ts
+++ b/src/field/schema.ts
@@ -373,7 +373,12 @@ export function buildFieldSchema({
     return null
   }
 
-  const presentation = schema['x-jsf-presentation'] || {}
+  const presentation = {
+    // We need to use the original schema's presentation as a basis as there are some properties that can't be
+    // serialized (so they were not cloned)
+    ...(originalSchema['x-jsf-presentation'] || {}),
+    ...(schema['x-jsf-presentation'] || {}),
+  }
   const errorMessage = schema['x-jsf-errorMessage']
 
   // Get input type from presentation or fallback to schema type

--- a/src/form.ts
+++ b/src/form.ts
@@ -245,11 +245,11 @@ function buildFields(params: { schema: JsfObjectSchema, originalSchema: JsfObjec
 /**
  * Ensures that no forbidden options are given
  * @param options - The options to validate
- * @throws An error if any forbidden options are found
+ * Alerts to the console that the option is deprecated and not being considered
  */
 function validateOptions(options: CreateHeadlessFormOptions) {
   if (Object.prototype.hasOwnProperty.call(options, 'customProperties')) {
-    throw new Error('`customProperties` is a deprecated option and it\'s not supported on json-schema-form v1')
+    console.error('[json-schema-form] `customProperties` is a deprecated option and it\'s not supported on json-schema-form v1')
   }
 }
 

--- a/src/validation/util.ts
+++ b/src/validation/util.ts
@@ -71,6 +71,7 @@ export function deepEqual(a: SchemaValue, b: SchemaValue): boolean {
 
 /**
  * Deep clones an object using structuredClone if available, otherwise falls back to JSON.parse/stringify approach.
+ * Please note: some properties might not be serializable (e.g. functions), so they will be lost in the clone.
  *
  * @param obj - The object to clone
  * @returns deep clone of the original object

--- a/test/fields.test.ts
+++ b/test/fields.test.ts
@@ -163,7 +163,10 @@ describe('fields', () => {
     })
   })
 
-  it('should handle custom x-jsf-presentation properties', () => {
+  it('should handle custom x-jsf-presentation properties, including functions', () => {
+    const customComponent = () => {
+      return null
+    }
     const schema: JsfSchema = {
       type: 'object',
       properties: {
@@ -174,6 +177,7 @@ describe('fields', () => {
             inputType: 'file',
             accept: '.pdf,.doc',
             maxFileSize: 5000000,
+            Component: customComponent,
           },
         },
       },
@@ -192,6 +196,7 @@ describe('fields', () => {
         required: false,
         accept: '.pdf,.doc',
         maxFileSize: 5000000,
+        Component: customComponent,
       },
     ])
   })

--- a/test/fields/array.test.ts
+++ b/test/fields/array.test.ts
@@ -217,6 +217,8 @@ describe('buildFieldArray', () => {
           isVisible: true,
           nameKey: 'title',
           required: false,
+          foo: 'bar',
+          bar: 'baz',
         },
       ],
       items: expect.any(Object),

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -1,5 +1,5 @@
 import type { JsfObjectSchema } from '../src/types'
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, jest } from '@jest/globals'
 import { createHeadlessForm } from '../src'
 
 describe('createHeadlessForm', () => {
@@ -16,9 +16,10 @@ describe('createHeadlessForm', () => {
     }
 
     it('should throw error when customProperties option is provided', () => {
-      expect(() => {
-        createHeadlessForm(basicSchema, { customProperties: {} } as any)
-      }).toThrow('`customProperties` is a deprecated option and it\'s not supported on json-schema-form v1')
+      // spy on console.error
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      createHeadlessForm(basicSchema, { customProperties: {} } as any)
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[json-schema-form] `customProperties` is a deprecated option and it\'s not supported on json-schema-form v1')
     })
 
     it('should not throw error when modifyConfig option is not provided', () => {


### PR DESCRIPTION
We had a bug where custom field properties that are not serializable (eg functions) were being left out in the final output. This PR fixes it.