### PR TITLE
fix(json-logic): add custom operators on headless form creation

### DIFF
--- a/src/validation/json-logic.ts
+++ b/src/validation/json-logic.ts
@@ -281,11 +281,3 @@ export function addCustomJsonLogicOperations(ops?: Record<string, (...args: any[
     }
   }
 }
-
-export function removeCustomJsonLogicOperations(ops?: Record<string, (...args: any[]) => any>) {
-  if (ops) {
-    for (const name of Object.keys(ops)) {
-      jsonLogic.rm_operation(name)
-    }
-  }
-}


### PR DESCRIPTION
Currently all custom JSON Logic operators are applied ad-hoc when the validation functions are executed, and then removed afterwards. While this makes sense from the point of view of simulating a deterministic call to JSON Logic, other places on the form's lifecycle require these custom operators to be available.

This means that if a form is loaded with an initial value where a property needs a computed value that relies on a custom operator, the operator won't be available (as it's only added when a validation happens), thus throwing an error.

This PR simplifies the logic by adding all custom operators at once when the `createHeadlessForm` is called, which happens only once per page load.