### PR TITLE
fix: evaluate value-dependent items conditionals per array row

### DIFF
--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -125,13 +125,13 @@ function applySchemaRules(
   for (const { rule, matches } of conditionalRules) {
     // If the rule matches, process the then branch
     if (matches && rule.then) {
-      processBranch(schema, values, rule.then, options, jsonLogicContext)
+      processBranch(schema, values, rule.then, options, jsonLogicContext, constantIfsOnly)
       // Delete the then branch to avoid processing it again when validating the schema
       delete rule.then
     }
     // If the rule doesn't match, process the else branch
     else if (!matches && rule.else) {
-      processBranch(schema, values, rule.else, options, jsonLogicContext)
+      processBranch(schema, values, rule.else, options, jsonLogicContext, constantIfsOnly)
       // Delete the else branch to avoid processing it again when validating the schema
       delete rule.else
     }
@@ -174,11 +174,12 @@ function applySchemaRules(
  * @param branch - The branch (schema representing and then/else) to process
  * @param options - Validation options
  * @param jsonLogicContext - JSON Logic context
+ * @param constantIfsOnly - When true, only constant (boolean) conditionals are pre-applied
  */
-function processBranch(schema: JsfObjectSchema, values: SchemaValue, branch: JsfSchema, options: CreateHeadlessFormOptions = {}, jsonLogicContext: JsonLogicContext | undefined) {
+function processBranch(schema: JsfObjectSchema, values: SchemaValue, branch: JsfSchema, options: CreateHeadlessFormOptions = {}, jsonLogicContext: JsonLogicContext | undefined, constantIfsOnly: boolean = false) {
   const branchSchema = branch as JsfObjectSchema
 
-  applySchemaRules(branchSchema, values, options, jsonLogicContext)
+  applySchemaRules(branchSchema, values, options, jsonLogicContext, constantIfsOnly)
   mergeSchemaBranch(schema, branchSchema, options)
 }
 

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -89,15 +89,19 @@ function applySchemaRules(
   values: SchemaValue = {},
   options: CreateHeadlessFormOptions = {},
   jsonLogicContext: JsonLogicContext | undefined,
+  constantIfsOnly: boolean = false,
 ) {
   if (!isObjectValue(values)) {
     return
   }
 
+  const shouldProcessRule = (ifNode: JsfSchema | undefined): boolean =>
+    typeof ifNode !== 'undefined' && (!constantIfsOnly || typeof ifNode === 'boolean')
+
   const conditionalRules: { rule: NonBooleanJsfSchema, matches: boolean }[] = []
 
   // If the schema has an if property, evaluate it and add it to the conditional rules array
-  if (typeof schema.if !== 'undefined') {
+  if (shouldProcessRule(schema.if)) {
     conditionalRules.push(evaluateConditional(values, schema, schema, options, jsonLogicContext))
   }
 
@@ -105,7 +109,7 @@ function applySchemaRules(
   const allOf = schema.allOf ?? []
   const jsonLogicAllOf = schema['x-jsf-logic']?.allOf ?? [];
 
-  [...allOf, ...jsonLogicAllOf].filter((rule: JsfSchema) => typeof rule.if !== 'undefined').forEach((rule) => {
+  [...allOf, ...jsonLogicAllOf].filter((rule: JsfSchema) => shouldProcessRule(rule.if)).forEach((rule) => {
     const result = evaluateConditional(values, schema, rule, options, jsonLogicContext)
     conditionalRules.push(result)
   })
@@ -131,23 +135,25 @@ function applySchemaRules(
       if (typeof property === 'object') {
         const propertySchema = property as JsfObjectSchema
         if (propertySchema.type === 'object') {
-          applySchemaRules(propertySchema, values[key] as ObjectValue, options, jsonLogicContext)
+          applySchemaRules(propertySchema, values[key] as ObjectValue, options, jsonLogicContext, constantIfsOnly)
         }
         if (propertySchema.items) {
           /*
-          * This is a partial workaround to apply conditional logic to fields with items.
-          * Due to the nature of these fields, the value is an array. applySchemaRules expects
-          * an object and it simply does not process the rules if the value is not an object.
+          * An array property has one shared `items` schema but many row values, so a
+          * value-dependent then/else branch cannot be baked into the schema — it would
+          * be wrong for any row where the condition evaluates differently. The previous
+          * workaround evaluated every rule against an empty object, which permanently
+          * merged (and deleted) whichever branch matched `{}`; rules with an `else` or
+          * a negated `if` were then wrong for every row and for validation too.
           *
-          * The correct solution would be to refactor applySchemaRules to handle arrays properly,
-          * but for now we simply pass an empty object to ensure the rules are applied.
-          *
-          * This means that the visibility rules in this case will only be based on the
-          * schema and will not work based on the actual values of the items in the array.
-          *
-          * This is not ideal, but it's better than the previous situation where the rules were not applied at all.
+          * Only constant conditionals (`if: true` / `if: false`) are pre-applied here —
+          * their branch is the same for every row, so baking them is safe and keeps
+          * schema-driven visibility inside items working. Value-dependent rules are
+          * left intact so `validateSchema` (via `validateCondition`) evaluates them per
+          * item with the row's actual value. Per-row FIELD mutations (visibility /
+          * required flags) remain unsupported for group-array items.
           */
-          applySchemaRules(propertySchema.items as JsfObjectSchema, {}, options, jsonLogicContext)
+          applySchemaRules(propertySchema.items as JsfObjectSchema, {}, options, jsonLogicContext, true)
         }
       }
     }

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -78,6 +78,16 @@ function evaluateConditional(
 }
 
 /**
+ * Checks whether a conditional rule should be pre-applied to the schema
+ * @param ifNode - The rule's `if` schema
+ * @param constantIfsOnly - When true, only constant (boolean) conditionals qualify
+ * @returns Whether the rule should be processed
+ */
+function shouldProcessRule(ifNode: JsfSchema | undefined, constantIfsOnly: boolean): boolean {
+  return typeof ifNode !== 'undefined' && (!constantIfsOnly || typeof ifNode === 'boolean')
+}
+
+/**
  * Applies JSON Schema conditional rules to determine updated field properties
  * @param schema - The JSON schema containing the rules
  * @param values - The current form values
@@ -95,13 +105,10 @@ function applySchemaRules(
     return
   }
 
-  const shouldProcessRule = (ifNode: JsfSchema | undefined): boolean =>
-    typeof ifNode !== 'undefined' && (!constantIfsOnly || typeof ifNode === 'boolean')
-
   const conditionalRules: { rule: NonBooleanJsfSchema, matches: boolean }[] = []
 
   // If the schema has an if property, evaluate it and add it to the conditional rules array
-  if (shouldProcessRule(schema.if)) {
+  if (shouldProcessRule(schema.if, constantIfsOnly)) {
     conditionalRules.push(evaluateConditional(values, schema, schema, options, jsonLogicContext))
   }
 
@@ -109,7 +116,7 @@ function applySchemaRules(
   const allOf = schema.allOf ?? []
   const jsonLogicAllOf = schema['x-jsf-logic']?.allOf ?? [];
 
-  [...allOf, ...jsonLogicAllOf].filter((rule: JsfSchema) => shouldProcessRule(rule.if)).forEach((rule) => {
+  [...allOf, ...jsonLogicAllOf].filter((rule: JsfSchema) => shouldProcessRule(rule.if, constantIfsOnly)).forEach((rule) => {
     const result = evaluateConditional(values, schema, rule, options, jsonLogicContext)
     conditionalRules.push(result)
   })

--- a/test/fields/array.test.ts
+++ b/test/fields/array.test.ts
@@ -702,10 +702,6 @@ describe('buildFieldArray', () => {
     })
 
     it('evaluates conditionals with an else branch per array item', () => {
-      // Regression test: the pre-processing in calculateFinalSchema used to
-      // evaluate items conditionals against an empty object, permanently baking
-      // the {}-matching branch into the shared items schema. Rules with an
-      // `else` branch were then wrong for every row.
       const schema: JsfObjectSchema = {
         type: 'object',
         properties: {
@@ -755,7 +751,6 @@ describe('buildFieldArray', () => {
 
       const form = createHeadlessForm(schema)
 
-      // Per-row divergence: row 0 satisfies the else branch, row 1 the then branch
       expect(form.handleValidation({
         rules: [
           { name: 'flat', flat_rate: '1.5' },
@@ -763,7 +758,6 @@ describe('buildFieldArray', () => {
         ],
       }).formErrors).toEqual(undefined)
 
-      // The else branch must fire only for rows without populated bands
       expect(form.handleValidation({
         rules: [
           { name: 'flat missing rate' },
@@ -773,15 +767,12 @@ describe('buildFieldArray', () => {
         rules: [{ flat_rate: 'Required field' }, undefined],
       })
 
-      // A banded row must not be forced into the else branch requirements
       expect(form.handleValidation({
         rules: [{ name: 'banded', banding: { period: 'daily', bands: [{ rate: '2.0' }] } }],
       }).formErrors).toEqual(undefined)
     })
 
     it('evaluates negated conditionals per array item', () => {
-      // A negated `if` matches the empty object, so the old pre-processing baked
-      // the `then` branch in for every row regardless of its values.
       const schema: JsfObjectSchema = {
         type: 'object',
         properties: {
@@ -815,6 +806,101 @@ describe('buildFieldArray', () => {
       }).formErrors).toEqual({
         rules: [{ detail: 'Required field' }],
       })
+    })
+
+    it('applies an if: true allOf conditional on an object property', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          address: {
+            'type': 'object',
+            'x-jsf-presentation': { inputType: 'fieldset' },
+            'properties': {
+              city: { type: 'string' },
+              zip: { type: 'string' },
+            },
+            'allOf': [
+              {
+                if: true,
+                then: { required: ['city'], properties: { zip: false } },
+                else: { required: ['zip'], properties: { city: false } },
+              },
+            ],
+          },
+        },
+      }
+
+      const form = createHeadlessForm(schema, { initialValues: { address: {} } })
+
+      const addressFields = form.fields.find(({ name }) => name === 'address')?.fields
+      expect(addressFields?.find(({ name }) => name === 'city')?.isVisible).toBe(true)
+      expect(addressFields?.find(({ name }) => name === 'zip')?.isVisible).toBe(false)
+
+      expect(form.handleValidation({ address: {} }).formErrors).toEqual({
+        address: { city: 'Required field' },
+      })
+      expect(form.handleValidation({ address: { city: 'Porto' } }).formErrors).toEqual(undefined)
+    })
+
+    it('applies an if: true conditional directly on an object property', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          config: {
+            type: 'object',
+            properties: {
+              a: { type: 'string' },
+              b: { type: 'string' },
+            },
+            if: true,
+            then: { required: ['a'] },
+            else: { required: ['b'] },
+          },
+        },
+      }
+
+      const form = createHeadlessForm(schema, { initialValues: { config: {} } })
+
+      const configFields = form.fields.find(({ name }) => name === 'config')?.fields
+      expect(configFields?.find(({ name }) => name === 'a')?.required).toBe(true)
+      expect(configFields?.find(({ name }) => name === 'b')?.required).toBe(false)
+
+      expect(form.handleValidation({ config: {} }).formErrors).toEqual({
+        config: { a: 'Required field' },
+      })
+      expect(form.handleValidation({ config: { a: 'x' } }).formErrors).toEqual(undefined)
+    })
+
+    it('applies an if: true conditional directly on array items', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          tasks: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                a: { type: 'string' },
+                b: { type: 'string' },
+              },
+              if: true,
+              then: { required: ['a'] },
+              else: { required: ['b'] },
+            },
+          },
+        },
+      }
+
+      const form = createHeadlessForm(schema)
+
+      const taskFields = form.fields.find(({ name }) => name === 'tasks')?.fields
+      expect(taskFields?.find(({ name }) => name === 'a')?.required).toBe(true)
+      expect(taskFields?.find(({ name }) => name === 'b')?.required).toBe(false)
+
+      expect(form.handleValidation({ tasks: [{}, { a: 'x' }] }).formErrors).toEqual({
+        tasks: [{ a: 'Required field' }, undefined],
+      })
+      expect(form.handleValidation({ tasks: [{ a: 'x' }] }).formErrors).toEqual(undefined)
     })
 
     it('handles uniqueItems validation for arrays', () => {

--- a/test/fields/array.test.ts
+++ b/test/fields/array.test.ts
@@ -903,6 +903,50 @@ describe('buildFieldArray', () => {
       expect(form.handleValidation({ tasks: [{ a: 'x' }] }).formErrors).toEqual(undefined)
     })
 
+    it('evaluates value-dependent conditionals nested in a constant branch per array item', () => {
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          tasks: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                mode: { type: 'string' },
+                detail: { type: 'string' },
+              },
+              allOf: [
+                {
+                  if: true,
+                  then: {
+                    allOf: [
+                      {
+                        if: { properties: { mode: { const: 'auto' } }, required: ['mode'] },
+                        then: {},
+                        else: { required: ['detail'] },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }
+
+      const form = createHeadlessForm(schema)
+
+      expect(form.handleValidation({
+        tasks: [{ mode: 'auto' }, { mode: 'manual', detail: 'x' }],
+      }).formErrors).toEqual(undefined)
+
+      expect(form.handleValidation({
+        tasks: [{ mode: 'manual' }],
+      }).formErrors).toEqual({
+        tasks: [{ detail: 'Required field' }],
+      })
+    })
+
     it('handles uniqueItems validation for arrays', () => {
       const schema: JsfObjectSchema = {
         type: 'object',

--- a/test/fields/array.test.ts
+++ b/test/fields/array.test.ts
@@ -701,6 +701,122 @@ describe('buildFieldArray', () => {
       })
     })
 
+    it('evaluates conditionals with an else branch per array item', () => {
+      // Regression test: the pre-processing in calculateFinalSchema used to
+      // evaluate items conditionals against an empty object, permanently baking
+      // the {}-matching branch into the shared items schema. Rules with an
+      // `else` branch were then wrong for every row.
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          rules: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['name'],
+              properties: {
+                name: { type: 'string' },
+                flat_rate: { type: 'string' },
+                banding: {
+                  type: ['object', 'null'],
+                  properties: {
+                    period: { type: 'string', enum: ['daily', 'weekly'] },
+                    bands: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        required: ['rate'],
+                        properties: { rate: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+              allOf: [
+                {
+                  if: {
+                    properties: {
+                      banding: {
+                        type: 'object',
+                        properties: { bands: { minItems: 1 } },
+                        required: ['bands'],
+                      },
+                    },
+                    required: ['banding'],
+                  },
+                  then: { required: ['banding'] },
+                  else: { required: ['flat_rate'] },
+                },
+              ],
+            },
+          },
+        },
+      }
+
+      const form = createHeadlessForm(schema)
+
+      // Per-row divergence: row 0 satisfies the else branch, row 1 the then branch
+      expect(form.handleValidation({
+        rules: [
+          { name: 'flat', flat_rate: '1.5' },
+          { name: 'banded', banding: { period: 'daily', bands: [{ rate: '2.0' }] } },
+        ],
+      }).formErrors).toEqual(undefined)
+
+      // The else branch must fire only for rows without populated bands
+      expect(form.handleValidation({
+        rules: [
+          { name: 'flat missing rate' },
+          { name: 'banded', banding: { period: 'daily', bands: [{ rate: '2.0' }] } },
+        ],
+      }).formErrors).toEqual({
+        rules: [{ flat_rate: 'Required field' }, undefined],
+      })
+
+      // A banded row must not be forced into the else branch requirements
+      expect(form.handleValidation({
+        rules: [{ name: 'banded', banding: { period: 'daily', bands: [{ rate: '2.0' }] } }],
+      }).formErrors).toEqual(undefined)
+    })
+
+    it('evaluates negated conditionals per array item', () => {
+      // A negated `if` matches the empty object, so the old pre-processing baked
+      // the `then` branch in for every row regardless of its values.
+      const schema: JsfObjectSchema = {
+        type: 'object',
+        properties: {
+          rules: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                mode: { type: 'string' },
+                detail: { type: 'string' },
+              },
+              allOf: [
+                {
+                  if: { not: { properties: { mode: { const: 'auto' } }, required: ['mode'] } },
+                  then: { required: ['detail'] },
+                },
+              ],
+            },
+          },
+        },
+      }
+
+      const form = createHeadlessForm(schema)
+
+      expect(form.handleValidation({
+        rules: [{ mode: 'auto' }, { mode: 'manual', detail: 'x' }],
+      }).formErrors).toEqual(undefined)
+
+      expect(form.handleValidation({
+        rules: [{ mode: 'manual' }],
+      }).formErrors).toEqual({
+        rules: [{ detail: 'Required field' }],
+      })
+    })
+
     it('handles uniqueItems validation for arrays', () => {
       const schema: JsfObjectSchema = {
         type: 'object',


### PR DESCRIPTION
## Summary

Conditionals (`if`/`then`/`else` in `allOf`) inside an array's `items` schema are
evaluated against an empty object instead of each row's value. Whichever branch
matches `{}` gets permanently merged into the shared `items` schema and deleted,
so rules with an `else` branch (or a negated `if`) validate wrongly for every
row. This PR pre-applies only constant conditionals inside `items` and leaves
value-dependent ones intact, so `validateSchema` evaluates them per row.

| Before    | After |
| -------- | ------- |
|  <img width="530" height="773" alt="SCR-20260820-ksyz" src="https://github.com/user-attachments/assets/93761296-f93d-47a5-b8f5-55cd82f72f14" /> | <img width="1221" height="1626" alt="SCR-20260820-ktnq" src="https://github.com/user-attachments/assets/29ffd1bb-1d56-4384-9e6d-bf8abe542b1c" />   |


<details>

<summary>Json Schema</summary>
<pre>
{
  "title": "Per-row conditionals in nested arrays",
  "type": "object",
  "properties": {
    "discount_rules": {
      "type": "array",
      "title": "Discount rules",
      "x-jsf-presentation": { "inputType": "group-array", "addFieldText": "Add rule" },
      "items": {
        "type": "object",
        "title": "Rule",
        "x-jsf-order": ["name", "mode", "percent", "tiering"],
        "required": ["name", "mode"],
        "x-jsf-presentation": { "inputType": "fieldset" },
        "properties": {
          "name": {
            "type": "string",
            "title": "Name",
            "x-jsf-presentation": { "inputType": "text" }
          },
          "mode": {
            "type": "string",
            "title": "Mode",
            "default": "flat",
            "oneOf": [
              { "const": "flat", "title": "Flat" },
              { "const": "tiered", "title": "Tiered" }
            ],
            "x-jsf-presentation": { "inputType": "radio" }
          },
          "percent": {
            "type": ["string", "null"],
            "title": "Percent",
            "x-jsf-presentation": { "inputType": "text" }
          },
          "tiering": {
            "type": ["object", "null"],
            "title": "Tiering",
            "x-jsf-order": ["period", "tiers"],
            "x-jsf-presentation": { "inputType": "fieldset" },
            "properties": {
              "period": {
                "type": "string",
                "title": "Period",
                "oneOf": [
                  { "const": "monthly", "title": "Monthly" },
                  { "const": "yearly", "title": "Yearly" }
                ],
                "x-jsf-presentation": { "inputType": "select" }
              },
              "tiers": {
                "type": "array",
                "title": "Tiers",
                "x-jsf-presentation": { "inputType": "group-array", "addFieldText": "Add tier" },
                "items": {
                  "type": "object",
                  "title": "Tier",
                  "x-jsf-order": ["up_to", "percent"],
                  "required": ["percent"],
                  "x-jsf-presentation": { "inputType": "fieldset" },
                  "properties": {
                    "up_to": {
                      "type": "integer",
                      "title": "Up to",
                      "x-jsf-presentation": { "inputType": "number" }
                    },
                    "percent": {
                      "type": "string",
                      "title": "Percent",
                      "x-jsf-presentation": { "inputType": "text" }
                    }
                  }
                }
              }
            }
          }
        },
        "allOf": [
          {
            "if": {
              "properties": { "mode": { "const": "tiered" } },
              "required": ["mode"]
            },
            "then": {
              "required": ["tiering"],
              "properties": {
                "tiering": {
                  "type": "object",
                  "required": ["period", "tiers"],
                  "properties": {
                    "tiers": {
                      "minItems": 1,
                      "x-jsf-errorMessage": { "minItems": "Add at least one tier, or switch the mode to flat." }
                    }
                  }
                },
                "percent": {
                  "maxLength": 0,
                  "x-jsf-errorMessage": { "maxLength": "Not used for tiered rules. Clear it or switch the mode to flat." }
                }
              }
            },
            "else": {
              "required": ["percent"],
              "properties": {
                "percent": { "type": "string" },
                "tiering": {
                  "properties": {
                    "tiers": {
                      "maxItems": 0,
                      "x-jsf-errorMessage": { "maxItems": "Tiers only apply to tiered rules. Remove them or switch the mode." }
                    }
                  }
                }
              }
            }
          }
        ]
      }
    }
  }
}
</pre>
</details>

## Changes Made

`calculateFinalSchema` pre-applies conditional rules by merging the matching
branch into the schema and deleting the branch. That is correct at the root,
where `values` is the real form value, but for `items` the existing workaround
in `applySchemaRules` passed a hardcoded `{}`:

- a rule with an `else` branch had the `else` baked in for all rows (an `if`
  that requires a field never matches `{}`), producing wrong validation even
  for rows where the condition is true;
- a negated `if` always matches `{}`, baking the `then` in for all rows;
- because the branch is deleted after merging, the per-row conditional
  evaluation in `validateCondition` (which is correct) never saw it.

The change threads a `constantIfsOnly` flag through `applySchemaRules`. Inside
`items`, only conditionals whose `if` is a boolean (`if: true` / `if: false`)
are pre-applied — their branch is row-independent, which is what the original
workaround supported (schema-driven visibility inside items, covered by the
existing "with constant logic" tests). Value-dependent rules keep their
`then`/`else` and are evaluated per item with the row's actual value.

Known limitation, unchanged by this PR: per-row FIELD state (visibility,
required flags, titles) is still not representable, since all rows of a
group-array share a single fields array. This PR fixes validation only; the
`describe.skip('with logic based on answers')` for group-array field visibility
stays skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core schema mutation in `applySchemaRules`, which affects validation and field derivation for nested arrays; behavior change is intentional but could surface edge cases in complex conditional schemas.
> 
> **Overview**
> Fixes **wrong validation for array row schemas** when `items` uses value-dependent `if`/`then`/`else` rules. Previously `applySchemaRules` ran against `{}` for shared `items` schemas, permanently merging one branch and breaking `else`/negated `if` for every row.
> 
> The change adds **`constantIfsOnly`** (via `shouldProcessRule`) so only **`if: true` / `if: false`** conditionals are pre-merged into `items`; value-dependent rules stay on the schema and are evaluated **per row** during validation. Constant conditionals on nested objects and array items still drive shared field metadata (e.g. visibility/required).
> 
> New array tests cover `else` branches, negated `if`, nested constant+value-dependent rules, and `if: true` on objects and items. **Per-row field UI mutations** for group-arrays remain out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d4962336fed905500858bdfaf95663263f556f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->