### PR TITLE
fix: anyof condition breaking UI 

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -20,6 +20,7 @@ export type SchemaValidationErrorType =
    */
   | 'oneOf'
   | 'not'
+  | 'anyOf'
   /**
    * String validation keywords
    */

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -18,7 +18,6 @@ export type SchemaValidationErrorType =
    * Schema composition keywords (allOf, anyOf, oneOf, not)
    * These keywords apply subschemas in a logical manner according to JSON Schema spec
    */
-  | 'anyOf'
   | 'oneOf'
   | 'not'
   /**

--- a/src/errors/messages.ts
+++ b/src/errors/messages.ts
@@ -43,8 +43,6 @@ export function getErrorMessage(
     case 'enum':
       return `The option "${valueToString(value)}" is not valid.`
     // Schema composition
-    case 'anyOf':
-      return `The option "${valueToString(value)}" is not valid.`
     case 'oneOf':
       return `The option "${valueToString(value)}" is not valid.`
     case 'not':

--- a/src/errors/messages.ts
+++ b/src/errors/messages.ts
@@ -45,6 +45,8 @@ export function getErrorMessage(
     // Schema composition
     case 'oneOf':
       return `The option "${valueToString(value)}" is not valid.`
+    case 'anyOf':
+      return `The option "${valueToString(value)}" is not valid.`
     case 'not':
       return 'The value must not satisfy the provided schema'
     // String validation

--- a/src/field/schema.ts
+++ b/src/field/schema.ts
@@ -420,7 +420,10 @@ export function buildFieldSchema({
     })
   }
 
-  addOptions(field, schema)
+  if (name !== 'root') {
+    addOptions(field, schema)
+  }
+
   addFields(field, schema, originalSchema)
 
   return field

--- a/src/validation/composition.ts
+++ b/src/validation/composition.ts
@@ -75,21 +75,26 @@ export function validateAnyOf(
     return []
   }
 
+  const errorGroups: ValidationError[][] = []
+
+  // Check how many rules inside the anyOf array are met
   for (const subSchema of schema.anyOf) {
-    const errors = validateSchema(value, subSchema, options, path, jsonLogicContext)
-    if (errors.length === 0) {
-      return []
+    const schemaErrors = validateSchema(value, subSchema, options, path, jsonLogicContext)
+    // If the schema is not valid, add the errors to the errorGroups array
+    if (schemaErrors.length !== 0) {
+      errorGroups.push(schemaErrors)
     }
   }
 
-  return [
-    {
-      path,
-      validation: 'anyOf',
-      schema,
-      value,
-    },
-  ]
+  // If the number of failed rules is less than the number of rules, it means that the
+  // "any of" condition is met, so we return an empty array. Otherwise, we return the flattened errors.
+  const anyConditionMet = errorGroups.length < schema.anyOf.length
+  if (anyConditionMet) {
+    return []
+  }
+  else {
+    return errorGroups.flat()
+  }
 }
 
 /**

--- a/test/errors/messages.test.ts
+++ b/test/errors/messages.test.ts
@@ -514,6 +514,46 @@ describe('validation error messages', () => {
       })
     })
 
+    it('shows field validation error messages for nested schemas in a root anyOf', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          field_a: {
+            type: 'string',
+          },
+          field_b: {
+            type: 'string',
+          },
+        },
+        anyOf: [
+          { required: ['field_a'] },
+          { required: ['field_b'] },
+        ],
+      }
+      const form = createHeadlessForm(schema)
+
+      // Check that we get an error for both fields if none is provided
+      let result = form.handleValidation({ })
+
+      expect(result.formErrors).toMatchObject({
+        field_a: 'Required field',
+        field_b: 'Required field',
+      })
+
+      // Check that we get don't get an error if one of the fields is provided
+      result = form.handleValidation({
+        field_a: '123456',
+      })
+
+      expect(result.formErrors).toBeUndefined()
+
+      result = form.handleValidation({
+        field_b: '123456',
+      })
+
+      expect(result.formErrors).toBeUndefined()
+    })
+
     it('shows oneOf validation error messages', () => {
       const schema: JsfObjectSchema = {
         type: 'object',

--- a/test/validation/composition.test.ts
+++ b/test/validation/composition.test.ts
@@ -148,8 +148,9 @@ describe('schema composition validators', () => {
       it('should fail when value matches no schema', () => {
         const value = 'too long'
         const errors = validateSchema(value, schema)
-        expect(errors).toHaveLength(1)
-        expect(errors[0].validation).toBe('anyOf')
+        expect(errors).toHaveLength(2)
+        expect(errors[0].validation).toBe('maxLength')
+        expect(errors[1].validation).toBe('type')
       })
     })
 
@@ -225,7 +226,7 @@ describe('schema composition validators', () => {
       it('should fail for non-null values', () => {
         const errors = validateSchema(123, schema)
         expect(errors).toHaveLength(1)
-        expect(errors[0].validation).toBe('anyOf')
+        expect(errors[0].validation).toBe('type')
       })
     })
   })

--- a/test/validation/composition.test.ts
+++ b/test/validation/composition.test.ts
@@ -149,8 +149,8 @@ describe('schema composition validators', () => {
         const value = 'too long'
         const errors = validateSchema(value, schema)
         expect(errors).toHaveLength(2)
-        expect(errors[0].validation).toBe('maxLength')
-        expect(errors[1].validation).toBe('type')
+        expect(errors[0].validation).toBe('type')
+        expect(errors[1].validation).toBe('maxLength')
       })
     })
 


### PR DESCRIPTION
The current `anyOf` implementation has 2 issues:

- visually it breaks the form, as it wrongly interprets root anyOf as if it belonged to a select or checkbox group options

- the error message is a string with a stringified json object which is wrong. It should target individual fields with issues, and not treat the anyOf as a single error.

This MR addresses it by:
- not adding `options` if the field is the root
- returning the actual failed validations for each field when an `anyOf` is not valid