### PR TITLE
fix: mutating of initial value object

### DIFF
--- a/v0/src/helpers.js
+++ b/v0/src/helpers.js
@@ -202,7 +202,6 @@ export function getPrefillValues(fields, initialValues = {}) {
       }
 
       default: {
-        if (!initialValues[fieldName]) 
         break;
       }
     }


### PR DESCRIPTION
## Problem 

Intialvalue object getting updated from schema's default value in V0 of JSF #92 
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/3b188bee-05fd-4d27-a342-8fd800303a3b" />
<img width="562" height="172" alt="image" src="https://github.com/user-attachments/assets/217ee79a-e612-4b74-b45c-607fbf5b57cd" />


## solution

removed the mutating statement present **getPrefillValues** to just **break** if no **_fieldName_** is present in **_initialValues_**

I have tested it using this changes using a[ local build ](https://github.com/remoteoss/json-schema-form/blob/main/CONTRIBUTING.md#local-build)