### PR TITLE
feat: export FormResult and related types for better type inference

### DIFF
--- a/src/form.ts
+++ b/src/form.ts
@@ -10,7 +10,7 @@ import { validateSchema } from './validation/schema'
 
 export { LegacyOptions } from './validation/schema'
 
-interface FormResult {
+export interface FormResult {
   fields: Field[]
   isError: boolean
   error: string | null

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   createHeadlessForm,
   type CreateHeadlessFormOptions,
   type FormErrors,
+  type FormResult,
   type LegacyOptions,
   type ValidationResult,
 } from './form'


### PR DESCRIPTION
**Problem**

When using createHeadlessForm() with async hooks like useQuery, TypeScript couldn't infer the return type, resulting in unknown type:

```tsx
const { data } = useQuery({  queryFn: async () => createHeadlessForm(schema),})// ❌ data is typed as 'unknown' - no intellisense or type safety
```

**Solution**

Export the core types from the public API so TypeScript can properly infer them:
const { data } = useQuery({  queryFn: async () => createHeadlessForm(schema),})// ✅ data is now properly typed

Tested in local with the https://github.com/remoteoss/remote-flows package to make sure that it worked
