### PR TITLE
fix(schema): use big.js to avoid floating-point errors in multipleOf

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "release": "node ./scripts/release official"
   },
   "dependencies": {
+    "big.js": "^7.0.1",
     "json-logic-js": "^2.0.5"
   },
   "devDependencies": {
@@ -56,6 +57,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@jest/globals": "^29.7.0",
     "@jest/reporters": "^29.7.0",
+    "@types/big.js": "^7.0.0",
     "@types/json-logic-js": "^2.0.8",
     "@types/lodash": "^4.17.16",
     "@types/validator": "^13.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      big.js:
+        specifier: ^7.0.1
+        version: 7.0.1
       json-logic-js:
         specifier: ^2.0.5
         version: 2.0.5
@@ -30,6 +33,9 @@ importers:
       '@jest/reporters':
         specifier: ^29.7.0
         version: 29.7.0
+      '@types/big.js':
+        specifier: ^7.0.0
+        version: 7.0.0
       '@types/json-logic-js':
         specifier: ^2.0.8
         version: 2.0.8
@@ -1213,6 +1219,9 @@ packages:
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
 
+  '@types/big.js@7.0.0':
+    resolution: {integrity: sha512-WfAGp7IbJvyB8EmWK4tJD24rJRAL6uVbw3LV/hJntFNam+os9KWKj0PzXo8rRRpjupYK8U0M8FoBB8dBhWF2dg==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1451,6 +1460,9 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  big.js@7.0.1:
+    resolution: {integrity: sha512-iFgV784tD8kq4ccF1xtNMZnXeZzVuXWWM+ERFzKQjv+A5G9HC8CY3DuV45vgzFFcW+u2tIvmF95+AzWgs6BjCg==}
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
@@ -4609,6 +4621,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.5
 
+  '@types/big.js@7.0.0': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -4914,6 +4928,8 @@ snapshots:
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.0)
 
   balanced-match@1.0.2: {}
+
+  big.js@7.0.1: {}
 
   bluebird@3.7.2: {}
 

--- a/src/validation/number.ts
+++ b/src/validation/number.ts
@@ -1,6 +1,28 @@
 import type { ValidationError, ValidationErrorPath } from '../errors'
 import type { NonBooleanJsfSchema, SchemaValue } from '../types'
+import Big from 'big.js'
 import { getSchemaType } from './schema'
+
+/**
+ * Check whether a value is an exact multiple of `multipleOf` using
+ * arbitrary-precision arithmetic to avoid floating-point rounding errors.
+ * @param value - The number being validated
+ * @param multipleOf - The divisor the value must be a multiple of
+ * @returns `true` if `value` is an exact multiple of `multipleOf`
+ * @description
+ * big.js throws a `RangeError` when an operation would exceed its precision
+ * limit (e.g. dividing a huge value like `1e308` by a small `multipleOf`). In
+ * that case the value cannot be represented as a clean multiple, so we treat it
+ * as not being a multiple rather than letting the error bubble up.
+ */
+function isMultipleOf(value: number, multipleOf: number): boolean {
+  try {
+    return new Big(value).mod(new Big(multipleOf)).eq(0)
+  }
+  catch {
+    return false
+  }
+}
 
 /**
  * Validate a number against a schema
@@ -32,9 +54,15 @@ export function validateNumber(
     return []
   }
 
-  // MultipleOf validation - dividing value by multipleOf must have no remainder
-  if (schema.multipleOf !== undefined && value % schema.multipleOf !== 0) {
-    errors.push({ path, validation: 'multipleOf', schema, value })
+  // MultipleOf validation - dividing value by multipleOf must have no remainder.
+  // A naive `value % multipleOf` check is unreliable with floating-point numbers
+  // (e.g. `100 % 0.01` yields `0.0099...` instead of `0`), so we use big.js for
+  // arbitrary-precision arithmetic to avoid these rounding errors.
+  // See https://github.com/remoteoss/json-schema-form/issues/222
+  if (schema.multipleOf !== undefined) {
+    if (!isMultipleOf(value, schema.multipleOf)) {
+      errors.push({ path, validation: 'multipleOf', schema, value })
+    }
   }
 
   // Maximum validation - value must be less than or equal to maximum

--- a/test/json-schema-test-suite/failed-json-schema-test-suite.json
+++ b/test/json-schema-test-suite/failed-json-schema-test-suite.json
@@ -177,12 +177,6 @@
     "minProperties validation with a decimal": [
       "too short is invalid"
     ],
-    "by small number": [
-      "0.0075 is multiple of 0.0001"
-    ],
-    "small multiple of large integer": [
-      "any integer is a multiple of 1e-8"
-    ],
     "collect annotations inside a 'not', even if collection is disabled": [
       "unevaluated property"
     ],

--- a/test/validation/number.test.ts
+++ b/test/validation/number.test.ts
@@ -163,4 +163,18 @@ describe('number validation', () => {
       }),
     ])
   })
+
+  // multipleOf must not be thrown off by floating-point rounding errors.
+  // e.g. `100 % 0.01` evaluates to `0.0099...` in plain JS arithmetic.
+  // See https://github.com/remoteoss/json-schema-form/issues/222
+  it('validates multipleOf without floating-point rounding errors', () => {
+    expect(validateSchema(100, { type: 'number', multipleOf: 0.01 })).toEqual([])
+    expect(validateSchema(0.0075, { type: 'number', multipleOf: 0.0001 })).toEqual([])
+    expect(validateSchema(4.5, { type: 'number', multipleOf: 1.5 })).toEqual([])
+
+    // Values that are genuinely not multiples must still fail
+    expect(validateSchema(0.00751, { type: 'number', multipleOf: 0.0001 })).toEqual([
+      errorLike({ path: [], validation: 'multipleOf' }),
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

Fixes `multipleOf` validation incorrectly rejecting valid numbers due to floating-point rounding errors. For example, `100` with `multipleOf: 0.01` was reported as invalid because `100 % 0.01` evaluates to `0.0099...` rather than `0` in plain JavaScript arithmetic.

As suggested by @lukad in the issue, this replaces the native modulo check with arbitrary-precision arithmetic via [big.js](https://github.com/MikeMcl/big.js), which eliminates this class of rounding error entirely. big.js adds ~3KB
(minified + gzipped) and has zero dependencies.

## Changes Made

- **`src/validation/number.ts`**
  - Replaced the naive `value % multipleOf !== 0` check with an `isMultipleOf` helper that uses `big.js` for the modulo operation.
  - The helper guards against the `RangeError` big.js throws when an operation exceeds its precision limit (e.g. `1e308` divided by a tiny `multipleOf`); in that case the value is treated as not a multiple, matching the expected `invalid` result instead of throwing.

- **`test/json-schema-test-suite/failed-json-schema-test-suite.json`**
  - Re-enabled two official JSON Schema Test Suite cases that were previously  ignored because of this bug: `"0.0075 is multiple of 0.0001"` and `"any integer is a multiple of 1e-8"`. They now pass.

- **`test/validation/number.test.ts`**
  - Added a unit test covering floating-point cases (incl. the issue's `100 / 0.01` example) and a negative case (`0.00751` is not a multiple of `0.0001`) to confirm genuine non-multiples still fail.

- **`package.json`**
  - Added `big.js` (dependency) and `@types/big.js` (devDependency).

## Related Issues/PRs

Fixes #222

## Screenshots (Before/After if applicable)

N/A — validation-only change.

## Checklist

- [x] I have read the [Contributing Guidelines](../../CONTRIBUTING.md) and followed them.
- [x] Unit tests were added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to number multipleOf validation with a small dependency; min/max and other number rules are unchanged.
> 
> **Overview**
> **`multipleOf`** validation no longer uses JavaScript’s `%` operator, which falsely rejects valid values when divisors are fractional (e.g. `100` with `multipleOf: 0.01`).
> 
> The check now uses **`big.js`** via a new **`isMultipleOf`** helper that tests remainder with arbitrary-precision **`mod`**. If **`big.js`** throws **`RangeError`** on extreme magnitudes, the value is treated as **not** a multiple instead of crashing validation.
> 
> **`big.js`** and **`@types/big.js`** were added as dependencies. Two JSON Schema Test Suite cases that were previously allow-listed as failures were removed from the ignore list, and unit tests cover decimal **`multipleOf`** pass/fail cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac879e0f3d5e65c9aab0cd9f72e2f6e3f8c49e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->