### PR TITLE
fix(options): Allow only known options

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -11,6 +11,7 @@ const roots = [
   // '<rootDir>/../src/tests',
   // 2. The new tests for this version
   '<rootDir>/test',
+  '<rootDir>/src',
 ]
 
 /**

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dev": "NODE_ENV=development tsup --watch",
     "test": "jest",
     "test:watch": "jest --watchAll",
+    "test:write-failed-tests": "SHOULD_WRITE_FAILED_TESTS_TO_FILE=true jest",
     "test:file": "jest --runTestsByPath --watch",
     "test:v0-update-baseline": "cd v0 && jest --json --outputFile=../test/v0-baseline-test-results.json;",
     "test:v0-compare-results": "node test/v0_compare_test_results.js",

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -3,7 +3,7 @@ import type { CreateHeadlessFormOptions } from './form'
 import type { JsfObjectSchema, JsfSchema, JsonLogicContext, NonBooleanJsfSchema, ObjectValue, SchemaValue } from './types'
 import type { LegacyOptions } from './validation/schema'
 import { buildFieldSchema } from './field/schema'
-import { deepMergeSchemas } from './utils'
+import { mergeFieldProperties, mergeSchemaBranch } from './utils'
 import { evaluateIfCondition } from './validation/conditions'
 import { applyComputedAttrsToSchema, getJsonLogicContextFromSchema } from './validation/json-logic'
 import { validateSchema } from './validation/schema'
@@ -168,7 +168,7 @@ function processBranch(schema: JsfObjectSchema, values: SchemaValue, branch: Jsf
   const branchSchema = branch as JsfObjectSchema
 
   applySchemaRules(branchSchema, values, options, jsonLogicContext)
-  deepMergeSchemas(schema, branchSchema)
+  mergeSchemaBranch(schema, branchSchema)
 }
 
 /**
@@ -194,7 +194,7 @@ export function updateFieldProperties(fields: Field[], schema: JsfObjectSchema, 
       // Properties might have been removed with the most recent schema (due to most recent form values)
       // so we need to remove them from the original field
       removeNonExistentProperties(field, newField)
-      deepMergeSchemas(field, newField)
+      mergeFieldProperties(field, newField)
 
       const fieldSchema = schema.properties?.[field.name]
       const originalFieldSchema = originalSchema.properties?.[field.name]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,8 +141,9 @@ export function mergeSchemaBranch<T extends Record<string, any>>(schema1?: T, sc
       }
 
       const allowedOptions = new Set(schema1Value.map(option => getOptionIdentity(option)))
-      // Keep the branch's option objects (so re-labeling works), but only for values
-      // already present in the base
+      // Keep the branch's option objects (so changing options properties works),
+      // but only for values that are already present in the base
+      // Note: this will set an empty array if the options are not of an expected format
       schema1[key as keyof T] = schema2Value.filter(
         (option: unknown) => allowedOptions.has(getOptionIdentity(option)),
       )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import type { Field } from './field/type'
+import type { JsfSchema } from './types'
 
 type DiskSizeUnit = 'Bytes' | 'KB' | 'MB'
 
@@ -53,19 +54,66 @@ export function convertKBToMB(kb: number): number {
   return Number.parseFloat(mb.toFixed(2)) // Keep 2 decimal places
 }
 
-// When merging schemas, we should skip merging the if/then/else properties as we could be creating wrong conditions
+// When merging a conditional branch into a schema, we should skip merging the if/then/else
+// properties as we could be creating wrong conditions
 const KEYS_TO_SKIP = ['if', 'then', 'else']
 
-function isObject(value: any): boolean {
-  return value && typeof value === 'object' && !Array.isArray(value)
+function isObject(value: unknown): boolean {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
 /**
- * Merges schema 2 into schema 1 recursively
- * @param schema1 - The first schema to merge
- * @param schema2 - The second schema to merge
+ * Checks if the array is options-like.
+ * Options-like arrays are arrays of objects, all items of which have a const property.
+ *
+ * @param schemaKey - The key of the schema to check.
+ * @param schema - The schema to check.
+ * @returns True if the schema is options-like, false otherwise.
  */
-export function deepMergeSchemas<T extends Record<string, any>>(schema1?: T, schema2?: T): void {
+function isOptionsLikeSchema(schemaKey: string, schema: JsfSchema[]): boolean {
+  switch (schemaKey) {
+    case 'options':
+    case 'enum':
+      return true
+    case 'oneOf':
+    case 'anyOf':
+      return schema.length > 0 && schema.every(item => isObject(item) && 'const' in item)
+    default:
+      return false
+  }
+}
+
+/**
+ * Returns the value that identifies an option, regardless of the option-like array shape:
+ * - `oneOf`/`anyOf` entries are `{ const, title }` objects, identified by `const`
+ * - `options` entries are `{ value, label }` objects, identified by `value`
+ * - `enum` entries are the raw values themselves
+ */
+function getOptionIdentity(option: unknown): unknown {
+  if (isObject(option)) {
+    const obj = option as Record<string, any>
+    if ('const' in obj) {
+      return obj.const
+    }
+    if ('value' in obj) {
+      return obj.value
+    }
+  }
+  return option
+}
+
+/**
+ * Merges a conditional branch schema into the base schema recursively.
+ *
+ * Option-like arrays (enum/oneOf/anyOf/options) are restricted to the options already
+ * present on the base field: the branch may narrow or re-label existing options, but any
+ * option whose value isn't present in the base is ignored. If the base field declares no
+ * option array for a given key, the branch's options are dropped entirely.
+ *
+ * @param schema1 - The base schema to merge into
+ * @param schema2 - The conditional branch schema to merge from
+ */
+export function mergeSchemaBranch<T extends Record<string, any>>(schema1?: T, schema2?: T): void {
   // Handle null/undefined values
   if (!schema1 || !schema2) {
     return
@@ -85,11 +133,27 @@ export function deepMergeSchemas<T extends Record<string, any>>(schema1?: T, sch
 
     const schema1Value = schema1[key]
 
+    // Restrict option-like arrays to the options already present on the base field
+    if (isOptionsLikeSchema(key, schema2Value)) {
+      // Base declares no options for this key -> a conditional cannot introduce any
+      if (!Array.isArray(schema1Value)) {
+        continue
+      }
+
+      const allowedOptions = new Set(schema1Value.map(option => getOptionIdentity(option)))
+      // Keep the branch's option objects (so re-labeling works), but only for values
+      // already present in the base
+      schema1[key as keyof T] = schema2Value.filter(
+        (option: unknown) => allowedOptions.has(getOptionIdentity(option)),
+      )
+      continue
+    }
+
     // If the value is an object:
     if (isObject(schema2Value)) {
       // If both schemas have this key and it's an object, merge recursively
       if (isObject(schema1Value)) {
-        deepMergeSchemas(schema1Value, schema2Value)
+        mergeSchemaBranch(schema1Value, schema2Value)
       }
       // Otherwise, if the value is different, just assign it
       else if (schema1Value !== schema2Value) {
@@ -99,12 +163,10 @@ export function deepMergeSchemas<T extends Record<string, any>>(schema1?: T, sch
     // If the value is an array, replace the whole array
     // for the "required" key, we only add new elements to the array
     else if (schema1Value && Array.isArray(schema2Value)) {
-      const originalArray = schema1Value
-
       if (key === 'required') {
         for (const item of schema2Value) {
-          if (!originalArray.includes(item)) {
-            originalArray.push(item)
+          if (!schema1Value.includes(item)) {
+            schema1Value.push(item)
           }
         }
       }
@@ -116,6 +178,27 @@ export function deepMergeSchemas<T extends Record<string, any>>(schema1?: T, sch
     // Finally, if the value is different, just assign it
     else if (schema1[key] !== schema2Value) {
       schema1[key as keyof T] = schema2Value
+    }
+  }
+}
+
+/**
+ * Merges a freshly-built field into an existing field, in place.
+ *
+ * @param target - The existing field to merge into
+ * @param source - The newly-built field to merge from
+ */
+export function mergeFieldProperties(target: Field, source: Field): void {
+  for (const [key, sourceValue] of Object.entries(source)) {
+    const targetValue = target[key]
+
+    // If both values are plain objects, merge them recursively
+    if (isObject(sourceValue) && isObject(targetValue)) {
+      mergeFieldProperties(targetValue as Field, sourceValue as Field)
+    }
+    // Otherwise, replace when the value changed, arrays are fully replaced
+    else if (targetValue !== sourceValue) {
+      target[key] = sourceValue
     }
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,8 +135,9 @@ export function mergeSchemaBranch<T extends Record<string, any>>(schema1?: T, sc
 
     // Restrict option-like arrays to the options already present on the base field
     if (isOptionsLikeSchema(key, schema2Value)) {
-      // Base declares no options for this key -> a conditional cannot introduce any
+      // Base declares no options for this key, let a conditional branch introduce them
       if (!Array.isArray(schema1Value)) {
+        schema1[key as keyof T] = schema2Value
         continue
       }
 

--- a/test/fields/mutation.test.ts
+++ b/test/fields/mutation.test.ts
@@ -14,7 +14,7 @@ describe('field mutation', () => {
         },
         permissions: {
           type: 'string',
-          enum: ['read', 'write', 'execute'],
+          enum: ['read', 'write', 'execute', 'all'],
         },
       },
       allOf: [
@@ -22,7 +22,7 @@ describe('field mutation', () => {
           if: {
             properties: {
               userType: {
-                const: 'admin',
+                const: 'user',
               },
             },
             required: ['userType'],
@@ -30,7 +30,7 @@ describe('field mutation', () => {
           then: {
             properties: {
               permissions: {
-                enum: ['read', 'write', 'execute', 'all'],
+                enum: ['read', 'write', 'execute'],
               },
             },
           },
@@ -57,13 +57,13 @@ describe('field mutation', () => {
 
     it('should have default enum options for permissions field', () => {
       const form = createHeadlessForm(schema)
-      expect(getField(form.fields, 'permissions')?.enum).toEqual(['read', 'write', 'execute'])
+      expect(getField(form.fields, 'permissions')?.enum).toEqual(['read', 'write', 'execute', 'all'])
     })
 
-    it('should update enum options when userType is admin', () => {
+    it('should update enum options when userType is user', () => {
       const form = createHeadlessForm(schema)
-      form.handleValidation({ userType: 'admin' })
-      expect(getField(form.fields, 'permissions')?.enum).toEqual(['read', 'write', 'execute', 'all'])
+      form.handleValidation({ userType: 'user' })
+      expect(getField(form.fields, 'permissions')?.enum).toEqual(['read', 'write', 'execute'])
     })
 
     it('should update enum options when userType is guest', () => {
@@ -72,13 +72,13 @@ describe('field mutation', () => {
       expect(getField(form.fields, 'permissions')?.enum).toEqual(['read'])
     })
 
-    it('should revert to default enum options when userType changes back to user', () => {
+    it('should revert to default enum options when userType changes back to admin', () => {
       const form = createHeadlessForm(schema)
-      form.handleValidation({ userType: 'admin' })
-      expect(getField(form.fields, 'permissions')?.enum).toEqual(['read', 'write', 'execute', 'all'])
-
       form.handleValidation({ userType: 'user' })
       expect(getField(form.fields, 'permissions')?.enum).toEqual(['read', 'write', 'execute'])
+
+      form.handleValidation({ userType: 'admin' })
+      expect(getField(form.fields, 'permissions')?.enum).toEqual(['read', 'write', 'execute', 'all'])
     })
   })
 

--- a/test/fields/options.test.ts
+++ b/test/fields/options.test.ts
@@ -308,3 +308,94 @@ describe('conditionally replacing option-like arrays', () => {
     expect(form.handleValidation({ userType: 'user', permissions: 'write' }).formErrors).toBeUndefined()
   })
 })
+
+describe('conditionals cannot introduce options that are not in the base field', () => {
+  const getOptions = (form: ReturnType<typeof createHeadlessForm>, name: string) =>
+    form.fields.find(f => f.name === name)?.options
+
+  it('should ignore oneOf options a conditional introduces that are not in the base', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        trigger: { type: 'string' as const },
+        choice: {
+          type: 'string' as const,
+          oneOf: [
+            { const: 'a', title: 'A' },
+            { const: 'b', title: 'B' },
+            { const: 'c', title: 'C' },
+          ],
+        },
+      },
+      allOf: [
+        {
+          if: { properties: { trigger: { const: 'go' } }, required: ['trigger'] },
+          then: {
+            properties: {
+              choice: {
+                // 'd' is not present on the base field and must be ignored
+                oneOf: [{ const: 'c', title: 'C' }, { const: 'd', title: 'D' }],
+              },
+            },
+          },
+        },
+      ],
+    }
+
+    const form = createHeadlessForm(schema)
+
+    form.handleValidation({ trigger: 'go' })
+    // Only 'c' survives; the injected 'd' is dropped
+    expect(getOptions(form, 'choice')).toEqual([{ label: 'C', value: 'c' }])
+    expect(form.handleValidation({ trigger: 'go', choice: 'd' }).formErrors).toEqual({
+      choice: 'The option "d" is not valid.',
+    })
+
+    // Reverting still restores the full base option set
+    form.handleValidation({ trigger: 'stop' })
+    expect(getOptions(form, 'choice')).toEqual([
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+      { label: 'C', value: 'c' },
+    ])
+  })
+
+  it('should ignore enum options a conditional introduces that are not in the base', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        userType: { type: 'string' as const },
+        permissions: {
+          type: 'string' as const,
+          enum: ['read', 'write', 'execute'],
+        },
+      },
+      allOf: [
+        {
+          if: { properties: { userType: { const: 'admin' } }, required: ['userType'] },
+          then: {
+            properties: {
+              permissions: {
+                // 'delete' is not present on the base field and must be ignored
+                enum: ['read', 'delete'],
+              },
+            },
+          },
+        },
+      ],
+    }
+
+    const form = createHeadlessForm(schema)
+    const getEnum = () => form.fields.find(f => f.name === 'permissions')?.enum
+
+    form.handleValidation({ userType: 'admin' })
+    expect(getEnum()).toEqual(['read'])
+    expect(form.handleValidation({ userType: 'admin', permissions: 'delete' }).formErrors).toEqual({
+      permissions: 'The option "delete" is not valid.',
+    })
+
+    // Reverting still restores the full base enum
+    form.handleValidation({ userType: 'user' })
+    expect(getEnum()).toEqual(['read', 'write', 'execute'])
+  })
+})

--- a/test/json-schema-test-suite/json-schema-test-suite-tracker.js
+++ b/test/json-schema-test-suite/json-schema-test-suite-tracker.js
@@ -1,11 +1,14 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 import { JSON_SCHEMA_SUITE_FAILED_TESTS_FILE_NAME } from './constants.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
+
+const shouldWriteFailedTestsToFile = process.env.SHOULD_WRITE_FAILED_TESTS_TO_FILE === 'true'
 
 // Save newly failed tests
 function saveFailedTests(failedTests) {
@@ -25,7 +28,7 @@ function saveFailedTests(failedTests) {
  *
  * Note: The failed tests are not being saved to file every time the suite runs,
  * as this could cause for bugs to surface due to a change in the codebase.
- * The SHOULD_WRITE_FAILED_TESTS_TO_FILE constant can be set to true to write the
+ * The SHOULD_WRITE_FAILED_TESTS_TO_FILE env variable can be set to true to write the
  * failed tests to a file (on-demand), for later consumption at the
  * json_schema_test_suite.test.js file.
  *
@@ -64,17 +67,26 @@ class FailureTrackingReporter {
     }
 
     testResult.testResults.forEach((result) => {
-      if (result.status === 'failed' || result.status === 'pending') {
+      if (result.status === 'failed' || (shouldWriteFailedTestsToFile && result.status === 'pending')) {
         this.addFailedTest(result)
       }
     })
   }
 
-  onRunComplete() {
+  getLastError() {
     if (this.size > 0) {
-      // eslint-disable-next-line no-console
-      console.log(`JSON Schema Test Suite: Test run complete, saving ${this.size} tests to ${JSON_SCHEMA_SUITE_FAILED_TESTS_FILE_NAME} file so they're ignored for now and enabled later`)
-      saveFailedTests(this.unimplementedFeatures)
+      if (shouldWriteFailedTestsToFile) {
+        // eslint-disable-next-line no-console
+        console.log(`JSON Schema Test Suite: Test run complete, ${this.size} failing tests exist.`)
+        // eslint-disable-next-line no-console
+        console.log(`Saving ${this.size} test failures to ${JSON_SCHEMA_SUITE_FAILED_TESTS_FILE_NAME} file so they're skipped on the next test runs.`)
+        saveFailedTests(this.unimplementedFeatures)
+      }
+      else {
+        // eslint-disable-next-line no-console
+        console.log(`JSON Schema Test Suite: Test run complete, ${this.size} new failing tests found!
+🚨 If these failing tests are expected, run 'pnpm test:write-failed-tests' to update the failing tests file and skip them on the next test runs.`)
+      }
     }
   }
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import type { Field } from '../src/field/type'
 import { describe, expect, it } from '@jest/globals'
-import { convertKBToMB, deepMergeSchemas, getField } from '../src/utils'
+import { convertKBToMB, getField, mergeFieldProperties, mergeSchemaBranch } from '../src/utils'
 
 describe('getField', () => {
   const mockFields: Field[] = [
@@ -135,30 +135,30 @@ describe('convertKBToMB', () => {
   })
 })
 
-describe('deepMergeSchemas', () => {
+describe('mergeSchemaBranch', () => {
   it('should do nothing when either schema is missing', () => {
     const schema1 = { type: 'string' }
-    expect(() => deepMergeSchemas(undefined, schema1)).not.toThrow()
-    expect(() => deepMergeSchemas(schema1, undefined)).not.toThrow()
+    expect(() => mergeSchemaBranch(undefined, schema1)).not.toThrow()
+    expect(() => mergeSchemaBranch(schema1, undefined)).not.toThrow()
     expect(schema1).toEqual({ type: 'string' })
   })
 
   it('should return early without mutating when a schema is a truthy non-object', () => {
     const schema1: Record<string, any> = { type: 'string' }
-    expect(() => deepMergeSchemas(42 as any, schema1)).not.toThrow()
-    expect(() => deepMergeSchemas(schema1, 'not-an-object' as any)).not.toThrow()
+    expect(() => mergeSchemaBranch(42 as any, schema1)).not.toThrow()
+    expect(() => mergeSchemaBranch(schema1, 'not-an-object' as any)).not.toThrow()
     expect(schema1).toEqual({ type: 'string' })
   })
 
   it('should copy over properties that only exist in schema2', () => {
     const schema1: Record<string, any> = { type: 'string' }
-    deepMergeSchemas(schema1, { title: 'Name' })
+    mergeSchemaBranch(schema1, { title: 'Name' })
     expect(schema1).toEqual({ type: 'string', title: 'Name' })
   })
 
   it('should overwrite primitive values that differ', () => {
     const schema1: Record<string, any> = { title: 'Old' }
-    deepMergeSchemas(schema1, { title: 'New' })
+    mergeSchemaBranch(schema1, { title: 'New' })
     expect(schema1.title).toBe('New')
   })
 
@@ -166,7 +166,7 @@ describe('deepMergeSchemas', () => {
     const schema1: Record<string, any> = {
       properties: { name: { type: 'string' } },
     }
-    deepMergeSchemas(schema1, {
+    mergeSchemaBranch(schema1, {
       properties: { age: { type: 'number' } },
     })
     expect(schema1.properties).toEqual({
@@ -177,13 +177,13 @@ describe('deepMergeSchemas', () => {
 
   it('should assign an object when the target value is not an object', () => {
     const schema1: Record<string, any> = { meta: 'string' }
-    deepMergeSchemas(schema1, { meta: { nested: true } })
+    mergeSchemaBranch(schema1, { meta: { nested: true } })
     expect(schema1.meta).toEqual({ nested: true })
   })
 
   it('should skip if/then/else properties', () => {
     const schema1: Record<string, any> = { type: 'object' }
-    deepMergeSchemas(schema1, {
+    mergeSchemaBranch(schema1, {
       if: { properties: { a: { const: 1 } } },
       then: { required: ['b'] },
       else: { required: ['c'] },
@@ -191,55 +191,124 @@ describe('deepMergeSchemas', () => {
     expect(schema1).toEqual({ type: 'object' })
   })
 
-  it('should replace enum arrays', () => {
-    const schema1: Record<string, any> = { enum: ['a', 'b'] }
-    deepMergeSchemas(schema1, { enum: ['c', 'd'] })
-    expect(schema1.enum).toEqual(['c', 'd'])
-  })
-
   it('should only add new elements to the required array', () => {
     const schema1: Record<string, any> = { required: ['a', 'b'] }
-    deepMergeSchemas(schema1, { required: ['b', 'c'] })
+    mergeSchemaBranch(schema1, { required: ['b', 'c'] })
     expect(schema1.required).toEqual(['a', 'b', 'c'])
   })
 
-  it('should replace the whole options array', () => {
-    const schema1: Record<string, any> = {
+  describe('restricting option-like arrays to the base options', () => {
+    it('should narrow enum arrays to the options present in the base', () => {
+      const schema1: Record<string, any> = { enum: ['a', 'b', 'c'] }
+      mergeSchemaBranch(schema1, { enum: ['b', 'c'] })
+      expect(schema1.enum).toEqual(['b', 'c'])
+    })
+
+    it('should ignore enum options that are not present in the base', () => {
+      const schema1: Record<string, any> = { enum: ['a', 'b', 'c'] }
+      // 'd' does not exist on the base field and must be dropped
+      mergeSchemaBranch(schema1, { enum: ['c', 'd'] })
+      expect(schema1.enum).toEqual(['c'])
+    })
+
+    it('should narrow the options array and ignore new options', () => {
+      const schema1: Record<string, any> = {
+        options: [{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }, { value: 'c', label: 'C' }],
+      }
+      mergeSchemaBranch(schema1, {
+        options: [{ value: 'c', label: 'C' }, { value: 'd', label: 'D' }],
+      })
+      expect(schema1.options).toEqual([{ value: 'c', label: 'C' }])
+      expect(schema1.options).toHaveLength(1)
+    })
+
+    it('should narrow the anyOf array and ignore new options', () => {
+      const schema1: Record<string, any> = {
+        anyOf: [{ const: 'A' }, { const: 'B' }, { const: 'C' }],
+      }
+      mergeSchemaBranch(schema1, {
+        anyOf: [{ const: 'C' }, { const: 'X' }],
+      })
+      expect(schema1.anyOf).toEqual([{ const: 'C' }])
+      expect(schema1.anyOf).toHaveLength(1)
+    })
+
+    it('should narrow the oneOf array and ignore new options', () => {
+      const schema1: Record<string, any> = {
+        oneOf: [{ const: 'A' }, { const: 'B' }, { const: 'C' }],
+      }
+      mergeSchemaBranch(schema1, {
+        oneOf: [{ const: 'A' }, { const: 'Z' }],
+      })
+      expect(schema1.oneOf).toEqual([{ const: 'A' }])
+      expect(schema1.oneOf).toHaveLength(1)
+    })
+
+    it('should keep the branch version of a matched option (allowing re-labeling)', () => {
+      const schema1: Record<string, any> = {
+        oneOf: [{ const: 'a', title: 'A' }, { const: 'b', title: 'B' }],
+      }
+      mergeSchemaBranch(schema1, {
+        oneOf: [{ const: 'a', title: 'Relabeled A' }, { const: 'new', title: 'New' }],
+      })
+      expect(schema1.oneOf).toEqual([{ const: 'a', title: 'Relabeled A' }])
+    })
+
+    it('should drop the branch options entirely when the base declares none', () => {
+      const schema1: Record<string, any> = { type: 'string' }
+      mergeSchemaBranch(schema1, { enum: ['a', 'b'] })
+      expect(schema1).toEqual({ type: 'string' })
+      expect(schema1.enum).toBeUndefined()
+    })
+
+    it('should restrict a nested items.anyOf options array', () => {
+      const schema1: Record<string, any> = {
+        items: { anyOf: [{ const: 'A' }, { const: 'B' }, { const: 'C' }] },
+      }
+      mergeSchemaBranch(schema1, {
+        items: { anyOf: [{ const: 'C' }, { const: 'D' }] },
+      })
+      expect(schema1.items.anyOf).toEqual([{ const: 'C' }])
+      expect(schema1.items.anyOf).toHaveLength(1)
+    })
+  })
+})
+
+describe('mergeFieldProperties', () => {
+  const baseField = (): Field => ({
+    name: 'field',
+    type: 'text',
+    inputType: 'text',
+    required: false,
+    jsonType: 'string',
+    isVisible: true,
+  })
+
+  it('should copy over properties that only exist in the source', () => {
+    const target = baseField()
+    mergeFieldProperties(target, { ...baseField(), label: 'Label' })
+    expect(target.label).toBe('Label')
+  })
+
+  it('should overwrite primitive values that differ', () => {
+    const target = { ...baseField(), label: 'Old' }
+    mergeFieldProperties(target, { ...baseField(), label: 'New' })
+    expect(target.label).toBe('New')
+  })
+
+  it('should merge nested objects recursively', () => {
+    const target = { ...baseField(), errorMessage: { required: 'Required' } }
+    mergeFieldProperties(target, { ...baseField(), errorMessage: { type: 'Wrong type' } })
+    expect(target.errorMessage).toEqual({ required: 'Required', type: 'Wrong type' })
+  })
+
+  it('should fully replace option arrays', () => {
+    const target = { ...baseField(), options: [{ value: 'c', label: 'C' }] }
+    // Reverting to a larger option set must not be blocked
+    mergeFieldProperties(target, {
+      ...baseField(),
       options: [{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }, { value: 'c', label: 'C' }],
-    }
-    const incomingOptions = [{ value: 'c', label: 'C' }]
-    deepMergeSchemas(schema1, {
-      options: incomingOptions,
     })
-    expect(schema1.options).toStrictEqual([{ value: 'c', label: 'C' }])
-    // preserves the reference identity of the incoming options array
-    expect(schema1.options).toEqual(incomingOptions)
-    expect(schema1.options).toHaveLength(1)
-  })
-
-  it('should replace the whole anyOf options array', () => {
-    const schema1: Record<string, any> = {
-      anyOf: [{ const: 'A', label: 'A' }, { const: 'B', label: 'B' }, { const: 'C', label: 'C' }],
-    }
-    const incomingAnyOf = [{ const: 'C', label: 'C' }]
-    deepMergeSchemas(schema1, {
-      anyOf: incomingAnyOf,
-    })
-    // preserves the reference identity of the incoming anyOf array
-    expect(schema1.anyOf).toEqual(incomingAnyOf)
-    expect(schema1.anyOf).toHaveLength(1)
-  })
-
-  it('should replace a nested items.anyOf options array', () => {
-    const schema1: Record<string, any> = {
-      items: { anyOf: [{ const: 'A', label: 'A' }, { const: 'B', label: 'B' }, { const: 'C', label: 'C' }] },
-    }
-    const incomingItemsAnyOf = [{ const: 'C', label: 'C' }]
-    deepMergeSchemas(schema1, {
-      items: { anyOf: incomingItemsAnyOf },
-    })
-    // preserves the reference identity of the incoming anyOf array
-    expect(schema1.items.anyOf).toEqual(incomingItemsAnyOf)
-    expect(schema1.items.anyOf).toHaveLength(1)
+    expect(target.options).toEqual([{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }, { value: 'c', label: 'C' }])
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -205,10 +205,16 @@ describe('mergeSchemaBranch', () => {
     })
 
     it('should ignore enum options that are not present in the base', () => {
-      const schema1: Record<string, any> = { enum: ['a', 'b', 'c'] }
+      const schema1: Record<string, any> = { enum: ['a', 'b', 'c', null] }
       // 'd' does not exist on the base field and must be dropped
-      mergeSchemaBranch(schema1, { enum: ['c', 'd'] })
-      expect(schema1.enum).toEqual(['c'])
+      mergeSchemaBranch(schema1, { enum: ['c', 'd', null] })
+      expect(schema1.enum).toEqual(['c', null])
+    })
+
+    it('should narrow array of enum objects to the options present in the base, assuming option-like objects', () => {
+      const schema1: Record<string, any> = { enum: [{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }, { value: 'c', label: 'C' }] }
+      mergeSchemaBranch(schema1, { enum: [{ value: 'b', label: 'B' }, { value: 'c', label: 'C' }] })
+      expect(schema1.enum).toEqual([{ value: 'b', label: 'B' }, { value: 'c', label: 'C' }])
     })
 
     it('should narrow the options array and ignore new options', () => {
@@ -220,6 +226,12 @@ describe('mergeSchemaBranch', () => {
       })
       expect(schema1.options).toEqual([{ value: 'c', label: 'C' }])
       expect(schema1.options).toHaveLength(1)
+    })
+
+    it('should ignore options that are not option-like objects, still replacing the array', () => {
+      const schema1: Record<string, any> = { options: [{ flag: true, label: 'A' }, { flag: false, label: 'B' }, { flag: true, label: 'C' }] }
+      mergeSchemaBranch(schema1, { options: [{ flag: true, label: 'A' }, { flag: false, label: 'B' }] })
+      expect(schema1.options).toEqual([])
     })
 
     it('should narrow the anyOf array and ignore new options', () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -266,13 +266,6 @@ describe('mergeSchemaBranch', () => {
       expect(schema1.oneOf).toEqual([{ const: 'a', title: 'Relabeled A' }])
     })
 
-    it('should drop the branch options entirely when the base declares none', () => {
-      const schema1: Record<string, any> = { type: 'string' }
-      mergeSchemaBranch(schema1, { enum: ['a', 'b'] })
-      expect(schema1).toEqual({ type: 'string' })
-      expect(schema1.enum).toBeUndefined()
-    })
-
     it('should restrict a nested items.anyOf options array', () => {
       const schema1: Record<string, any> = {
         items: { anyOf: [{ const: 'A' }, { const: 'B' }, { const: 'C' }] },
@@ -282,6 +275,24 @@ describe('mergeSchemaBranch', () => {
       })
       expect(schema1.items.anyOf).toEqual([{ const: 'C' }])
       expect(schema1.items.anyOf).toHaveLength(1)
+    })
+
+    it('should add the branch options when the base declares none', () => {
+      const schema1: Record<string, any> = { type: 'string' }
+      mergeSchemaBranch(schema1, { enum: ['a', 'b'] })
+      expect(schema1).toEqual({ type: 'string', enum: ['a', 'b'] })
+    })
+
+    it('should add the branch options when the base declares none for option-like arrays', () => {
+      const schema1: Record<string, any> = { type: 'string' }
+      mergeSchemaBranch(schema1, { oneOf: [{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }] })
+      expect(schema1.oneOf).toEqual([{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }])
+    })
+
+    it('should not add the branch options when the base an empty array', () => {
+      const schema1: Record<string, any> = { type: 'string', enum: [] }
+      mergeSchemaBranch(schema1, { enum: ['a', 'b'] })
+      expect(schema1).toEqual({ type: 'string', enum: [] })
     })
   })
 })


### PR DESCRIPTION
Follow up to https://github.com/remoteoss/json-schema-form/pull/263

- **Breaking change** – Ensures new options cannot be added when processing a conditional branch unless they are specified in the field's base options. If the field doesn't have the options property (e.g. `anyOf`), then any new options provided via conditionals are accepted
  - This is a breaking change since schemas that don't declare all the allowed options in the field by default, now won't show them when a conditional is adding new options
- Refactors `deepMergeSchemas` into two separate functions: `mergeSchemaBranch` for the logic of merging conditional branches, `mergeFieldProperties` to merge field properties. `deepMergeSchemas` did both with mixed logic
- Running tests in watch mode now properly watches the `src` folder
- `test/json-schema-test-suite/failed-json-schema-test-suite.json` is not written every time we run the tests now, only via the `test:write-failed-tests` script. This fixes `test:watch` running an infinite loop, and ensures the file is only written to when intended 
 

For the **breaking change**, if a field is declared the following way:

```
    "properties": {
        "permissions": {
            "type": "string",
            "enum": ["read", "write", "all"]
        }
    }
```

Then conditionals can only conditionally apply the options in the base enum, a subset or all of `"enum": ["read", "write", "all"]`. Any new value like `update` won't be accepted. The schema validates against both the _base_ `enum` and the conditional `enum`. This applies even if the _base_ enum is declared as an empty array.

However, if the key `enum` doesn't exist at all, then a conditional can add any `enum` option it wants. So if the schema is:

```
    "properties": {
        "permissions": {
            "type": "string"
        }
    }
```

then a conditional can set `permissions.enum: ["update"]` and it will accept that new option.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking behavior for schemas that relied on conditionals to introduce new options; core mutation/validation path changed with broad test coverage.
> 
> **Overview**
> **Breaking change:** When `if`/`then`/`else` (or `allOf`) branches merge into a field schema, **`enum`**, **`oneOf`**, **`anyOf`**, and **`options`** can only **narrow or relabel** values already declared on the base property—conditionals can no longer inject new option values. Field updates after validation use a separate merge path so option lists can still be fully replaced when reverting conditionals.
> 
> `deepMergeSchemas` is split into **`mergeSchemaBranch`** (conditional schema merge with option filtering) and **`mergeFieldProperties`** (in-place field updates); **`mutations.ts`** calls the new APIs.
> 
> **Tooling:** Jest **`roots`** includes **`src`** for watch mode; JSON Schema Test Suite failure tracking writes **`failed-json-schema-test-suite.json`** only when **`SHOULD_WRITE_FAILED_TESTS_TO_FILE=true`** via new **`test:write-failed-tests`** script (avoids watch loops and accidental overwrites).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc71e4cd45acf54fa3580aef58770d2c956f5869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->