### PR TITLE
feat(json-logic): apply computed attrs on nested allOf/anyOf/oneOf properties

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -142,7 +142,7 @@ async function gitCommit({ newVersion, releaseType }) {
     cmd = `git add package.json CHANGELOG.md && git commit -m "Release ${newVersion}" && git tag ${newVersion} && git push && git push origin --tags`;
   } else {
     // For dev, we only create a tag
-    cmd = `git tag ${prefix}-${newVersion} && git push origin --tags`;
+    cmd = `git tag ${newVersion} && git push origin --tags`;
   }
 
   await runExec(cmd);

--- a/src/validation/json-logic.ts
+++ b/src/validation/json-logic.ts
@@ -162,51 +162,45 @@ function cycleThroughPropertiesAndApplyValues(schemaCopy: JsfSchema, computedVal
       cycleThroughAttrsAndApplyValues(propertySchema, computedValues, computedAttrs)
     }
 
-    if (propertySchema.type === 'object' && propertySchema.properties) {
-      cycleThroughPropertiesAndApplyValues(propertySchema, computedValues)
+    // If the schemas has properties, we need to cycle through each one and apply the computed values
+    if (typeof propertySchema.properties === 'object') {
+      for (const propertyName in propertySchema.properties) {
+        processProperty(propertySchema.properties[propertyName])
+      }
+    }
+
+    // If the schema has an if statement, we need to cycle through the properties and apply the computed values
+    if (typeof propertySchema.if === 'object') {
+      cycleThroughPropertiesAndApplyValues(propertySchema.if, computedValues)
+    }
+
+    /* If the schema has an allOf or anyOf property, we need to cycle through each property inside it and
+    * apply the computed values
+    */
+
+    if (propertySchema.allOf && propertySchema.allOf.length > 0) {
+      for (const schema of propertySchema.allOf) {
+        cycleThroughPropertiesAndApplyValues(schema, computedValues)
+      }
+    }
+
+    if (propertySchema.anyOf && propertySchema.anyOf.length > 0) {
+      for (const schema of propertySchema.anyOf) {
+        cycleThroughPropertiesAndApplyValues(schema, computedValues)
+      }
+    }
+
+    if (propertySchema.oneOf && propertySchema.oneOf.length > 0) {
+      for (const schema of propertySchema.oneOf) {
+        cycleThroughPropertiesAndApplyValues(schema, computedValues)
+      }
     }
 
     // deleting x-jsf-logic-computedAttrs to keep the schema clean
     delete propertySchema['x-jsf-logic-computedAttrs']
   }
 
-  // If the schemas has properties, we need to cycle through each one and apply the computed values
-  // Otherwise, just process the property
-  if (schemaCopy.properties) {
-    for (const propertyName in schemaCopy.properties) {
-      processProperty(schemaCopy.properties[propertyName])
-    }
-  }
-  else {
-    processProperty(schemaCopy)
-  }
-
-  // If the schema has an if statement, we need to cycle through the properties and apply the computed values
-  if (typeof schemaCopy.if === 'object') {
-    cycleThroughPropertiesAndApplyValues(schemaCopy.if, computedValues)
-  }
-
-  /* If the schema has an allOf or anyOf property, we need to cycle through each property inside it and
-   * apply the computed values
-   */
-
-  if (schemaCopy.allOf && schemaCopy.allOf.length > 0) {
-    for (const schema of schemaCopy.allOf) {
-      cycleThroughPropertiesAndApplyValues(schema, computedValues)
-    }
-  }
-
-  if (schemaCopy.anyOf && schemaCopy.anyOf.length > 0) {
-    for (const schema of schemaCopy.anyOf) {
-      cycleThroughPropertiesAndApplyValues(schema, computedValues)
-    }
-  }
-
-  if (schemaCopy.oneOf && schemaCopy.oneOf.length > 0) {
-    for (const schema of schemaCopy.oneOf) {
-      cycleThroughPropertiesAndApplyValues(schema, computedValues)
-    }
-  }
+  processProperty(schemaCopy)
 }
 
 /**


### PR DESCRIPTION
Refactors the `cycleThroughAttrsAndApplyValues` implementation on `json-logic` with a more recursive-ish logic so that properties nested on `allOf`/`anyOf`/`oneOf` definitions are also parsed when `x-jsf-logic-computedAttrs` are resolved.

For instance, given the following property:

```
'temperature_setting': {
  'title': 'Select a preset temperature',
  'type': 'string',
  'oneOf': [
    {
      'title': 'Low',
      'const': 18,
    },
    {
      'title': 'Medium',
      'const': 20,
    },
    {
      'title': 'Maximum',
      'x-jsf-logic-computedAttrs': {
        'const': 'maximum_temperature',
      },
    },
  ],
},
```

the `const` on the last item of the property's `oneOf` will be properly parsed with the computed value.

Also fixes the `dev` version release script.