### PR TITLE
chore(changelog) - update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 #### 1.2.12 (2026-05-25)
 
+##### Bug Fixes
+
+* Remove console.log in safeDeepClone ([#255](https://github.com/remoteoss/json-schema-form/pull/255)) ([f2769e3](https://github.com/remoteoss/json-schema-form/commit/f2769e3b0fb3e065573044424d6c8c92a35aa5f5))
+
+###### Chore
+
+* **security**: add zizmor to add static analysis for github actions ([#256](https://github.com/remoteoss/json-schema-form/pull/256)) ([0600423](https://github.com/remoteoss/json-schema-form/commit/06004237e7df9f0ae60382ed89d7be8069e633cf))
+
+
 #### 1.2.11 (2026-03-19)
 
 ##### Bug Fixes


### PR DESCRIPTION
Add missing changelog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md with no runtime or CI behavior changes in this PR.
> 
> **Overview**
> Adds the missing **1.2.12 (2026-05-25)** release section at the top of `CHANGELOG.md`, documenting a bug fix (remove `console.log` in `safeDeepClone`, #255) and a security chore (add zizmor for GitHub Actions static analysis, #256).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42844cdb60739d1d3979f61f81989702d634b721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->