### PR TITLE
fix: update changelog on non-dev release

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -197,7 +197,7 @@ async function init() {
   await bumpVersion({ newVersion });
 
   // Only update changelog for beta releases
-  if (releaseType === 'beta') {
+  if (releaseType !== 'dev') {
     await updateChangelog();
     const answerChangelog = await askForConfirmation(
       'Changelog is updated. You may tweak it as needed. Once ready, press Y to continue.'


### PR DESCRIPTION
Fixes issues where changelog updates were only done for beta releases (it should also happen for _official_ releases)