### PR TITLE
fix(schema): additionalProperties not working

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -14,6 +14,7 @@ export type SchemaValidationErrorType =
   | 'forbidden'
   | 'const'
   | 'enum'
+  | 'additionalProperties'
   /**
    * Schema composition keywords (allOf, anyOf, oneOf, not)
    * These keywords apply subschemas in a logical manner according to JSON Schema spec

--- a/src/errors/messages.ts
+++ b/src/errors/messages.ts
@@ -112,6 +112,8 @@ export function getErrorMessage(
       throw new Error('"minContains" is not implemented yet')
     case 'maxContains':
       throw new Error('"maxContains" is not implemented yet')
+    case 'additionalProperties':
+      return 'Additional property is not allowed'
     case 'json-logic':
       return customErrorMessage || 'The value is not valid'
   }

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -259,6 +259,42 @@ export function validateSchema(
     }
   }
 
+  if (schema.additionalProperties === false && isObjectValue(value)) {
+    const definedProperties = new Set(Object.keys(schema.properties || {}))
+    const actualProperties = Object.keys(value)
+
+    // Create a set of pattern regexes from patternProperties
+    const patternRegexes: RegExp[] = []
+    if (schema.patternProperties) {
+      for (const pattern of Object.keys(schema.patternProperties)) {
+        try {
+          patternRegexes.push(new RegExp(pattern))
+        }
+        catch {
+          throw new Error(`[json-schema-form] Invalid regex pattern in patternProperties: ${pattern}`)
+        }
+      }
+    }
+
+    for (const prop of actualProperties) {
+      if (definedProperties.has(prop)) {
+        continue
+      }
+
+      const matchesPattern = patternRegexes.some(regex => regex.test(prop))
+      if (matchesPattern) {
+        continue
+      }
+
+      errors.push({
+        path: [...path, prop],
+        validation: 'additionalProperties',
+        schema,
+        value: value[prop],
+      })
+    }
+  }
+
   return [
     ...errors,
     // JSON-schema spec validations

--- a/test/validation/additional_properties.test.ts
+++ b/test/validation/additional_properties.test.ts
@@ -1,0 +1,93 @@
+import type { JsfObjectSchema } from '../../src/types'
+import { describe, expect, it } from '@jest/globals'
+import { createHeadlessForm } from '../../src'
+
+describe('additionalProperties validation', () => {
+  describe('basic additionalProperties: false', () => {
+    const schema: JsfObjectSchema = {
+      type: 'object',
+      properties: {
+        a: { type: 'integer' },
+        b: { type: 'string' },
+      },
+      additionalProperties: false,
+    }
+    const form = createHeadlessForm(schema)
+
+    it('allows objects with only defined properties', () => {
+      expect(form.handleValidation({ a: 1 })).not.toHaveProperty('formErrors')
+      expect(form.handleValidation({ a: 1, b: 'test' })).not.toHaveProperty('formErrors')
+    })
+
+    it('rejects objects with additional properties', () => {
+      expect(form.handleValidation({ a: 1, c: 'extra' })).toMatchObject({
+        formErrors: { c: 'Additional property is not allowed' },
+      })
+
+      expect(form.handleValidation({ a: 1, b: 'test', c: 'extra' })).toMatchObject({
+        formErrors: { c: 'Additional property is not allowed' },
+      })
+    })
+
+    it('rejects objects with only additional properties', () => {
+      expect(form.handleValidation({ c: 'extra' })).toMatchObject({
+        formErrors: { c: 'Additional property is not allowed' },
+      })
+    })
+  })
+
+  describe('additionalProperties: false with patternProperties', () => {
+    const schema: JsfObjectSchema = {
+      type: 'object',
+      properties: {
+        foo: {},
+        bar: {},
+      },
+      patternProperties: {
+        '^v': {},
+      },
+      additionalProperties: false,
+    }
+    const form = createHeadlessForm(schema)
+
+    it('allows properties defined in properties', () => {
+      expect(form.handleValidation({ foo: 1 })).not.toHaveProperty('formErrors')
+      expect(form.handleValidation({ foo: 1, bar: 2 })).not.toHaveProperty('formErrors')
+    })
+
+    it('allows properties matching patternProperties', () => {
+      expect(form.handleValidation({ vroom: 1 })).not.toHaveProperty('formErrors')
+      expect(form.handleValidation({ vampire: 1 })).not.toHaveProperty('formErrors')
+      expect(form.handleValidation({ v: 1 })).not.toHaveProperty('formErrors')
+    })
+
+    it('allows combination of properties and patternProperties', () => {
+      expect(form.handleValidation({ foo: 1, vroom: 2 })).not.toHaveProperty('formErrors')
+      expect(form.handleValidation({ foo: 1, bar: 2, vampire: 3 })).not.toHaveProperty('formErrors')
+    })
+
+    it('rejects properties that match neither properties nor patternProperties', () => {
+      expect(form.handleValidation({ foo: 1, quux: 'boom' })).toMatchObject({
+        formErrors: { quux: 'Additional property is not allowed' },
+      })
+
+      expect(form.handleValidation({ hello: 'world' })).toMatchObject({
+        formErrors: { hello: 'Additional property is not allowed' },
+      })
+    })
+  })
+
+  describe('when additionalProperties is not false', () => {
+    const schema: JsfObjectSchema = {
+      type: 'object',
+      properties: {
+        a: { type: 'integer' },
+      },
+    }
+    const form = createHeadlessForm(schema)
+
+    it('allows additional properties', () => {
+      expect(form.handleValidation({ a: 1, b: 2, c: 3 })).not.toHaveProperty('formErrors')
+    })
+  })
+})


### PR DESCRIPTION
A JSON Schema with `additionalProperties: false` is meant to disallow properties not declared in the JSON Schema! 

This adds the validation based on that option