### PR TITLE
Update contributing docs to mention semver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,7 @@ The final release is done after merge.
 We follow [Semantic Versioning](https://semver.org/). Given a version number `MAJOR.MINOR.PATCH`, increment the:
 
 - **MAJOR** version when you make incompatible API changes
+  - disabled since we want to keep v1 backwards compatible for the foreseeable future
 - **MINOR** version when you add functionality in a backward compatible manner
 - **PATCH** version when you make backward compatible bug fixes
 
@@ -168,7 +169,7 @@ Pick the bump that matches your changes and run the matching command:
 
 | Bump    | When to use                                     | Command                     |
 | ------- | ----------------------------------------------- | --------------------------- |
-| `major` | Incompatible API changes                        | `pnpm run release major`    |
+| `major` | Incompatible API changes                        | Disabled                    |
 | `minor` | New functionality, backward compatible          | `pnpm run release minor`    |
 | `patch` | Backward compatible bug fixes                   | `pnpm run release patch`    |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,15 +158,29 @@ The final release is done after merge.
 
 ### Publishing a stable release
 
-1.  Checkout `main` and pull the latest commit
-2.  Depending if you want a `patch` or `minor`, run the command `pnpm run release patch` or `pnpm run release minor`.
+We follow [Semantic Versioning](https://semver.org/). Given a version number `MAJOR.MINOR.PATCH`, increment the:
 
-    1. You'll be shown what's the new version and prompt you if it's correct. Eg
+- **MAJOR** version when you make incompatible API changes
+- **MINOR** version when you add functionality in a backward compatible manner
+- **PATCH** version when you make backward compatible bug fixes
+
+Pick the bump that matches your changes and run the matching command:
+
+| Bump    | When to use                                     | Command                     |
+| ------- | ----------------------------------------------- | --------------------------- |
+| `major` | Incompatible API changes                        | `pnpm run release major`    |
+| `minor` | New functionality, backward compatible          | `pnpm run release minor`    |
+| `patch` | Backward compatible bug fixes                   | `pnpm run release patch`    |
+
+1.  Checkout `main` and pull the latest commit
+2.  Run the command matching the bump you need (see the table above).
+
+    1. You'll be shown what's the new version and prompt you if it's correct. E.g. with `pnpm run release minor`:
 
        ```
        Creating a new version...
-       :: Current version: 1.0.0-beta.0
-       :::::: New version: 1.1.0-beta.0
+       :: Current version: 1.0.0
+       :::::: New version: 1.1.0
        Ready to commit and publish it? (y/n)
 
        ```

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -19,7 +19,8 @@ const packageJsonPath = path.resolve(__dirname, '../package.json');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 
 const releaseTypes = ['dev', 'beta', 'official'];
-const bumpTypes = ['patch', 'minor', 'major'];
+// 'major' is disabled to avoid accidental major releases
+const bumpTypes = ['patch', 'minor'];
 
 async function checkGitBranchAndStatus() {
   const releaseType = process.argv[2];


### PR DESCRIPTION
Our releases should follow [semver](https://semver.org/), but it was not clearly stated in the docs.

Disables release of `major` versions to prevent accidental bumps. Matches v0 package scripts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and release-script validation only; no runtime library behavior changes.
> 
> **Overview**
> Documents **Semantic Versioning** in the stable-release section of `CONTRIBUTING.md`, including when to use patch vs minor bumps and that **major** bumps are intentionally disabled to keep v1 backward compatible.
> 
> Adds a bump-type → `pnpm run release` command table and tightens the release steps (including a stable-version example instead of beta-style version strings).
> 
> Aligns `scripts/release.js` with the docs by removing `major` from allowed official bump types, with a comment explaining it avoids accidental major releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dcaae3589180d954990a6d9b67dab83645e5ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->