### PR TITLE
fix: modify() preserve unknown top-level schema keys when using pick

### DIFF
--- a/src/modify-schema.ts
+++ b/src/modify-schema.ts
@@ -354,9 +354,8 @@ function pickFields(originalSchema: JsfSchema, fieldsToPick: ModifyConfig['pick'
 
         break
       }
-      case 'x-jsf-logic':
+      default:
         newSchema[attrKey] = attrValue
-        break
     }
   })
 

--- a/src/modify-schema.ts
+++ b/src/modify-schema.ts
@@ -355,7 +355,7 @@ function pickFields(originalSchema: JsfSchema, fieldsToPick: ModifyConfig['pick'
         break
       }
       default:
-        newSchema[attrKey] = attrValue
+        (newSchema as Record<string, unknown>)[attrKey] = attrValue
     }
   })
 

--- a/test/modify-schema.test.ts
+++ b/test/modify-schema.test.ts
@@ -1146,6 +1146,21 @@ describe('modifySchema', () => {
       expect(warnings).toHaveLength(0)
     })
 
+    it('preserves unknown top-level schema keys (e.g. x-rmt-meta) not just properties/order/allOf', () => {
+      const schemaWithMeta = {
+        ...schemaTickets,
+        'type': 'object',
+        'x-rmt-meta': { jsfOldVersion: true },
+      }
+
+      const { schema } = modifySchema(schemaWithMeta, {
+        pick: ['quantity'],
+      })
+
+      expect(schema.type).toBe('object')
+      expect(schema['x-rmt-meta']).toEqual({ jsfOldVersion: true })
+    })
+
     it('basic usage without conditionals', () => {
       const schemaMinimal = {
         'properties': {

--- a/test/modify-schema.test.ts
+++ b/test/modify-schema.test.ts
@@ -1155,7 +1155,7 @@ describe('modifySchema', () => {
 
       const { schema } = modifySchema(schemaWithMeta, {
         pick: ['quantity'],
-      })
+      }) as { schema: { 'type'?: string, 'x-rmt-meta'?: unknown } }
 
       expect(schema.type).toBe('object')
       expect(schema['x-rmt-meta']).toEqual({ jsfOldVersion: true })


### PR DESCRIPTION
## Bug

This bug happens in v1, but not in v0.

`modify()` used with `pick` silently drops any top-level schema key it doesn't explicitly know about (`type`, `x-rmt-meta`, `additionalProperties`, `$schema`, etc). Only `properties`, `x-jsf-order`, `required`, `allOf`, `x-jsf-logic` survived.

Repro:

```js
const schema = {
  'type': 'object',
  'x-rmt-meta': { jsfOldVersion: true },
  'properties': {
    name: { type: 'string' },
    age: { type: 'number' },
  },
}

const { schema: result } = modify(schema, { pick: ['name'] })

result.type // undefined, should be 'object'
result['x-rmt-meta'] // undefined, should be { jsfOldVersion: true }
```


## Fix

Added the missing `default` case so unrecognized top-level keys pass through unchanged, matching v0.