### PR TITLE
fix(json-logic): ensure custom operators are always available

### DIFF
--- a/src/form.ts
+++ b/src/form.ts
@@ -273,6 +273,14 @@ function validateOptions(options: CreateHeadlessFormOptions) {
   }
 }
 
+/**
+ * JSON Logic uses a single global operators registry for all of its calls, so
+ * we need to take extra measures to keep each createHeadlessForm deterministic.
+ *
+ * addCustomJsonLogicOperations and removeCustomJsonLogicOperations are called on each
+ * createHeadlessForm and handleValidation in order to ensure each headless form's operators
+ * are limited to its schema and validations without side effects.
+ */
 export function createHeadlessForm(
   schema: JsfObjectSchema,
   options: CreateHeadlessFormOptions = {},
@@ -280,6 +288,10 @@ export function createHeadlessForm(
   validateOptions(options)
   const initialValues = options.initialValues || {}
   const strictInputType = options.strictInputType || false
+  const customJsonLogicOps = options?.customJsonLogicOps
+
+  addCustomJsonLogicOperations(customJsonLogicOps)
+
   // Make a new version of the schema with all the computed attrs applied, as well as the final version of each property (taking into account conditional rules)
   const updatedSchema = calculateFinalSchema({
     schema,
@@ -293,8 +305,6 @@ export function createHeadlessForm(
   const isError = false
 
   const handleValidation = (value: SchemaValue) => {
-    const customJsonLogicOps = options?.customJsonLogicOps
-
     try {
       addCustomJsonLogicOperations(customJsonLogicOps)
 
@@ -314,6 +324,8 @@ export function createHeadlessForm(
       removeCustomJsonLogicOperations(customJsonLogicOps)
     }
   }
+
+  removeCustomJsonLogicOperations(customJsonLogicOps)
 
   return {
     fields,

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -29,12 +29,12 @@ export function calculateFinalSchema({
 }): JsfObjectSchema {
   const jsonLogicContext = schema['x-jsf-logic'] ? getJsonLogicContextFromSchema(schema['x-jsf-logic'], values) : undefined
   const schemaCopy = safeDeepClone(schema)
-  const { legacyOptions, customJsonLogicOps } = options
+  const { legacyOptions } = options
 
   applySchemaRules(schemaCopy, values, legacyOptions, jsonLogicContext)
 
   if (jsonLogicContext?.schema.computedValues) {
-    applyComputedAttrsToSchema(schemaCopy, jsonLogicContext.schema.computedValues, values, customJsonLogicOps)
+    applyComputedAttrsToSchema(schemaCopy, jsonLogicContext.schema.computedValues, values)
     // If we had computed values applied to the schema,
     // we need to re-apply the schema rules to update the fields
     applySchemaRules(schemaCopy, values, legacyOptions, jsonLogicContext)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { RulesLogic } from 'json-logic-js'
+import type { AdditionalOperation, RulesLogic } from 'json-logic-js'
 import type { JSONSchema } from 'json-schema-typed/draft-2020-12'
 import type { FieldType } from './field/type'
 /**
@@ -38,10 +38,10 @@ export interface JsonLogicContext {
 export interface JsonLogicRules {
   validations?: Record<string, {
     errorMessage?: string
-    rule: RulesLogic
+    rule: RulesLogic<AdditionalOperation>
   }>
   computedValues?: Record<string, {
-    rule: RulesLogic
+    rule: RulesLogic<AdditionalOperation>
   }>
 }
 export type JsonLogicRootSchema = Pick<NonBooleanJsfSchema, 'if' | 'then' | 'else' | 'anyOf' | 'oneOf' | 'not'> & {

--- a/src/validation/json-logic.ts
+++ b/src/validation/json-logic.ts
@@ -1,6 +1,5 @@
-import type { RulesLogic } from 'json-logic-js'
+import type { AdditionalOperation, RulesLogic } from 'json-logic-js'
 import type { ValidationError, ValidationErrorPath } from '../errors'
-import type { CreateHeadlessFormOptions } from '../form'
 import type { JsfObjectSchema, JsfSchema, JsonLogicContext, JsonLogicRules, JsonLogicSchema, NonBooleanJsfSchema, ObjectValue, SchemaValue } from '../types'
 import jsonLogic from 'json-logic-js'
 
@@ -109,7 +108,7 @@ export function validateJsonLogicRules(
 
 export function computePropertyValues(
   name: string,
-  rule: RulesLogic,
+  rule: RulesLogic<AdditionalOperation>,
   values: SchemaValue,
 ): any {
   if (!rule) {
@@ -129,14 +128,11 @@ export function computePropertyValues(
  * @param schema - The schema to apply computed attributes to
  * @param computedValuesDefinition - The computed values to apply
  * @param values - The current form values
- * @param customJsonLogicOps - The custom JSON Logic operations to apply
  * @returns The schema with computed attributes applied
  */
-export function applyComputedAttrsToSchema(schema: JsfObjectSchema, computedValuesDefinition: JsonLogicRules['computedValues'], values: SchemaValue, customJsonLogicOps: CreateHeadlessFormOptions['customJsonLogicOps'] = {}): JsfObjectSchema {
+export function applyComputedAttrsToSchema(schema: JsfObjectSchema, computedValuesDefinition: JsonLogicRules['computedValues'], values: SchemaValue): JsfObjectSchema {
   if (computedValuesDefinition) {
     const computedValues: Record<string, any> = {}
-
-    addCustomJsonLogicOperations(customJsonLogicOps)
 
     Object.entries(computedValuesDefinition).forEach(([name, definition]) => {
       const computedValue = computePropertyValues(name, definition.rule, values)
@@ -144,8 +140,6 @@ export function applyComputedAttrsToSchema(schema: JsfObjectSchema, computedValu
     })
 
     cycleThroughPropertiesAndApplyValues(schema, computedValues)
-
-    removeCustomJsonLogicOperations(customJsonLogicOps)
   }
 
   return schema

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -1,10 +1,30 @@
 import type { JsfObjectSchema } from '../src/types'
 import { afterEach, describe, expect, it, jest } from '@jest/globals'
 import { createHeadlessForm } from '../src'
+import { schemaWithCustomValidationFunction } from './validation/json-logic.fixtures'
 
 describe('createHeadlessForm', () => {
   it('should be a function', () => {
     expect(createHeadlessForm).toBeInstanceOf(Function)
+  })
+
+  it('should allow form-specific JSON Logic operators', () => {
+    const { handleValidation } = createHeadlessForm(schemaWithCustomValidationFunction, { strictInputType: false, customJsonLogicOps: { is_hello: a => a === 'hello world' } })
+    expect(handleValidation({ field_a: 'hello world' }).formErrors).toEqual(undefined)
+    const { formErrors: formErrors1 } = handleValidation({ field_a: 'goodbye universe' })
+    expect(formErrors1?.field_a).toEqual('Invalid hello world')
+
+    const { handleValidation: handleValidation2 } = createHeadlessForm(schemaWithCustomValidationFunction, { strictInputType: false, customJsonLogicOps: { is_hello: a => a === 'goodbye universe' } })
+    expect(handleValidation2({ field_a: 'goodbye universe' }).formErrors).toEqual(undefined)
+    const { formErrors: formErrors2 } = handleValidation2({ field_a: 'hello world' })
+    expect(formErrors2?.field_a).toEqual('Invalid hello world')
+
+    const { handleValidation: handleValidation3 } = createHeadlessForm(schemaWithCustomValidationFunction, { strictInputType: false })
+    const actionThatWillThrow = () => {
+      handleValidation3({ field_a: 'hello world' })
+    }
+
+    expect(actionThatWillThrow).toThrow('Unrecognized operation is_hello')
   })
 
   describe('options validation', () => {

--- a/test/validation/json-logic.fixtures.ts
+++ b/test/validation/json-logic.fixtures.ts
@@ -1,4 +1,6 @@
-export function createSchemaWithRulesOnFieldA(rules) {
+import type { JsfObjectSchema, JsonLogicRules } from '../../src/types'
+
+export function createSchemaWithRulesOnFieldA(rules: NonNullable<JsonLogicRules['validations']>) {
   return {
     'properties': {
       field_a: {
@@ -14,7 +16,7 @@ export function createSchemaWithRulesOnFieldA(rules) {
   }
 }
 
-export function createSchemaWithThreePropertiesWithRuleOnFieldA(rules) {
+export function createSchemaWithThreePropertiesWithRuleOnFieldA(rules: NonNullable<JsonLogicRules['validations']>) {
   return {
     'properties': {
       field_a: {
@@ -746,6 +748,7 @@ export const schemaWithReduceAccumulator = {
 }
 
 export const schemaWithCustomValidationFunction = {
+  'type': 'object',
   'properties': {
     field_a: {
       'type': 'string',
@@ -762,7 +765,7 @@ export const schemaWithCustomValidationFunction = {
       },
     },
   },
-}
+} as JsfObjectSchema
 
 export const schemaWithCustomComputedValueFunction = {
   'properties': {


### PR DESCRIPTION
This simplifies the lifecycle of JSON Logic custom operators, ensuring they are always registered at the beginning of each `createHeadlessForm` call and de-registered at its end (in addition to always doing it on every `handleValidation` call.

The previous logic did it every time `applyComputedAttrsToSchema` was called. However, we have other places where operators were needed but not available (such as when processing conditions that depend on JSON Logic).

Registering and de-registering operators on every `createHeadlessForm` and `handleValidation` call is necessary because JSON Logic maintains a single registry of operators shared across all headless forms. Handling this lifecyle in runtime guarantees each headless form instance has its own set of operators without side effects.