### PR TITLE
fix(checkbox): Support optional boolean type

### DIFF
--- a/src/field/schema.ts
+++ b/src/field/schema.ts
@@ -15,7 +15,7 @@ function addCheckboxAttributes(inputType: string, field: Field, schema: NonBoole
   field.checkboxValue = schema.const
 
   // However, if the schema type is boolean, we should set the valid value as `true`
-  if (schema.type === 'boolean') {
+  if (Array.isArray(schema.type) ? schema.type.includes('boolean') : schema.type === 'boolean') {
     field.checkboxValue = true
   }
 }

--- a/test/fields.test.ts
+++ b/test/fields.test.ts
@@ -686,6 +686,18 @@ describe('fields', () => {
       expect(field?.checkboxValue).toBe(true)
     })
 
+    it('uses checkbox input for boolean/null type array with boolean const value', () => {
+      const booleanNullSchema = {
+        'x-jsf-presentation': {
+          inputType: 'checkbox' as const,
+        },
+        'type': ['boolean', 'null'],
+      }
+      const field = buildFieldSchema(booleanNullSchema, 'test')
+      expect(field?.inputType).toBe('checkbox')
+      expect(field?.checkboxValue).toBe(true)
+    })
+
     // Skipping these tests until we have group-array support
     describe('array type inputs', () => {
       it('uses group-array when items has properties', () => {


### PR DESCRIPTION
Currently when a `checkbox` of type `["boolean", "null"]` is included in a schema it does not apply the correct values. When it's checked nothing will be sent to the API, and when it is unchecked `null` will be sent rather than `false`. 

This PR corrects that behaviour so that:

- checked -> `true`
- unchecked -> `false`

Link to corresponding [MR](https://gitlab.com/remote-com/employ-starbase/dragon/-/merge_requests/48463).

<details>
  <summary><b>Toggle screenshots</b></summary>
 
<img width="1122" height="685" alt="Screenshot 2025-10-02 at 11 00 14 am" src="https://github.com/user-attachments/assets/001eab2e-cdb4-4f1c-9d7b-ad120245d9af" />
<img width="1122" height="685" alt="Screenshot 2025-10-02 at 11 00 08 am" src="https://github.com/user-attachments/assets/a5b979ac-bbcf-41f3-8977-b4acd782ba20" />

</details>
