### PR TITLE
feat: allow accumulator/current in reduce/map operations

### DIFF
--- a/v0/src/tests/jsonLogic.fixtures.js
+++ b/v0/src/tests/jsonLogic.fixtures.js
@@ -1061,7 +1061,7 @@ export const schemaWithReduceAccumulator = {
       type: 'number',
       'x-jsf-logic-computedAttrs': {
         const: 'computed_work_hours_per_week',
-        defaultValue: 'computed_work_hours_per_week',
+        default: 'computed_work_hours_per_week',
         title: '{{computed_work_hours_per_week}} hours per week',
       },
     },
@@ -1073,8 +1073,56 @@ export const schemaWithReduceAccumulator = {
           '*': [
             { var: 'working_hours_per_day' },
             {
-              reduce: [{ var: 'work_days' }, { '+': [{ var: ['accumulator', 0] }, 1] }, 0],
+              reduce: [{ var: 'work_days' }, { '+': [{ var: 'accumulator' }, 1] }, 0],
             },
+          ],
+        },
+      },
+    },
+  },
+};
+
+export const schemaWithReduceAccumulatorAndMerge = {
+  properties: {
+    work_days: {
+      items: {
+        anyOf: [
+          { const: 'monday', title: 'Monday' },
+          { const: 'tuesday', title: 'Tuesday' },
+          { const: 'wednesday', title: 'Wednesday' },
+          { const: 'thursday', title: 'Thursday' },
+          { const: 'friday', title: 'Friday' },
+          { const: 'saturday', title: 'Saturday' },
+          { const: 'sunday', title: 'Sunday' },
+        ],
+      },
+      type: 'array',
+      uniqueItems: true,
+      'x-jsf-presentation': {
+        inputType: 'select',
+      },
+    },
+    working_hours_per_day: {
+      type: 'number',
+    },
+    working_hours_per_week: {
+      type: 'number',
+      'x-jsf-logic-computedAttrs': {
+        const: 'computed_work_hours_per_week',
+        default: 'computed_work_hours_per_week',
+        title: '{{computed_work_hours_per_week}} hours per week',
+      },
+    },
+  },
+  'x-jsf-logic': {
+    computedValues: {
+      computed_work_hours_per_week: {
+        rule: {
+          reduce: [
+            { var: 'work_days' },
+            { merge: [{ var: 'accumulator' }, [{ var: 'current' }]] },
+            // note we use the wrong accumulator type
+            0,
           ],
         },
       },

--- a/v0/src/tests/jsonLogic.test.js
+++ b/v0/src/tests/jsonLogic.test.js
@@ -35,6 +35,7 @@ import {
   schemaWithValidationThatDoesNotExistOnProperty,
   badSchemaThatWillNotSetAForcedValue,
   schemaWithReduceAccumulator,
+  schemaWithReduceAccumulatorAndMerge,
   schemaWithComputedPresentationAttributes,
 } from './jsonLogic.fixtures';
 import { mockConsole, restoreConsoleAndEnsureItWasNotCalled } from './testUtils';
@@ -245,8 +246,7 @@ describe('jsonLogic: cross-values validations', () => {
     });
   });
 
-  // TODO: Implement this test.
-  describe.skip('Reduce', () => {
+  describe('Reduce', () => {
     it('reduce: working_hours_per_day * work_days', () => {
       const { fields, handleValidation } = createHeadlessForm(schemaWithReduceAccumulator, {
         strictInputType: false,
@@ -259,6 +259,18 @@ describe('jsonLogic: cross-values validations', () => {
       expect(field.const).toEqual(16);
       expect(field.default).toEqual(16);
       expect(field.label).toEqual('16 hours per week');
+    });
+
+    it('reduce: handles when operator is non numerical', () => {
+      const { fields, handleValidation } = createHeadlessForm(schemaWithReduceAccumulatorAndMerge, {
+        strictInputType: false,
+      });
+      handleValidation({
+        work_days: ['monday', 'tuesday'],
+        working_hours_per_day: 8,
+      });
+      const field = fields.find((i) => i.name === 'working_hours_per_week');
+      expect(field.const).toEqual([0, 'monday', 'tuesday']);
     });
   });
 


### PR DESCRIPTION
As part of removing some code from the dragon frontend, to be able to use it in our SDK/API, I had to move some frontend logic to the backend.
To do that, I need to use `reduce`, in order to calculate the length on a array. This is in theory supported by `json-logic-js`.
The issue is that we run validation against the data provided, but we don't accommodate for the fact that if we are within a reduce/map block, we should allow `current` and `accumulator`. 
This code enriches the validation data if we are within a reduce/map block, while it maintains checking the integrity of the rest of the variables.

Let me know if the implementation is what you expect or you'd rather be different, thank you!