### PR TITLE
fix(structuredClone) - remove warning

### DIFF
--- a/src/validation/util.ts
+++ b/src/validation/util.ts
@@ -83,8 +83,7 @@ export function safeDeepClone<T>(obj: T): T {
     try {
       return structuredClone(obj)
     }
-    catch (err) {
-      console.warn('structuredClone failed, falling back to JSON method:', err)
+    catch {
       // Fall through to JSON method
     }
   }


### PR DESCRIPTION
I have users telling me this warning adds noise as they think they could have an error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in a clone helper; clone and fallback behavior are unchanged.
> 
> **Overview**
> Removes the **`console.warn`** when `structuredClone` throws in **`safeDeepClone`**, so the existing JSON parse/stringify fallback runs **silently** instead of looking like an application error to users.
> 
> Behavior is unchanged: still tries `structuredClone` first, then falls back on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108291b35cfa3cb87e74a4b9dddd7dc4d32b8529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->