### PR TITLE
feat(ci) - add `zizmor` to do static analysis on github actions

### DIFF
--- a/.github/workflows/actions-v0.yml
+++ b/.github/workflows/actions-v0.yml
@@ -5,17 +5,22 @@ on:
       - next/** # Skip if ONLY next/ directory files change
       - .github/workflows/build-next.yml
 
+permissions:
+  contents: read
+
 jobs:
   dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: v0/.nvmrc
       - name: Cache NPM dependencies
         # From: https://dev.to/drakulavich/aggressive-dependency-caching-in-github-actions-3c64
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         id: cache-v0
         with:
           path: v0/node_modules
@@ -28,13 +33,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dependencies]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: v0/.nvmrc
 
       - name: Get cached NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: v0/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('v0/package-lock.json') }}
@@ -46,13 +53,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dependencies]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: v0/.nvmrc
 
       - name: Get cached NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: v0/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('v0/package-lock.json') }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,9 +18,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
 
-      - name: Initialize submodules
-        run: git submodule update --init
-
       - name: Setup pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,29 +5,33 @@ on:
       - v0/** # Skip if ONLY v0/ directory files change
       - .github/workflows/build.yml # Skip if ONLY build.yml file changes
 
+permissions:
+  contents: read
+
 jobs:
   dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: true
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Initialize submodules
         run: git submodule update --init
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 9
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: .nvmrc
 
       - name: Cache PNPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         id: cache-jsf
         with:
           path: node_modules
@@ -41,21 +45,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dependencies]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: true
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
 
       - name: Get cached PNPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: node_modules
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Audit
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/*.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/*.yml'
+
+jobs:
+  zizmor:
+    name: Audit Workflows with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor security audit
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e
+        with:
+          sarif-file: zizmor-results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,5 +26,3 @@ jobs:
 
       - name: Run zizmor security audit
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e
-        with:
-          sarif-file: zizmor-results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,3 +230,31 @@ The code is organized into clear, focused modules to provide a clear separation 
         - we frequently use `false` schemas when we conditionally hide properties by setting them to `false`
         - as mentioned above, dragon passes `null` values for hidden fields to `handleValidate`
         - dragon’s `useCreateHeadlessForm` hook enables this option by default
+
+### Workflow Security Auditing (Optional)
+
+This project uses [zizmor](https://woodruffw.github.io/zizmor/) to audit GitHub Actions workflows for security issues. The audit runs automatically in CI when workflow files are modified.
+
+To run the audit locally, you'll need to install `zizmor`:
+
+**macOS/Linux (via Homebrew):**
+```bash
+brew install zizmor
+```
+
+**Via Cargo:**
+```bash
+cargo install zizmor
+```
+
+Once installed, you can run the audit commands:
+
+```bash
+# Audit workflows
+pnpm run lint:workflows
+
+# Audit and auto-fix issues
+pnpm run lint:workflows:fix
+```
+
+Note: Installing zizmor is optional for development unless you're modifying GitHub Actions workflow files.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "test:v0-compare-results": "node test/v0_compare_test_results.js",
     "test:v0": "cd v0 && jest --json --outputFile=../test/v0-test-results.json; cd ..; pnpm run test:v0-compare-results",
     "lint": "eslint --max-warnings 0 .",
+    "lint:workflows": "zizmor .github/workflows/",
+    "lint:workflows:fix": "zizmor --fix .github/workflows/",
     "typecheck": "tsc --noEmit",
     "check": "pnpm run lint && pnpm run typecheck",
     "check:pr-next-version": "node ./scripts/pr_next_dev_version",


### PR DESCRIPTION
After tanstack supply chain incident, we install [`zizmor`](https://github.com/zizmorcore/zizmor) to do static analysis on the github actions and prevent security incidents...

Whenever a github action changes, zizmor will run

Run the fix script to fix the errors and add some docs about the tool as you need to install it globally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and workflow-only changes that reduce supply-chain and credential exposure; no application runtime or auth logic is modified.
> 
> **Overview**
> Adds **zizmor** static analysis for GitHub Actions: a new workflow runs on PRs and `main` when `.github/workflows/*.yml` changes, and `pnpm run lint:workflows` / `lint:workflows:fix` are documented in **CONTRIBUTING.md**.
> 
> Hardens existing PR workflows (`actions.yml`, `actions-v0.yml`) with workflow-level `contents: read`, **pinned action SHAs** (checkout, setup-node, cache, pnpm), and **`persist-credentials: false`** on checkout. The main PR workflow drops the separate `git submodule update --init` step while keeping submodule checkout via `actions/checkout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0073fe5539a00ffcf3f2f000eab064517d8911bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->