### PR TITLE
Fix crash when an if.required field has a json-logic validation

### DIFF
--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -69,7 +69,7 @@ function evaluateConditional(
       }
       const fieldSchema = schema.properties[fieldName]
       const fieldValue = values[fieldName]
-      const fieldErrors = validateSchema(fieldValue, fieldSchema, options.legacyOptions ?? {})
+      const fieldErrors = validateSchema(fieldValue, fieldSchema, options.legacyOptions ?? {}, [], jsonLogicContext)
       return fieldErrors.some(error => error.validation === 'type')
     })
   }

--- a/test/validation/json-logic-v0.test.js
+++ b/test/validation/json-logic-v0.test.js
@@ -19,6 +19,7 @@ import {
   schemaWithCustomValidationFunction,
   schemaWithDeepVarThatDoesNotExist,
   schemaWithDeepVarThatDoesNotExistOnFieldset,
+  schemaWithIfRequiredAndLogicValidationOnSameField,
   schemaWithInlinedRuleOnComputedAttributeThatReferencesUnknownVar,
   schemaWithMissingComputedValue,
   schemaWithMissingRule,
@@ -488,6 +489,50 @@ describe('jsonLogic: cross-values validations', () => {
       }
 
       expect(actionThatWillThrow).not.toThrow()
+    })
+  })
+})
+
+describe('jsonLogic: if.required with x-jsf-logic-validations on the same field', () => {
+  it('does not throw at build time when an if.required field carries validations', () => {
+    expect(() =>
+      createHeadlessForm(schemaWithIfRequiredAndLogicValidationOnSameField, {
+        strictInputType: false,
+        initialValues: { field_a: 5, field_c: 'x' },
+      }),
+    ).not.toThrow()
+  })
+
+  it('runs the field validation instead of throwing (then branch)', () => {
+    const { handleValidation } = createHeadlessForm(
+      schemaWithIfRequiredAndLogicValidationOnSameField,
+      { strictInputType: false },
+    )
+
+    // field_a === 5 -> if matches -> field_c required; validation a_at_least_ten fails (5 < 10)
+    expect(handleValidation({ field_a: 5, field_c: 'x' }).formErrors).toEqual({
+      field_a: 'Field A must be at least 10',
+    })
+
+    // field_a === 5, field_c missing -> both the validation error AND field_c required
+    expect(handleValidation({ field_a: 5 }).formErrors).toEqual({
+      field_a: 'Field A must be at least 10',
+      field_c: 'Required field',
+    })
+  })
+
+  it('applies the else branch and validation when the condition is false', () => {
+    const { handleValidation } = createHeadlessForm(
+      schemaWithIfRequiredAndLogicValidationOnSameField,
+      { strictInputType: false },
+    )
+
+    // field_a === 20 -> if false -> else hides field_c; validation passes (20 >= 10)
+    expect(handleValidation({ field_a: 20 }).formErrors).toBeUndefined()
+
+    // field_a === 8 -> if false -> validation fails (8 < 10)
+    expect(handleValidation({ field_a: 8 }).formErrors).toEqual({
+      field_a: 'Field A must be at least 10',
     })
   })
 })

--- a/test/validation/json-logic.fixtures.ts
+++ b/test/validation/json-logic.fixtures.ts
@@ -796,3 +796,47 @@ export const schemaWithCustomComputedValueFunction = {
     },
   },
 }
+
+// A field named in if.required that ALSO carries x-jsf-logic-validations.
+// Reproduces the "required validation doesn't exist" throw when context is dropped.
+export const schemaWithIfRequiredAndLogicValidationOnSameField = {
+  'type': 'object',
+  'properties': {
+    field_a: {
+      'type': 'number',
+      'x-jsf-logic-validations': ['a_at_least_ten'],
+    },
+    field_c: {
+      type: 'string',
+    },
+  },
+  'required': ['field_a'],
+  'allOf': [
+    {
+      if: {
+        properties: {
+          field_a: { const: 5 },
+        },
+        required: ['field_a'],
+      },
+      then: {
+        required: ['field_c'],
+      },
+      else: {
+        properties: {
+          field_c: false,
+        },
+      },
+    },
+  ],
+  'x-jsf-logic': {
+    validations: {
+      a_at_least_ten: {
+        errorMessage: 'Field A must be at least 10',
+        rule: {
+          '>=': [{ var: 'field_a' }, 10],
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary

Fixes a crash when a form field appears in a conditional's required list and also has a json-logic validation.

## Why

createHeadlessForm threw required validation "<name>" doesn't exist for a valid schema, so the form could not be built or validated. The named validation was defined at the schema root the whole time; the conditional's type-error check could not see it. This blocked any schema that pairs if.required with x-jsf-logic-validations on the same field.

## How

forward jsonLogicContext (already in scope) and a path into that validateSchema call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-argument change on an internal conditional type-check path; behavior is narrowed to schemas that combine if.required with json-logic validations on the same field.
> 
> **Overview**
> Fixes a **build/validation crash** when a field listed in a conditional’s `if.required` also declares **`x-jsf-logic-validations`**. The type-error gate inside `evaluateConditional` now passes the existing **`jsonLogicContext`** (and path) into `validateSchema`, so json-logic rules resolve from the root schema instead of throwing that a named validation “doesn’t exist.”
> 
> Adds a **fixture and tests** for `field_a` with both `if.required` and `a_at_least_ten`: form creation no longer throws, the **then** branch still requires `field_c` alongside logic errors, and the **else** branch still hides `field_c` while logic validation runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a828b204aae9ce05f8885b14046861bcff41d4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->